### PR TITLE
Container's Dinamic ip as MON_IP

### DIFF
--- a/mon/entrypoint.sh
+++ b/mon/entrypoint.sh
@@ -12,10 +12,9 @@ if [ ! -n "$MON_NAME" ]; then
    exit 1
 fi
 
-if [ ! -n "$MON_IP" ]; then
-   echo "ERROR- MON_IP must be defined as the IP address of the monitor"
-   exit 1
-fi
+# MON_IP is the private container ip
+MON_IP=`ifconfig |grep "inet addr"|cut -d":" -f2|cut -d" " -f1|grep -v "127.0.0.1"`
+
 
 if [ ! -e /etc/ceph/ceph.conf ]; then
    ### Bootstrap the ceph cluster


### PR DESCRIPTION
Shouldn't MON_IP be the private ip of the container? If try to use any other ip I cannot get external connectivity.

By doing that nat works straight away and I can connect from other hosts to the monitor.