### PR TITLE
Be more ${CLUSTER} aware

### DIFF
--- a/daemon/entrypoint.sh
+++ b/daemon/entrypoint.sh
@@ -32,7 +32,7 @@ set -e
 
 function ceph_config_check {
 if [[ ! -e /etc/ceph/${CLUSTER}.conf ]]; then
-  echo "ERROR- /etc/ceph/ceph.conf must exist; get it from your existing mon"
+  echo "ERROR- /etc/ceph/${CLUSTER}.conf must exist; get it from your existing mon"
   exit 1
 fi
 }
@@ -148,6 +148,8 @@ function create_ceph_config_from_kv {
     echo "Waiting for confd to update templates..."
     sleep 1
   done
+
+  [ "${CLUSTER}" != "ceph" ] && mv /etc/ceph/ceph.conf /etc/ceph/${CLUSTER}.conf
 
   # Check/Create bootstrap key directories
   mkdir -p /var/lib/ceph/bootstrap-{osd,mds,rgw}
@@ -427,9 +429,9 @@ elif [[ "$CEPH_DAEMON" = "OSD_CEPH_DISK" ]]; then
   fi
 
   if [[ ! -z "${OSD_JOURNAL}" ]]; then
-    ceph-disk -v prepare ${OSD_DEVICE}:${OSD_JOURNAL}
+    ceph-disk -v prepare --cluster ${CLUSTER} ${OSD_DEVICE}:${OSD_JOURNAL}
   else
-    ceph-disk -v prepare ${OSD_DEVICE}
+    ceph-disk -v prepare --cluster ${CLUSTER} ${OSD_DEVICE}
   fi
 
   ceph-disk -v activate ${OSD_DEVICE}1


### PR DESCRIPTION
Using a cluster name other than `ceph` is not working.
This PR is to fix a few lines of code I have spotted.

Unfortunately I can't set `--cluster` when I call `ceph-disk activate`:

````
+ ceph-disk -v activate /dev/sda1
INFO:ceph-disk:Running command: /sbin/blkid -p -s TYPE -ovalue -- /dev/sda1
INFO:ceph-disk:Running command: /usr/bin/ceph-conf --cluster=ceph --name=osd. --lookup osd_mount_options_xfs
2015-07-15 15:18:53.769457 7ffabab197c0 -1 did not load config file, using default settings.
INFO:ceph-disk:Running command: /usr/bin/ceph-conf --cluster=ceph --name=osd. --lookup osd_fs_mount_options_xfs
````