### PR TITLE
Fix ceph/radosgw name instead of ceph/rgw

### DIFF
--- a/radosgw/Dockerfile
+++ b/radosgw/Dockerfile
@@ -24,3 +24,4 @@ ENTRYPOINT ["/entrypoint.sh"]
 
 # Expose Apache port
 EXPOSE 80
+

--- a/radosgw/README.md
+++ b/radosgw/README.md
@@ -10,9 +10,9 @@ Usage
 The environment variable `RGW_NAME` is required.  It describes the name of the RGW
 
 For example:
-`docker run -e RGW_NAME=myrgw ceph/rgw`
+`docker run -e RGW_NAME=myrgw ceph/radosgw`
 
 It will look for `/etc/ceph/ceph.client.admin.keyring` with which to authenticate.  You can get `ceph.client.admin.keyring` from another Ceph node.
 
 Commonly, you will want to bind-mount your host's `/etc/ceph` into the container.  For example:
-`docker run -d --net=host -e RGW_NAME=myrgw -v /etc/ceph:/etc/ceph ceph/rgw`
+`docker run -d --net=host -e RGW_NAME=myrgw -v /etc/ceph:/etc/ceph ceph/radosgw`

--- a/radosgw/entrypoint.sh
+++ b/radosgw/entrypoint.sh
@@ -72,3 +72,4 @@ a2ensite rgw.conf > /dev/null 2>&1
 # Start apache and radosgw
 source /etc/apache2/envvars
 /startRadosgw
+


### PR DESCRIPTION
Just noticed that ceph/rgw doesn't exist while ceph/radosgw does.