### PR TITLE
Sync cluster bootstrap using etcd

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,5 +12,6 @@ Components:
 * [`ceph/rados`](rados/): Convenience wrapper to execute the `rados` CLI tool
 * [`ceph/radosgw`](radosgw/): Ceph Rados gateway service; S3/swift API server
 * [`ceph/rbd`](rbd/): Convenience wrapper to execute the `rbd` CLI tool
+* [`ceph/config`](config/): Initializes and distributes cluster configuration
 
 

--- a/config/Dockerfile
+++ b/config/Dockerfile
@@ -1,0 +1,29 @@
+# DOCKER-VERSION 1.0.0
+# 
+# Ceph Config 
+#
+#  USAGE NOTES:
+#    - Define at least the two following environment variables:
+#      MONHOST - the hostname of this monitor
+#      MONIP   - the (externally visible) IP address of this monitor
+#    - /etc/ceph is set as a volume, so you may use a common configuration directory
+#      among your ceph daemons (this also keeps private keys outside of the image)
+#
+# VERSION 0.0.1
+
+FROM ceph/base
+MAINTAINER Sébastien Han "seb@redhat.com"
+
+RUN wget https://github.com/coreos/etcd/releases/download/v0.4.6/etcd-v0.4.6-linux-amd64.tar.gz
+RUN tar xzvf etcd-v0.4.6-linux-amd64.tar.gz
+RUN cp etcd-v0.4.6-linux-amd64/etcdctl /usr/local/bin
+
+# Add bootstrap script
+ADD entrypoint.sh /entrypoint.sh
+
+# Add volumes for ceph config and monitor data
+VOLUME ["/etc/ceph"]
+
+# Execute monitor as the entrypoint
+ENTRYPOINT ["/entrypoint.sh"]
+

--- a/config/README.md
+++ b/config/README.md
@@ -1,0 +1,47 @@
+ceph-config
+===========
+
+This Dockerfile may be used to bootstrap a cluster or add the cluster configuration
+to a new host. It uses etcd to store the cluster config. It is especially suitable
+to setup ceph on CoreOS.
+
+The following strategy is applied:
+
+  * If a cluster configuration is available, it will be written to `/etc/ceph`
+  * If no cluster configuration is available, it will be created. A lock mechanism 
+    is used to allow concurrent deployment of multiple hosts.
+
+## Usage 
+
+To bootstrap a new cluster run:
+
+`docker run -e MON_IP=192.168.101.50 -e MON_NAME=mymon -e CLUSTER=testing -v /etc/ceph:/etc/ceph ceph/config`
+
+This will generate:
+
+  *  `ceph.conf` 
+  *  `ceph.client.admin.keyring` 
+  *  `ceph.mon.keyring` 
+  *  `monmap` 
+
+Except the `monmap` the config will be stored in etcd under `/ceph-config/${CLUSTER}`. 
+
+In case a configuration for the cluster is found, the configuration will be pulled
+from etcd and written to `/etc/ceph`.
+
+Multiple concurrent invocations will block until the first host finished to generate 
+the configuration.
+
+When run without `MON_IP` and `MON_NAME` it will not generate a config but block and 
+wait until it becomes available. 
+
+## Configuration
+
+The following environment variables can be used to configure the bootstrapping:
+
+  * `CLUSTER` is the name of the ceph cluster (defaults to: "ceph") 
+
+Mandatory Configuration:
+  * `MON_NAME` is the name of the monitor. Usually the short hostname
+  * `MON_IP` is the IP address of the monitor (public)
+  * `ETCDCTL_PEERS` is a comma seperated list of etcd peers (e.g. http://192.168.2.4:4001)

--- a/config/README.md
+++ b/config/README.md
@@ -7,15 +7,16 @@ to setup ceph on CoreOS.
 
 The following strategy is applied:
 
+  * An `/etc/ceph/ceph.conf` is found, do nothing.
   * If a cluster configuration is available, it will be written to `/etc/ceph`
-  * If no cluster configuration is available, it will be created. A lock mechanism 
+  * If no cluster configuration is available, it will be bootstrapped. A lock mechanism 
     is used to allow concurrent deployment of multiple hosts.
 
 ## Usage 
 
 To bootstrap a new cluster run:
 
-`docker run -e MON_IP=192.168.101.50 -e MON_NAME=mymon -e CLUSTER=testing -v /etc/ceph:/etc/ceph ceph/config`
+`docker run -e ETCDCTL_PEERS=http://102.168.101.50:4001 -e MON_IP=192.168.101.50 -e MON_NAME=mymon -e CLUSTER=testing -v /etc/ceph:/etc/ceph ceph/config`
 
 This will generate:
 
@@ -31,9 +32,6 @@ from etcd and written to `/etc/ceph`.
 
 Multiple concurrent invocations will block until the first host finished to generate 
 the configuration.
-
-When run without `MON_IP` and `MON_NAME` it will not generate a config but block and 
-wait until it becomes available. 
 
 ## Configuration
 

--- a/config/ceph-config.service
+++ b/config/ceph-config.service
@@ -1,0 +1,35 @@
+[Unit]
+Description=Ceph Config
+After=docker.service
+Before=ceph-mon.service
+Before=ceph-osd.service
+Before=ceph-mds@.service
+
+[Service]
+EnvironmentFile=/etc/environment
+Type=oneshot
+RemainAfterExit=yes
+ExecStartPre=/bin/mkdir -p /etc/ceph
+
+# systemd-docker does not work here because we want to briefly block execution in
+# case another host is running a cluster bootstrap in parallel. systemd-docker's 
+# notify mechanism does not block. A workaround is described here:
+#
+# https://github.com/docker/docker/issues/6791#issuecomment-72338100
+
+ExecStartPre=/usr/bin/docker pull ceph/ceph-config
+ExecStartPre=-/usr/bin/docker kill %n
+ExecStartPre=-/usr/bin/docker rm %n
+ExecStartPre=/usr/bin/docker run -d -e MON_IP=${COREOS_PUBLIC_IPV4} -e MON_NAME=%H -e ETCDCTL_PEERS=http://${COREOS_PUBLIC_IPV4}:4001 -e CLUSTER=ceph --name %n -v /etc/ceph:/etc/ceph ceph/ceph-config 
+ExecStart=/usr/bin/docker logs -f %n
+ExecStop=-/usr/bin/docker stop %n
+ExecStopPost=-/usr/bin/docker stop %n
+
+[Install]
+RequiredBy=ceph-mon.service
+RequiredBy=ceph-osd.service
+RequiredBy=ceph-mds@.service
+WantedBy=multi-user.target
+
+[X-Fleet]
+Global=true

--- a/config/entrypoint.sh
+++ b/config/entrypoint.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+set -e 
+
+if [ ! -n "$MON_NAME" ]; then
+  echo >&2 "ERROR: MON_NAME must be defined as the name of the monitor"
+  exit 1
+fi
+ 
+if [ ! -n "$MON_IP" ]; then
+  echo >&2 "ERROR: MON_IP must be defined as the IP address of the monitor"
+  exit 1
+fi
+
+if [ ! -n "$ETCDCTL_PEERS" ]; then
+  echo >&2 "ERROR: ETCDCTL_PEERS must be defined"
+  exit 1
+fi
+ 
+CLUSTER=${CLUSTER:-ceph}
+CLUSTER_PATH=/ceph-config/$CLUSTER
+
+if [ -e /etc/ceph/ceph.conf ]; then
+  echo "Found existing config. Done."
+  exit 0
+fi
+ 
+# Aquire lock to not run into race conditions with parallel bootstraps
+until etcdctl mk ${CLUSTER_PATH}/lock $MON_NAME --ttl 60 > /dev/null 2>&1 ; do
+  echo "Configuration is locked by another host. Waiting."
+  sleep 1
+done
+
+if etcdctl get --consistent ${CLUSTER_PATH}/done > /dev/null 2>%1 ; then
+  echo "Configuration found for cluster ${CLUSTER}. Writing to disk."
+
+  etcdctl get ${CLUSTER_PATH}/ceph.conf > /etc/ceph/ceph.conf
+  etcdctl get ${CLUSTER_PATH}/ceph.mon.keyring > /etc/ceph/ceph.mon.keyring
+  etcdctl get ${CLUSTER_PATH}/ceph.client.admin.keyring > /etc/ceph/ceph.client.admin.keyring
+
+  ceph mon getmap -o /etc/ceph/monmap
+else 
+  echo "No configuration found for cluster ${CLUSTER}. Generating."
+
+  fsid=$(uuidgen)
+  cat <<ENDHERE >/etc/ceph/ceph.conf
+fsid = $fsid
+mon initial members = ${MON_NAME}
+mon host = ${MON_IP}
+auth cluster required = cephx
+auth service required = cephx
+auth client required = cephx
+ENDHERE
+
+  ceph-authtool /etc/ceph/ceph.client.admin.keyring --create-keyring --gen-key -n client.admin --set-uid=0 --cap mon 'allow *' --cap osd 'allow *' --cap mds 'allow'
+  ceph-authtool /etc/ceph/ceph.mon.keyring --create-keyring --gen-key -n mon. --cap mon 'allow *'
+  monmaptool --create --add ${MON_NAME} ${MON_IP} --fsid ${fsid}  /etc/ceph/monmap
+
+  etcdctl set ${CLUSTER_PATH}/ceph.conf < /etc/ceph/ceph.conf > /dev/null
+  etcdctl set ${CLUSTER_PATH}/ceph.mon.keyring < /etc/ceph/ceph.mon.keyring > /dev/null
+  etcdctl set ${CLUSTER_PATH}/ceph.client.admin.keyring < /etc/ceph/ceph.client.admin.keyring > /dev/null
+    
+  echo "completed initialization for ${MON_NAME}"
+  etcdctl set ${CLUSTER_PATH}/done true > /dev/null 2>&1
+fi
+
+etcdctl rm ${CLUSTER_PATH}/lock > /dev/null 2>&1
+


### PR DESCRIPTION
This container allows to automatically bootstrap a cluster or distribute existing ceph config to new hosts. It makes use of etcd to store the inital configuration. It is especially cool when run on CoreOS and bootstrapping a cluster from nothing without manual intervention. It is compatible to the existing configuration mechanisms in the `ceph-mon` containers. 

If this fits in the vision of `ceph-docker` I would be happy to keep on helping to maintain this config mechanism.

I'm using this on my own ceph cluster as can be seen here: https://github.com/BugRoger/d26a/tree/master/units/ceph