### PR TITLE
Introduce a ceph_disk_activate

### DIFF
--- a/daemon/README.md
+++ b/daemon/README.md
@@ -78,6 +78,24 @@ List of available options:
 If you do not want to use `--privileged=true`, please fall back on the second example.
 
 
+### Ceph disk activate ###
+
+This fonction is balance between ceph-disk and osd directory where the operator can use ceph-disk outside of the container (directly on the host) to prepare the devices.
+Devices will be prepared with `ceph-disk prepare`, then they will get activated inside the container.
+A priviledged container is still required as ceph-disk needs to access /dev/.
+So this has minimum value compare to the ceph-disk but might fit some use cases where the operators want to prepare their devices outside of a container.
+
+```
+$ sudo docker run -d --net=host \
+--privileged=true \
+-v /etc/ceph:/etc/ceph \
+-v /var/lib/ceph/:/var/lib/ceph/ \
+-v /dev/:/dev/ \
+-e OSD_DEVICE=/dev/vdd \
+ceph/daemon osd_ceph_disk_activate
+```
+
+
 ### Ceph OSD directory ###
 
 There are a number of environment variables which are used to configure

--- a/daemon/entrypoint.sh
+++ b/daemon/entrypoint.sh
@@ -121,7 +121,7 @@ function create_mon_ceph_config_from_kv {
     kviator --kvstore=${KV_TYPE} --client=${KV_IP}:${KV_PORT} put ${CLUSTER_PATH}/bootstrapOsdKeyring - < /var/lib/ceph/bootstrap-osd/ceph.keyring
     kviator --kvstore=${KV_TYPE} --client=${KV_IP}:${KV_PORT} put ${CLUSTER_PATH}/bootstrapMdsKeyring - < /var/lib/ceph/bootstrap-mds/ceph.keyring
     kviator --kvstore=${KV_TYPE} --client=${KV_IP}:${KV_PORT} put ${CLUSTER_PATH}/bootstrapRgwKeyring - < /var/lib/ceph/bootstrap-rgw/ceph.keyring
-    
+
     kviator --kvstore=${KV_TYPE} --client=${KV_IP}:${KV_PORT} put ${CLUSTER_PATH}/monmap - < /etc/ceph/monmap
 
     echo "Completed initialization for ${MON_NAME}"
@@ -164,6 +164,9 @@ case "$1" in
    osd_ceph_disk)
       CEPH_DAEMON=OSD_CEPH_DISK
       ;;
+   osd_ceph_disk_activate)
+      CEPH_DAEMON=OSD_CEPH_DISK_ACTIVATE
+      ;;
    rgw)
       CEPH_DAEMON=RGW
       ;;
@@ -172,11 +175,11 @@ case "$1" in
       ;;
 esac
 if [ ! -n "$CEPH_DAEMON" ]; then
-   echo "ERROR- One of CEPH_DAEMON or a daemon parameter must be defined as the name "
-   echo "of the daemon you want to deploy."
-   echo "Valid values for CEPH_DAEMON are MON, OSD_DIRECTORY, OSD_CEPH_DISK, MDS, RGW, RESTAPI"
-   echo "Valid values for the daemon parameter are mon, osd_directory, osd_ceph_disk, mds, rgw, restapi"
-   exit 1
+    echo "ERROR- One of CEPH_DAEMON or a daemon parameter must be defined as the name "
+    echo "of the daemon you want to deploy."
+    echo "Valid values for CEPH_DAEMON are MON, OSD_DIRECTORY, OSD_CEPH_DISK, OSD_CEPH_DISK_ACTIVATE, MDS, RGW, RESTAPI"
+    echo "Valid values for the daemon parameter are mon, osd_directory, osd_ceph_disk, osd_ceph_disk_activate, mds, rgw, restapi"
+    exit 1
 fi
 
 
@@ -415,6 +418,28 @@ elif [[ "$CEPH_DAEMON" = "OSD_CEPH_DISK" ]]; then
   exec /usr/bin/ceph-osd -f -d -i ${OSD_ID}
 
 
+##########################
+# OSD_CEPH_DISK_ACTIVATE #
+##########################
+
+elif [[ "$CEPH_DAEMON" = "OSD_CEPH_DISK_ACTIVATE" ]]; then
+
+  ceph_config_check
+
+  if [[ -z "${OSD_DEVICE}" ]];then
+    echo "ERROR- You must provide a device to build your OSD ie: /dev/sdb"
+    exit 1
+  fi
+
+  mkdir -p /var/lib/ceph/osd
+  ceph-disk -v activate ${OSD_DEVICE}1
+  OSD_ID=$(cat /var/lib/ceph/osd/$(ls -ltr /var/lib/ceph/osd/ | tail -n1 | awk -v pattern="$CLUSTER" '$0 ~ pattern {print $9}')/whoami)
+  OSD_WEIGHT=$(df -P -k /var/lib/ceph/osd/${CLUSTER}-$OSD_ID/ | tail -1 | awk '{ d= $2/1073741824 ; r = sprintf("%.2f", d); print r }')
+  ceph --name=osd.${OSD_ID} --keyring=/var/lib/ceph/osd/${CLUSTER}-${OSD_ID}/keyring osd crush create-or-move -- ${OSD_ID} ${OSD_WEIGHT} root=default host=$(hostname)
+
+  exec /usr/bin/ceph-osd -f -d -i ${OSD_ID}
+
+
 #######
 # MDS #
 #######
@@ -532,7 +557,7 @@ else
 
   echo "ERROR- One of CEPH_DAEMON or a daemon parameter must be defined as the name "
   echo "of the daemon you want to deploy."
-  echo "Valid values for CEPH_DAEMON are MON, OSD_DIRECTORY, OSD_CEPH_DISK, MDS, RGW, RESTAPI"
-  echo "Valid values for the daemon parameter are mon, osd_directory, osd_ceph_disk, mds, rgw, restapi"
+  echo "Valid values for CEPH_DAEMON are MON, OSD_DIRECTORY, OSD_CEPH_DISK, OSD_CEPH_DISK_ACTIVATE, MDS, RGW, RESTAPI"
+  echo "Valid values for the daemon parameter are mon, osd_directory, osd_ceph_disk, osd_ceph_disk_activate, mds, rgw, restapi"
   exit 1
 fi


### PR DESCRIPTION
In 'some' cases the operators might not want to run ceph-disk prepare
inside the container but might want it outside.
In this scenario, we only activate the OSD and don't prepare it.

Signed-off-by: leseb <seb@redhat.com>