### PR TITLE
Fix config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/rebase-to-upstream.sh

--- a/config/README.md
+++ b/config/README.md
@@ -37,7 +37,9 @@ the configuration.
 
 The following environment variables can be used to configure the bootstrapping:
 
+  * `CONFIG_ROOT` is the location in etcd for the ceph configuration (defaults to: "/ceph") 
   * `CLUSTER` is the name of the ceph cluster (defaults to: "ceph") 
+  * `CLUSTER_PATH` is the location in etcd for the ceph configuration (defaults to: "`${CONFIG_ROOT}/${CLUSTER}/config`") 
 
 Mandatory Configuration:
   * `MON_NAME` is the name of the monitor. Usually the short hostname

--- a/config/entrypoint.sh
+++ b/config/entrypoint.sh
@@ -36,8 +36,9 @@ fi
 # Change to the old CLUSTER_PATH, if it already exists
 set +e
 etcdctl get /ceph-config/${CLUSTER}/done
+RET=$?
 set -e
-if [ $? -eq 0 ]; then
+if [ $RET -eq 0 ]; then
    CLUSTER_PATH=/ceph-config/${CLUSTER}
 fi
  
@@ -50,8 +51,9 @@ done
 # Don't cancel this script when the `done` key doesn't exist
 set +e
 etcdctl get ${CLUSTER_PATH}/done 2>/dev/null >/dev/null
+RET=$?
 set -e
-if [ $? -eq 0 ]; then
+if [ $RET -eq 0 ]; then
   echo "Configuration found for cluster ${CLUSTER}. Writing to disk."
 
   etcdctl get ${CLUSTER_PATH}/ceph.conf > /etc/ceph/ceph.conf

--- a/config/entrypoint.sh
+++ b/config/entrypoint.sh
@@ -35,10 +35,11 @@ fi
 
 # Change to the old CLUSTER_PATH, if it already exists
 set +e
-etcdctl get /ceph-config/${CLUSTER}/done
+etcdctl get /ceph-config/${CLUSTER}/done 2>/dev/null
 RET=$?
 set -e
 if [ $RET -eq 0 ]; then
+   echo "Old configuration key (/ceph-config/) found; using it instead"
    CLUSTER_PATH=/ceph-config/${CLUSTER}
 fi
  
@@ -60,6 +61,7 @@ if [ $RET -eq 0 ]; then
   etcdctl get ${CLUSTER_PATH}/ceph.mon.keyring > /etc/ceph/ceph.mon.keyring
   etcdctl get ${CLUSTER_PATH}/ceph.client.admin.keyring > /etc/ceph/ceph.client.admin.keyring
 
+  echo "Attempting to pull monitor map from existing cluster."
   ceph mon getmap -o /etc/ceph/monmap
 else 
   echo "No configuration found for cluster ${CLUSTER}. Generating."
@@ -86,5 +88,6 @@ ENDHERE
   etcdctl set ${CLUSTER_PATH}/done true > /dev/null 2>&1
 fi
 
+echo "unlocking configuration"
 etcdctl rm ${CLUSTER_PATH}/lock > /dev/null 2>&1
 

--- a/config/entrypoint.sh
+++ b/config/entrypoint.sh
@@ -35,7 +35,7 @@ fi
 
 # Change to the old CLUSTER_PATH, if it already exists
 set +e
-etcdctl get /ceph-config/${CLUSTER}
+etcdctl get /ceph-config/${CLUSTER}/done
 set -e
 if [ $? -eq 0 ]; then
    CLUSTER_PATH=/ceph-config/${CLUSTER}


### PR DESCRIPTION
This PR fixes the check for cases where the cluster configuration doesn't exist.  Before, the script would die if the etcd keys didn't exist.  This also changes the etcd location schema (but will use the old, if it is present) and allows the user to override it entirely (documented in `README.md`)

The new default key location is `/ceph/<cluster-name>/config`, which seems more natural to me, but input is welcome.