### PR TITLE
rbd-volume: remove modprobe rbd

### DIFF
--- a/rbd-volume/entrypoint.sh
+++ b/rbd-volume/entrypoint.sh
@@ -10,9 +10,6 @@ set -e
 # Make sure the mountpoint exists
 mkdir -p ${RBD_TARGET}
 
-# Make sure the rbd module is loaded
-/sbin/modprobe rbd
-
 # Map the rbd volume
 /usr/bin/rbd map ${RBD_IMAGE} --pool ${RBD_POOL} -o ${RBD_OPTS}
 


### PR DESCRIPTION
When I try to to load the module from Docker container, an error occurs: modprobe: ERROR: ../libkmod/libkmod.c:556 kmod_search_moddep() could not open moddep file '/lib/modules/3.19.0/modules.dep.bin'. 
I think this is due to the lack of the kernel modules inside the container. Better to load rbd module outside Docker container.