### PR TITLE
Need a space for ceps-disk prepare with a journal

### DIFF
--- a/daemon/entrypoint.sh
+++ b/daemon/entrypoint.sh
@@ -249,7 +249,7 @@ function osd_disk {
   fi
 
   if [[ ! -z "${OSD_JOURNAL}" ]]; then
-    ceph-disk -v prepare ${OSD_DEVICE}:${OSD_JOURNAL}
+    ceph-disk -v prepare ${OSD_DEVICE} ${OSD_JOURNAL}
   else
     ceph-disk -v prepare ${OSD_DEVICE}
   fi


### PR DESCRIPTION
The OSD_DEVICE and OSD_JOURNAL need a space between them.