### PR TITLE
Use the latest stable version of Ceph

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -5,19 +5,18 @@
 FROM ubuntu:14.04
 MAINTAINER Sébastien Han "seb@redhat.com"
 
-ENV CEPH_VERSION firefly
 ENV ETCDCTL_VERSION v2.0.4
 ENV ETCDCTL_ARCH linux-amd64
+ENV CEPH_VERSION giant
 
 # Install prerequisites
-RUN apt-get update
-RUN apt-get install -y wget
+RUN apt-get update &&  apt-get install -y wget
 
 # Install Ceph
 RUN wget -q -O- 'https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc' | apt-key add -
 RUN echo deb http://ceph.com/debian-$CEPH_VERSION/ trusty main | tee /etc/apt/sources.list.d/ceph-$CEPH_VERSION.list
-RUN apt-get update
-RUN apt-get install -y --force-yes ceph
+RUN apt-get update && apt-get install -y --force-yes ceph && \
+apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Install etcdctl
 RUN wget -q -O- "https://github.com/coreos/etcd/releases/download/${ETCDCTL_VERSION}/etcd-${ETCDCTL_VERSION}-${ETCDCTL_ARCH}.tar.gz" |tar xfz - -C/tmp/ etcd-${ETCDCTL_VERSION}-${ETCDCTL_ARCH}/etcdctl


### PR DESCRIPTION
Moving away from Firefly and use Giant instead.

Fixes: #31 
Signed-off-by: Sébastien Han <sebastien.han@enovance.com>