### PR TITLE
Remove health warn with PGs

### DIFF
--- a/daemon/config.static.sh
+++ b/daemon/config.static.sh
@@ -20,6 +20,7 @@ auth client required = cephx
 public network = ${CEPH_PUBLIC_NETWORK}
 cluster network = ${CEPH_CLUSTER_NETWORK}
 osd journal size = ${OSD_JOURNAL_SIZE}
+mon pg warn max per osd = 0
 ENDHERE
 
     if [[ ! -z "$(ip -6 -o a | grep scope.global | awk '/eth/ { sub ("/..", "", $4); print $4 }' | head -n1)" ]]; then


### PR DESCRIPTION
When Ceph detects that the number of PGs is not sufficient it shows a
warn on its status. This is quiet anoying, so removing this warning.
I just wonder if you should make this configurable or not... For me it's
just a pain but would like feedback from others.

Signed-off-by: Sébastien Han <seb@redhat.com>