### PR TITLE
Make EnvironmentFile includes optional

### DIFF
--- a/config/ceph-config.service
+++ b/config/ceph-config.service
@@ -6,7 +6,7 @@ Before=ceph-osd.service
 Before=ceph-mds@.service
 
 [Service]
-EnvironmentFile=/etc/environment
+EnvironmentFile=-/etc/environment
 Type=oneshot
 RemainAfterExit=yes
 ExecStartPre=/bin/mkdir -p /etc/ceph

--- a/mds/ceph-mds@a.service
+++ b/mds/ceph-mds@a.service
@@ -4,7 +4,7 @@ After=docker.service
 
 [Service]
 TimeoutSec=0
-EnvironmentFile=/etc/environment
+EnvironmentFile=-/etc/environment
 ExecStartPre=/bin/mkdir -p /etc/ceph
 ExecStartPre=/usr/bin/docker pull ceph/mds
 ExecStartPre=-/usr/bin/docker rm ceph-mds-%i

--- a/mon/ceph-mon.service
+++ b/mon/ceph-mon.service
@@ -3,7 +3,7 @@ Description=Ceph Monitor
 After=docker.service
 
 [Service]
-EnvironmentFile=/etc/environment
+EnvironmentFile=-/etc/environment
 Environment=MON_IP=${COREOS_PUBLIC_IPV4}
 Environment=MON_NAME=%H
 ExecStartPre=/bin/mkdir -p /etc/ceph /var/lib/ceph

--- a/osd/ceph-osd.service
+++ b/osd/ceph-osd.service
@@ -4,7 +4,7 @@ After=docker.service
 RequiresMountsFor=/var/lib/ceph/osd/ceph-%i
 
 [Service]
-EnvironmentFile=/etc/environment
+EnvironmentFile=-/etc/environment
 Environment=OSD_ID=%i
 Environment=HOSTNAME=%H
 ExecStartPre=/usr/bin/docker run --rm -v /opt/bin:/opt/bin ibuildthecloud/systemd-docker


### PR DESCRIPTION
This makes the EnvironmentFile includes from each of the sample unit files optional, meaning that the units will not fail if the file does not exist.