### PR TITLE
Install etcdctl to base; remove from config

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -6,6 +6,8 @@ FROM ubuntu:14.04
 MAINTAINER Sébastien Han "seb@redhat.com"
 
 ENV CEPH_VERSION firefly
+ENV ETCDCTL_VERSION v2.0.4
+ENV ETCDCTL_ARCH linux-amd64
 
 # Install prerequisites
 RUN apt-get update
@@ -17,6 +19,11 @@ RUN echo deb http://ceph.com/debian-$CEPH_VERSION/ trusty main | tee /etc/apt/so
 RUN apt-get update
 RUN apt-get install -y --force-yes ceph
 
+# Install etcdctl
+RUN wget -q -O- "https://github.com/coreos/etcd/releases/download/${ETCDCTL_VERSION}/etcd-${ETCDCTL_VERSION}-${ETCDCTL_ARCH}.tar.gz" |tar xfz - -C/tmp/ etcd-${ETCDCTL_VERSION}-${ETCDCTL_ARCH}/etcdctl
+RUN mv /tmp/etcd-${ETCDCTL_VERSION}-${ETCDCTL_ARCH}/etcdctl /usr/local/bin/etcdctl
+
+WORKDIR /
 ADD entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -23,7 +23,6 @@ RUN apt-get install -y --force-yes ceph
 RUN wget -q -O- "https://github.com/coreos/etcd/releases/download/${ETCDCTL_VERSION}/etcd-${ETCDCTL_VERSION}-${ETCDCTL_ARCH}.tar.gz" |tar xfz - -C/tmp/ etcd-${ETCDCTL_VERSION}-${ETCDCTL_ARCH}/etcdctl
 RUN mv /tmp/etcd-${ETCDCTL_VERSION}-${ETCDCTL_ARCH}/etcdctl /usr/local/bin/etcdctl
 
-WORKDIR /
 ADD entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 

--- a/config/Dockerfile
+++ b/config/Dockerfile
@@ -14,10 +14,6 @@
 FROM ceph/base
 MAINTAINER Sébastien Han "seb@redhat.com"
 
-RUN wget https://github.com/coreos/etcd/releases/download/v0.4.6/etcd-v0.4.6-linux-amd64.tar.gz
-RUN tar xzvf etcd-v0.4.6-linux-amd64.tar.gz
-RUN cp etcd-v0.4.6-linux-amd64/etcdctl /usr/local/bin
-
 # Add bootstrap script
 ADD entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
1) Install version 2.0.4 of etcdctl to ceph/base
2) Remove etcdctl 0.4.6 from ceph/config