### PR TITLE
Allow native hostname extraction for OSDs, by default

### DIFF
--- a/daemon/entrypoint.sh
+++ b/daemon/entrypoint.sh
@@ -3,7 +3,8 @@ set -e
 
 : ${CLUSTER:=ceph}
 : ${CEPH_CLUSTER_NETWORK:=${CEPH_PUBLIC_NETWORK}}
-: ${MON_NAME:=$(hostname -s)}
+: ${HOSTNAME:=$(hostname -s)}
+: ${MON_NAME:=${HOSTNAME}}
 : ${MON_IP_AUTO_DETECT:=0}
 : ${MDS_NAME:=mds-$(hostname -s)}
 : ${OSD_FORCE_ZAP:=0}

--- a/osd/entrypoint.sh
+++ b/osd/entrypoint.sh
@@ -2,6 +2,7 @@
 set -e
 
 : ${CLUSTER:=ceph}
+: ${HOSTNAME:=$(hostname -s)}
 : ${WEIGHT:=1.0}
 
 for OSD_ID in $(ls /var/lib/ceph/osd |  awk 'BEGIN { FS = "-" } ; { print $2 }')


### PR DESCRIPTION
I know I required manually-configured HOSTNAME originally, but I cannot think of a good reason for it.  That could be failing memory on my part, though.

Regardless, this PR makes the HOSTNAME for OSDs _default_ to the hostname of the container, as requested in Issue #113 