### PR TITLE
ceph_base: allow older versions of docker to build

### DIFF
--- a/ceph-base/Dockerfile
+++ b/ceph-base/Dockerfile
@@ -6,7 +6,7 @@
 FROM ubuntu:14.04
 MAINTAINER Sébastien Han "seb@redhat.com"
 
-ENV CEPH_VERSION=firefly
+ENV CEPH_VERSION firefly
 
 # Install Ceph
 CMD wget -q -O- 'https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc' | apt-key add -


### PR DESCRIPTION
ENV key=val syntax was introduced in docker 1.4+, this format fails with
`invalid ENV format` for docker < 1.4. Since the other dockerfiles in the
repo are supporting docker 1.0, it probably makes sense that we change
this to support older docker versions for now

Signed-off-by: Abhishek Lekshmanan <abhishek.lekshmanan@gmail.com>