### PR TITLE
Example common OSD differentiator

### DIFF
--- a/daemon/entrypoint.sh
+++ b/daemon/entrypoint.sh
@@ -23,7 +23,7 @@ set -e
 
 if [ ! -n "$CEPH_DAEMON" ]; then
    echo "ERROR- CEPH_DAEMON must be defined as the name of the daemon you want to deploy"
-   echo "Valid values for CEPH_DAEMON are MON, OSD_DIRECTORY, OSD_CEPH_DISK, MDS, RGW"
+   echo "Valid values for CEPH_DAEMON are MON, OSD, OSD_DIRECTORY, OSD_CEPH_DISK, MDS, RGW"
    exit 1
 fi
 
@@ -121,6 +121,20 @@ ENDHERE
 
   # start MON
   exec /usr/bin/ceph-mon -d -i ${MON_NAME} --public-addr ${MON_IP}:6789
+fi
+
+################
+# OSD (common) #
+################
+
+if [[ "$CEPH_DAEMON" = "OSD" ]]; then
+  if [ -n "$(find /var/lib/ceph/osd -prune -empty)" ]; then
+     echo "No bootstrapped OSDs found; trying ceph-disk"
+     CEPH_DAEMON="OSD_CEPH_DISK"
+  else
+     echo "Bootstrapped OSD(s) found; using OSD directory"
+     CEPH_DAEMON="OSD_DIRECTORY"
+  fi
 fi
 
 


### PR DESCRIPTION
Add a differentiator to allow for common OSD execution (automatically figure out what to do).

Note:  better would be to do this, _then_ try ceph-disk, _then_ try manual bootstrapping.  That, however, would require a bit more rearrangement.