### PR TITLE
Added OSD_GET_ADMIN_KEY option

### DIFF
--- a/daemon/entrypoint.sh
+++ b/daemon/entrypoint.sh
@@ -10,6 +10,7 @@ set -e
 : ${MDS_NAME:=mds-${HOSTNAME}}
 : ${OSD_FORCE_ZAP:=0}
 : ${OSD_JOURNAL_SIZE:=100}
+: ${OSD_GET_ADMIN_KEY:=0}
 : ${CRUSH_LOCATION:=root=default host=${HOSTNAME}}
 : ${CEPHFS_CREATE:=0}
 : ${CEPHFS_NAME:=cephfs}
@@ -137,6 +138,7 @@ function start_mon {
 function start_osd {
    get_config
    check_config
+   [ ${OSD_GET_ADMIN_KEY} -eq "1" ] && get_admin_key
 
    case "$OSD_TYPE" in
       directory)

--- a/daemon/entrypoint.sh
+++ b/daemon/entrypoint.sh
@@ -4,13 +4,13 @@ set -e
 : ${CLUSTER:=ceph}
 : ${CEPH_CLUSTER_NETWORK:=${CEPH_PUBLIC_NETWORK}}
 : ${CEPH_DAEMON:=${1}} # default daemon to first argument
+: ${CEPH_GET_ADMIN_KEY:=0}
 : ${HOSTNAME:=$(hostname -s)}
 : ${MON_NAME:=${HOSTNAME}}
 : ${MON_IP_AUTO_DETECT:=0}
 : ${MDS_NAME:=mds-${HOSTNAME}}
 : ${OSD_FORCE_ZAP:=0}
 : ${OSD_JOURNAL_SIZE:=100}
-: ${OSD_GET_ADMIN_KEY:=0}
 : ${CRUSH_LOCATION:=root=default host=${HOSTNAME}}
 : ${CEPHFS_CREATE:=0}
 : ${CEPHFS_NAME:=cephfs}
@@ -138,7 +138,11 @@ function start_mon {
 function start_osd {
    get_config
    check_config
-   [ ${OSD_GET_ADMIN_KEY} -eq "1" ] && get_admin_key
+
+   if [ ${CEPH_GET_ADMIN_KEY} -eq "1" ]; then
+     get_admin_key
+     check_admin_key
+   fi
 
    case "$OSD_TYPE" in
       directory)
@@ -356,6 +360,11 @@ function start_mds {
 function start_rgw {
   get_config
   check_config
+
+  if [ ${CEPH_GET_ADMIN_KEY} -eq "1" ]; then
+    get_admin_key
+    check_admin_key
+  fi
 
   # Check to see if our RGW has been initialized
   if [ ! -e /var/lib/ceph/radosgw/${RGW_NAME}/keyring ]; then


### PR DESCRIPTION
If OSD_GET_ADMIN_KEY=0 (default) nothing happens.
If OSD_GET_ADMIN_KEY=1 and a KV backend is present it gets the admin keyring and stores it in `/etc/ceph/${CLUSTER}.client.admin.keyring`