### PR TITLE
Add deprecation notices for discrete daemons

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,11 @@ Ceph-related dockerfiles
 ## Core Components:
 
 * [`ceph/base`](base/):  Ceph base container image.  This is nothing but a fresh install of the latest Ceph on Ubuntu LTS (14.04)
-* [`ceph/mds`](mds/): Ceph MDS (Metadata server)
-* [`ceph/mon`](mon/): Ceph Mon(itor)
-* [`ceph/osd`](osd/): Ceph OSD (object storage daemon)
-* [`ceph/radosgw`](radosgw/): Ceph Rados gateway service; S3/swift API server
+* [`ceph/daemon`](daemon/): All-in-one container for all core daemons.
+* [`ceph/mds`](mds/): _DEPRECATED (use `daemon`)_ Ceph MDS (Metadata server)
+* [`ceph/mon`](mon/): _DEPRECATED (use `daemon`)_ Ceph Mon(itor)
+* [`ceph/osd`](osd/): _DEPRECATED (use `daemon`)_ Ceph OSD (object storage daemon)
+* [`ceph/radosgw`](radosgw/): _DEPRECATED (use `daemon`)_ Ceph Rados gateway service; S3/swift API server
 
 ## Utilities and convenience wrappers
 

--- a/mds/README.md
+++ b/mds/README.md
@@ -1,6 +1,8 @@
 ceph-mds
 ========
 
+_Note_:  This container is DEPRECATED.  Please use `ceph/daemon` instead.  It is better maintained and more featureful.  This container may be removed in a future version.
+
 This Dockerfile creates a Ceph metadata server (MDS) image
 
 

--- a/mon/README.md
+++ b/mon/README.md
@@ -1,6 +1,8 @@
 ceph-mon
 ========
 
+_Note_:  This container is DEPRECATED.  Please use `ceph/daemon` instead.  It is better maintained and more featureful.  This container may be removed in a future version.
+
 This Dockerfile may be used to bootstrap a Ceph cluster or add a mon to an existing cluster.
 
 

--- a/osd/README.md
+++ b/osd/README.md
@@ -1,6 +1,8 @@
 ceph-osd
 ========
 
+_Note_:  This container is DEPRECATED.  Please use `ceph/daemon` instead.  It is better maintained and more featureful.  This container may be removed in a future version.
+
 Run Ceph OSDs in docker
 
 Usage

--- a/radosgw/README.md
+++ b/radosgw/README.md
@@ -1,6 +1,8 @@
 ceph-rgw
 ========
 
+_Note_:  This container is DEPRECATED.  Please use `ceph/daemon` instead.  It is better maintained and more featureful.  This container may be removed in a future version.
+
 This Dockerfile creates a Ceph RADOS gateway server (RGW) image
 Both external CGI interface and civetweb are supported.
 However civetweb is preferred so it's enabled by default.


### PR DESCRIPTION
Add deprecation notices for:
 - `ceph/osd`
 - `ceph/mon`
 - `ceph/mds`
 - `ceph/radosgw`

in favor of `ceph/daemon`

This doesn't _remove_ them.  It simply updates the documentation to mark the discrete daemon containers as deprecated.