### PR TITLE
entrypoint.sh: mds auth error w/ admin keyring

### DIFF
--- a/daemon/entrypoint.sh
+++ b/daemon/entrypoint.sh
@@ -296,18 +296,18 @@ function start_mds {
      mkdir -p /var/lib/ceph/mds/${CLUSTER}-${MDS_NAME}
 
     if [ -e /etc/ceph/${CLUSTER}.client.admin.keyring ]; then
-       KEYRING_OPT="--keyring /etc/ceph/${CLUSTER}.client.admin.keyring"
+       KEYRING_OPT="--name client.admin --keyring /etc/ceph/${CLUSTER}.client.admin.keyring"
     elif [ -e /var/lib/ceph/bootstrap-mds/${CLUSTER}.keyring ]; then
-       KEYRING_OPT="--keyring /var/lib/ceph/bootstrap-mds/${CLUSTER}.keyring"
+       KEYRING_OPT="--name client.bootstrap-mds --keyring /var/lib/ceph/bootstrap-mds/${CLUSTER}.keyring"
     else
       echo "ERROR- Failed to bootstrap MDS: could not find admin or bootstrap-mds keyring.  You can extract it from your current monitor by running 'ceph auth get client.bootstrap-mds -o /var/lib/ceph/bootstrap-mds/${CLUSTER}.keyring'"
       exit 1
     fi
 
-    timeout 10 ceph ${CEPH_OPTS} --name client.bootstrap-mds $KEYRING_OPT health || exit 1
+    timeout 10 ceph ${CEPH_OPTS} $KEYRING_OPT health || exit 1
 
     # Generate the MDS key
-    ceph ${CEPH_OPTS} --name client.bootstrap-mds $KEYRING_OPT auth get-or-create mds.$MDS_NAME osd 'allow rwx' mds 'allow' mon 'allow profile mds' -o /var/lib/ceph/mds/${CLUSTER}-${MDS_NAME}/keyring
+    ceph ${CEPH_OPTS} $KEYRING_OPT auth get-or-create mds.$MDS_NAME osd 'allow rwx' mds 'allow' mon 'allow profile mds' -o /var/lib/ceph/mds/${CLUSTER}-${MDS_NAME}/keyring
 
   fi
 


### PR DESCRIPTION
mds won't start for me with the following error:

2015-07-16 16:20:14.168684 7f95b6028700 0 librados: client.bootstrap-mds authentication error (1) Operation not permitted
Error connecting to cluster: PermissionError

when running
ceph --cluster ${CLUSTER} --name client.bootstrap-mds $KEYRING_OPT health
with $KEYRING_OPT set to
--keyring /etc/ceph/${CLUSTER}.client.admin.keyring

It appears that the admin keyring (/var/lib/ceph/bootstrap-mds/ceph.keyring) is not accepted, however, it does work with the bootstrap-mds keyring in /var/lib/ceph/bootstrap-mds/ceph.keyring