### PR TITLE
Necessary changes for k8s to work

### DIFF
--- a/daemon/README.md
+++ b/daemon/README.md
@@ -31,10 +31,15 @@ ceph/daemon
 
 List of available options:
 
-* `MON_IP`: IP address of the host running Docker
 * `MON_NAME`: name of the monitor (default to hostname)
 * `CEPH_PUBLIC_NETWORK`: CIDR of the host running Docker, it should be in the same network as the `MON_IP`
 * `CEPH_CLUSTER_NETWORK`: CIDR of a secondary interface of the host running Docker. Used for the OSD replication traffic
+* `MON_IP`: IP address of the host running Docker
+* `MON_IP_AUTO_DETECT`: Whether and how to attempt IP autodetection.  
+    *  0 = Do not detect (default)
+    *  1 = Detect IPv6, fallback to IPv4 (if no globally-routable IPv6 address detected)
+    *  4 = Detect IPv4 only
+    *  6 = Detect IPv6 only
 
 
 Deploy an OSD

--- a/daemon/entrypoint.sh
+++ b/daemon/entrypoint.sh
@@ -76,7 +76,7 @@ if [[ "$CEPH_DAEMON" = "MON" ]]; then
 
   if [ ${MON_IP_AUTO_DETECT} -eq 1 ]; then
     MON_IP=$(ip -6 -o a | grep scope.global | awk '/eth/ { sub ("/..", "", $4); print $4 }' | head -n1)
-    if [ -z $MON_IP ]; then
+    if [ -z "$MON_IP" ]; then
       MON_IP=$(ip -4 -o a | awk '/eth/ { sub ("/..", "", $4); print $4 }')
     fi
   elif [ ${MON_IP_AUTO_DETECT} -eq 4 ]; then

--- a/daemon/entrypoint.sh
+++ b/daemon/entrypoint.sh
@@ -4,6 +4,7 @@ set -e
 : ${CLUSTER:=ceph}
 : ${CEPH_CLUSTER_NETWORK:=${CEPH_PUBLIC_NETWORK}}
 : ${MON_NAME:=$(hostname -s)}
+: ${MON_IP_AUTO_DETECT:=0}
 : ${MDS_NAME:=$(hostname -s)}
 : ${OSD_FORCE_ZAP:=0}
 : ${OSD_JOURNAL_SIZE:=100}
@@ -71,6 +72,10 @@ if [[ "$CEPH_DAEMON" = "MON" ]]; then
   if [ ! -n "$CEPH_PUBLIC_NETWORK" ]; then
     echo "ERROR- CEPH_PUBLIC_NETWORK must be defined as the name of the network for the OSDs"
     exit 1
+  fi
+
+  if [ ${MON_IP_AUTO_DETECT} -eq 1 ]; then
+    MON_IP=$(ip -4 -o a | awk '/eth/ { sub ("/..", "", $4); print $4 }')
   fi
 
   if [ ! -n "$MON_IP" ]; then

--- a/mon/README.md
+++ b/mon/README.md
@@ -7,10 +7,15 @@ This Dockerfile may be used to bootstrap a Ceph cluster or add a mon to an exist
 Usage
 -----
 
-The environment variables `MON_NAME` and `MON_IP` are required:
+Environment variables:
 
-*  `MON_NAME` is the name of the monitor
-*  `MON_IP` is the IP address of the monitor (public)
+*  `MON_NAME` is the name of the monitor (defaults to `hostname -s`)
+*  `MON_IP` is the IP address of the monitor (public) (required, if not using autodetection)
+*  `MON_IP_AUTO_DETECT`: Whether and how to attempt IP autodetection.  
+    *  0 = Do not detect (default)
+    *  1 = Detect IPv6, fallback to IPv4 (if no globally-routable IPv6 address detected)
+    *  4 = Detect IPv4 only
+    *  6 = Detect IPv6 only
 
 For example:
 `docker run -e MON_IP=192.168.101.50 -e MON_NAME=mymon ceph/mon`

--- a/mon/entrypoint.sh
+++ b/mon/entrypoint.sh
@@ -11,7 +11,7 @@ set -e
 
 if [ ${MON_IP_AUTO_DETECT} -eq 1 ]; then
   MON_IP=$(ip -6 -o a | grep scope.global | awk '/eth/ { sub ("/..", "", $4); print $4 } | head -n1')
-  if [ -z $MON_IP ]; then
+  if [ -z "$MON_IP" ]; then
     MON_IP=$(ip -4 -o a | awk '/eth/ { sub ("/..", "", $4); print $4 }')
   fi
 elif [ ${MON_IP_AUTO_DETECT} -eq 4 ]; then

--- a/mon/entrypoint.sh
+++ b/mon/entrypoint.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+: ${MON_IP_AUTO_DETECT:=0}
+
 # Expected environment variables:
 #   MON_IP - (IP address of monitor)
 #   MON_NAME - (name of monitor)
@@ -10,6 +12,10 @@ set -e
 if [ ! -n "$MON_NAME" ]; then
    echo "ERROR- MON_NAME must be defined as the name of the monitor"
    exit 1
+fi
+
+if [ ${MON_IP_AUTO_DETECT} -eq 1 ]; then
+  MON_IP=$(ip -4 -o a | awk '/eth/ { sub ("/..", "", $4); print $4 }')
 fi
 
 if [ ! -n "$MON_IP" ]; then


### PR DESCRIPTION
We can't use `--net=host` with k8s. Thus if we manually set `MON_IP` as
an environement variable we will get duplicate content when using a
replication controller.
Introducing a new variable to auto detect the IP address of the
container.
This will generally work for every use case that don't want to use
`--net=host`.

Signed-off-by: Sébastien Han <seb@redhat.com>