### PR TITLE
Standardize the entrypoint script location

### DIFF
--- a/mds/Dockerfile
+++ b/mds/Dockerfile
@@ -25,11 +25,11 @@ RUN ["echo", "fuse hold", "|" ,"dpkg", "--set-selections"]
 RUN apt-get install -y ceph-mds
 
 # Add bootstrap script
-ADD entrypoint.sh /usr/local/bin/entrypoint.sh
+ADD entrypoint.sh /entrypoint.sh
 
 # Expose the ceph mds port (6800, by default)
 EXPOSE 6800
 
 # Execute monitor as the entrypoint
 #WORKDIR /
-ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+ENTRYPOINT ["/entrypoint.sh"]

--- a/mon/Dockerfile
+++ b/mon/Dockerfile
@@ -27,7 +27,7 @@ FROM ceph/base
 MAINTAINER Seán C McCord "ulexus@gmail.com"
 
 # Add bootstrap script
-ADD entrypoint.sh /usr/local/bin/entrypoint.sh
+ADD entrypoint.sh /entrypoint.sh
 
 # Add volumes for ceph config and monitor data
 VOLUME ["/etc/ceph","/var/lib/ceph"]
@@ -36,4 +36,4 @@ VOLUME ["/etc/ceph","/var/lib/ceph"]
 EXPOSE 6789
 
 # Execute monitor as the entrypoint
-ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+ENTRYPOINT ["/entrypoint.sh"]

--- a/osd/Dockerfile
+++ b/osd/Dockerfile
@@ -13,7 +13,7 @@ MAINTAINER Seán C McCord "ulexus@gmail.com"
 # Expose the ceph OSD port (6800+, by default)
 EXPOSE 6800
 
-ADD entrypoint.sh /usr/local/bin/entrypoint.sh
-ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+ADD entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
 
 CMD ["ceph-osd"]

--- a/radosgw/Dockerfile
+++ b/radosgw/Dockerfile
@@ -14,9 +14,9 @@ RUN apt-add-repository -y multiverse
 RUN apt-get update
 RUN apt-get install -y --force-yes apache2 libapache2-mod-fastcgi radosgw
 
-ADD entrypoint.sh /usr/local/bin/entrypoint.sh
-RUN chmod +x /usr/local/bin/entrypoint.sh
-ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+ADD entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
 
 # Expose Apache port
 EXPOSE 80


### PR DESCRIPTION
Put the `entrypoint.sh` script in the same place for all components:  `/entrypoint.sh`