### PR TITLE
Add support for cephfs and pool creation to MDS

### DIFF
--- a/mds/README.md
+++ b/mds/README.md
@@ -17,4 +17,21 @@ It will look for either `/etc/ceph/ceph.client.admin.keyring` or `/etc/ceph/ceph
 Commonly, you will want to bind-mount your host's `/etc/ceph` into the container.  For example:
 `docker run -e MDS_NAME=mymds -v /etc/ceph:/etc/ceph ceph/mds`
 
-Note:  ceph-mds seems to die _most_ of the time when trying to start it.  Trying repeatedly will eventually get it to run.  If run _manually_ within the container (enrtypoint to base, then manually run entrypoint.sh), it fails _less_ often, but still frequently (though less than 50% of the time).
+CephFS
+------
+
+By default, the MDS does _NOT_ create a ceph filesystem.  If you wish to have this MDS create a ceph filesystem (it will only do this if the specified `CEPHFS_NAME` does not already exist), you _must_ set, at a minimum, `CEPHFS_CREATE=1`.  It is strongly recommended that you read the rest of this section, as well.
+
+For most people, the defaults for the following optional environment variables are fine, but if you wish to customize the data and metadata pools in which your CephFS is stored, you may override the following as you wish:
+
+  * `CEPHFS_CREATE`: Whether to create the ceph filesystem (0 = no / 1 = yes), if it doesn't exist.  Defaults to 0 (no)
+  * `CEPHFS_NAME`: The name of the new ceph filesystem and the basis on which the later variables are created.  Defaults to `cephfs`
+  * `CEPHFS_DATA_POOL`:  The name of the data pool for the ceph filesystem.  If it does not exist, it will be created.  Defaults to `${CEPHFS_NAME}_data`
+  * `CEPHFS_DATA_POOL_PG`:  The number of placement groups for the data pool.  Defaults to `8`
+  * `CEPHFS_METADATA_POOL`:  The name of the metadata pool for the ceph filesystem.  If it does not exist, it will be created.  Defaults to `${CEPHFS_NAME}_metadata`
+  * `CEPHFS_METADATA_POOL_PG`:  The number of placement groups for the metadata pool.  Defaults to `8`
+
+Miscellany
+----------
+
+`ceph/mds` seems to die _most_ of the time when trying to start it.  Trying repeatedly will eventually get it to run.  If run _manually_ within the container (enrtypoint to base, then manually run entrypoint.sh), it fails _less_ often, but still frequently (though less than 50% of the time).

--- a/mds/entrypoint.sh
+++ b/mds/entrypoint.sh
@@ -3,8 +3,21 @@ set -e
 
 # Expected environment variables:
 #   MDS_NAME - (name of metadata server)
+# Optional environment variables:
+#   CEPHFS_NAME (defaults to 'cephfs')
+#   CEPHFS_DATA_POOL (defaults to ${CEPHFS_NAME}_data)
+#   CEPHFS_DATA_POOL_PG (defaults to 8)
+#   CEPHFS_METADATA_POOL (defaults to ${CEPHFS_NAME}_metadata)
+#   CEPHFS_METADATA_POOL_PG (defaults to 8)
 # Usage:
 #   docker run -e MDS_NAME=mymds ceph/mds
+
+: ${CEPHFS_CREATE:=0}
+: ${CEPHFS_NAME:=cephfs}
+: ${CEPHFS_DATA_POOL:=${CEPHFS_NAME}_data}
+: ${CEPHFS_DATA_POOL_PG:=8}
+: ${CEPHFS_METADATA_POOL:=${CEPHFS_NAME}_metadata}
+: ${CEPHFS_METADATA_POOL_PG:=8}
 
 if [ ! -n "$MDS_NAME" ]; then
    echo "ERROR- MDS_NAME must be defined as the name of the metadata server"
@@ -33,6 +46,27 @@ if [ ! -e /var/lib/ceph/mds/ceph-$MDS_NAME/keyring ]; then
 
       # Generate the new MDS key
       ceph auth get-or-create mds.$MDS_NAME mds 'allow' osd 'allow *' mon 'allow profile mds' > /var/lib/ceph/mds/ceph-${MDS_NAME}/keyring
+   fi
+
+fi
+
+# Create the Ceph filesystem, if necessary
+if [ $CEPHFS_CREATE -gt 0 ]; then
+   FS_EXISTS=$(ceph fs ls | grep -c name:.${CEPHFS_NAME},)
+   if [ $FS_EXISTS -eq 0 ]; then
+      # Make sure the specified data pool exists
+      ceph osd pool stats ${CEPHFS_DATA_POOL} >/dev/null
+      if [ $? -ne 0 ]; then
+         ceph osd pool create ${CEPHFS_DATA_POOL} ${CEPHFS_DATA_POOL_PG}
+      fi
+
+      # Make sure the specified metadata pool exists
+      ceph osd pool stats ${CEPHFS_METADATA_POOL} >/dev/null
+      if [ $? -ne 0 ]; then
+         ceph osd pool create ${CEPHFS_METADATA_POOL} ${CEPHFS_METADATA_POOL_PG}
+      fi
+
+      ceph fs new ${CEPHFS_NAME} ${CEPHFS_METADATA_POOL} ${CEPHFS_DATA_POOL}
    fi
 fi
 

--- a/mds/entrypoint.sh
+++ b/mds/entrypoint.sh
@@ -51,7 +51,7 @@ if [ ! -e /var/lib/ceph/mds/ceph-$MDS_NAME/keyring ]; then
 fi
 
 # Create the Ceph filesystem, if necessary
-if [ $CEPHFS_CREATE -gt 0 ]; then
+if [ $CEPHFS_CREATE -eq 1 ]; then
    FS_EXISTS=$(ceph fs ls | grep -c name:.${CEPHFS_NAME},)
    if [ $FS_EXISTS -eq 0 ]; then
       # Make sure the specified data pool exists


### PR DESCRIPTION
This PR adds support for _optional_ (and disabled by default) CephFS creation to the MDS.  

Even if CephFS creation is enabled, it should check, first, to make sure that the pools and filesystem don't already exist before creating them.

This should be non-breaking to existing installations.