### PR TITLE
Default to osd_activate if OSD_DEVICE is provided

### DIFF
--- a/daemon/entrypoint.sh
+++ b/daemon/entrypoint.sh
@@ -143,7 +143,13 @@ function start_osd {
          osd_directory
          ;;
       disk)
-         osd_disk
+         if [ -n "$(find /var/lib/ceph/osd -prune -empty)" ]; then
+           echo "No bootstrapped OSDs found; trying ceph-disk on ${OSD_DEVICE}"
+           osd_disk
+         else
+           echo "Bootstrapped OSD(s) found; ${OSD_DEVICE} won't be bootstrapped this time"
+           osd_activate
+         fi
          ;;
       activate)
          osd_activate

--- a/daemon/entrypoint.sh
+++ b/daemon/entrypoint.sh
@@ -143,13 +143,7 @@ function start_osd {
          osd_directory
          ;;
       disk)
-         if [ -n "$(find /var/lib/ceph/osd -prune -empty)" ]; then
-           echo "No bootstrapped OSDs found; trying ceph-disk on ${OSD_DEVICE}"
-           osd_disk
-         else
-           echo "Bootstrapped OSD(s) found; ${OSD_DEVICE} won't be bootstrapped this time"
-           osd_activate
-         fi
+         osd_disk
          ;;
       activate)
          osd_activate
@@ -159,8 +153,13 @@ function start_osd {
             echo "No bootstrapped OSDs found; trying ceph-disk"
             osd_disk
          else
-            echo "Bootstrapped OSD(s) found; using OSD directory"
-            osd_directory
+            if [ -z "${OSD_DEVICE}" ]; then
+                echo "Bootstrapped OSD(s) found; using OSD directory"
+                osd_directory
+            else
+                echo "Bootstrapped OSD(s) found; using ${OSD_DEVICE}"
+                osd_activate
+            fi
          fi
          ;;
    esac


### PR DESCRIPTION
This patch is to dynamically choose between `osd_directory` and `osd_activate`.
The currently implementation forces `osd_directory` always.