### PR TITLE
Add missing wget in base

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -2,11 +2,14 @@
 # CEPH VERSION: Firefly
 # CEPH VERSION DETAIL: 0.80.8
 
-
 FROM ubuntu:14.04
 MAINTAINER Sébastien Han "seb@redhat.com"
 
 ENV CEPH_VERSION firefly
+
+# Install prerequisites
+RUN apt-get update
+RUN apt-get install -y wget
 
 # Install Ceph
 CMD wget -q -O- 'https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc' | apt-key add -


### PR DESCRIPTION
The Dockerfile for base uses `wget`, which does not exist in the ubuntu:14.04 base.  This adds `wget`.