### PR TITLE
Exec /bin/bash by default

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -12,7 +12,11 @@ RUN apt-get update
 RUN apt-get install -y wget
 
 # Install Ceph
-CMD wget -q -O- 'https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc' | apt-key add -
+RUN wget -q -O- 'https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc' | apt-key add -
 RUN echo deb http://ceph.com/debian-$CEPH_VERSION/ trusty main | tee /etc/apt/sources.list.d/ceph-$CEPH_VERSION.list
 RUN apt-get update
 RUN apt-get install -y --force-yes ceph
+
+ADD entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+

--- a/base/README.md
+++ b/base/README.md
@@ -9,5 +9,6 @@ https://registry.hub.docker.com/u/ceph/base/
 ## Usage (example)
 
 ```bash
-$ docker run -i -t ceph/base /bin/bash
+$ docker run -i -t ceph/base
 ```
+

--- a/base/entrypoint.sh
+++ b/base/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+if [ -z "$1" ]; then
+  /bin/bash
+else
+  $@
+fi


### PR DESCRIPTION
Hi,

Pushing few patches concerning mainly two things:
- There are still some references to old Docker repositories (ulexus/ or ceph/ceph-), that I replaced. I kept the ones for rbd in ulexus/ since they don't exist (yet ?) on ceph/.
- I added an helper script in ceph/base to be able to assist in the execution of this image directly (which can be conveniant to use ceph directly).

If you intend to create ceph/rados ceph/rbd ceph/rbd-* , please create a patch with:
grep -Rl "ulexus/" |grep -v ".git" |xargs sed -i 's^ulexus/^ceph/^g'

Thanks,
Bertrand