### PR TITLE
Adding Mon Host: key is already set

### DIFF
--- a/daemon/entrypoint.sh
+++ b/daemon/entrypoint.sh
@@ -49,7 +49,7 @@ function create_mon_ceph_config_from_kv {
   CLUSTER_PATH=ceph-config/${CLUSTER}
 
   echo "Adding Mon Host - ${MON_NAME}"
-  kviator --kvstore=${KV_TYPE} --client=${KV_IP}:${KV_PORT} cas ${CLUSTER_PATH}/mon_host/${MON_NAME} ${MON_IP} > /dev/null 2>&1
+  kviator --kvstore=${KV_TYPE} --client=${KV_IP}:${KV_PORT} put ${CLUSTER_PATH}/mon_host/${MON_NAME} ${MON_IP} > /dev/null 2>&1
 
   # Acquire lock to not run into race conditions with parallel bootstraps
   until kviator --kvstore=${KV_TYPE} --client=${KV_IP}:${KV_PORT} cas ${CLUSTER_PATH}/lock $MON_NAME > /dev/null 2>&1 ; do


### PR DESCRIPTION
Running `entrypoint.sh mon` more than once results in `key is already set`.
I think it should be safe to rewrite this key as many times as needed.
This is what I get otherwise:
```
+ echo 'Adding Mon Host - core-1.cell-0.dc-1.demo.lan'
Adding Mon Host - core-1.cell-0.dc-1.demo.lan
+ kviator --kvstore=etcd --client=127.0.0.1:4001 cas ceph-config/ceph-cell-0/mon_host/core-1.cell-0.dc-1.demo.lan 172.16.0.81
root@core-1:/# kviator --kvstore=etcd --client=127.0.0.1:4001 cas ceph-config/ceph-cell-0/mon_host/core-1.cell-0.dc-1.demo.lan 172.16.0.81
key is already set
```