### PR TITLE
The monitor name should not be mandatory

### DIFF
--- a/mon/entrypoint.sh
+++ b/mon/entrypoint.sh
@@ -1,16 +1,13 @@
 #!/bin/bash
 set -e
 
+: ${MON_NAME:=$(hostname -s)}
+
 # Expected environment variables:
 #   MON_IP - (IP address of monitor)
 #   MON_NAME - (name of monitor)
 # Usage:
 #   docker run -e MON_IP=192.168.101.50 -e MON_NAME=mymon ceph/mon
-
-if [ ! -n "$MON_NAME" ]; then
-   echo "ERROR- MON_NAME must be defined as the name of the monitor"
-   exit 1
-fi
 
 if [ ! -n "$MON_IP" ]; then
    echo "ERROR- MON_IP must be defined as the IP address of the monitor"


### PR DESCRIPTION
We can easily discover the hostname and populate the variable. If the
user wants something specific they can still override it.
ps: this is useful for k8s as well, if we set a specicif variable it
will be duplicated for every replication controller.

Signed-off-by: Sébastien Han <seb@redhat.com>