### PR TITLE
Version bump etcdctl: 2.2

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -5,7 +5,7 @@
 FROM ubuntu:14.04
 MAINTAINER Sébastien Han "seb@redhat.com"
 
-ENV ETCDCTL_VERSION v2.0.10
+ENV ETCDCTL_VERSION v2.2.0
 ENV ETCDCTL_ARCH linux-amd64
 ENV CEPH_VERSION hammer
 


### PR DESCRIPTION
Update etcdctl to version 2.2.0.

A merge of this PR (or any PR, actually) will also trigger a universal build, thus addressing issue #155 incidentally.