### PR TITLE
Fix docker caching: explicit ceph version

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -8,14 +8,15 @@ MAINTAINER Sébastien Han "seb@redhat.com"
 ENV ETCDCTL_VERSION v2.0.9
 ENV ETCDCTL_ARCH linux-amd64
 ENV CEPH_VERSION hammer
+ENV CEPH_VERSION_DETAIL 0.94.5-1trusty
 
 # Install prerequisites
-RUN apt-get update &&  apt-get install -y wget
+RUN apt-get update &&  apt-get install -y wget && apt-get clean
 
 # Install Ceph
 RUN wget -q -O- 'https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc' | apt-key add -
 RUN echo deb http://ceph.com/debian-$CEPH_VERSION/ trusty main | tee /etc/apt/sources.list.d/ceph-$CEPH_VERSION.list
-RUN apt-get update && apt-get install -y --force-yes ceph && \
+RUN apt-get update && apt-get install -y --force-yes ceph=${CEPH_VERSION_DETAIL} && \
 apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Install etcdctl


### PR DESCRIPTION
Hi,

Either docker caching or registry not being triggered implies that ceph version get outdated. For instance, the current versions of ceph/base:hammer is 0.94.1 while 0.94.5 is out.

This patch fixes this situation by explicitly stating the ceph package's version to use.