### PR TITLE
Typo in MDS keyring path

### DIFF
--- a/daemon/entrypoint.sh
+++ b/daemon/entrypoint.sh
@@ -342,7 +342,7 @@ function start_mds {
 
     # Generate the MDS key
     ceph ${CEPH_OPTS} $KEYRING_OPT auth get-or-create mds.$MDS_NAME osd 'allow rwx' mds 'allow' mon 'allow profile mds' -o /var/lib/ceph/mds/${CLUSTER}-${MDS_NAME}/keyring
-    chown ceph. /var/lib/ceph/mds/${MDS_NAME}/keyring
+    chown ceph. /var/lib/ceph/mds/${CLUSTER}-${MDS_NAME}/keyring
     chmod 600 /var/lib/ceph/mds/${CLUSTER}-${MDS_NAME}/keyring
 
   fi


### PR DESCRIPTION
I've got:
```
chown: cannot access '/var/lib/ceph/mds/mds-4ecf90c279f5/keyring': No such file or directory
```
When started MDS and I believe this is a typo that left after some previous paths refactoring.