### PR TITLE
create osd, init and run in one shot, without the need to run ceph os…

### DIFF
--- a/daemon/entrypoint.sh
+++ b/daemon/entrypoint.sh
@@ -201,7 +201,13 @@ function osd_directory {
   if [[ -n "$(find /var/lib/ceph/osd -prune -empty)" ]]; then
     echo "Creating osd with ceph osd create"
     OSD_ID=$(ceph osd create)
-    echo "OSD created with ID: ${OSD_ID}"
+    if [ "$OSD_ID" -eq "$OSD_ID" ] 2>/dev/null; then
+        echo "OSD created with ID: ${OSD_ID}"
+    else
+      echo "OSD creation failed: ${OSD_ID}"
+      exit 1
+    fi
+
     # create the folder and own it
     mkdir -p /var/lib/ceph/osd/${CLUSTER}-${OSD_ID}
     chown ceph. /var/lib/ceph/osd/${CLUSTER}-${OSD_ID}


### PR DESCRIPTION
this changes the logic on osd_directory endpoint

instead of having to run `ceph osd create` on then monitor, then create a directory manually on the host, chown it etc...  before running the daemon, this is done in the entrypoint to start an OSD in osd_directory mode

the original logic was looking for osd ids in the `/var/lib/ceph/osd/` folder however it doesn't make sense to have multiple OSD directories on the same host/drive as each will report full disk size as their own.
Here we automate creation of the OSD (no more manual steps) and prevent creation of multiple osd_directory at the same time.

this may be a breaking change if anyone was actually running multiple osd_directories on the same host, but my tests show it doesn't work well, so it must not be used that way.

PS: this PR goes along with the other PRs to populate KV store and bug fixes. it does not work well without those fixes.