### PR TITLE
mon-data added to ceph-mon mkfs.

### DIFF
--- a/daemon/entrypoint.sh
+++ b/daemon/entrypoint.sh
@@ -131,7 +131,7 @@ function start_mon {
     create_socket_dir
 
     # Prepare the monitor daemon's directory with the map and keyring
-    ceph-mon --setuser ceph --setgroup ceph --mkfs -i ${MON_NAME} --monmap /etc/ceph/monmap --keyring /tmp/${CLUSTER}.mon.keyring
+    ceph-mon --setuser ceph --setgroup ceph --mkfs -i ${MON_NAME} --monmap /etc/ceph/monmap --keyring /tmp/${CLUSTER}.mon.keyring --mon-data /var/lib/ceph/mon/${CLUSTER}-${MON_NAME}
 
     # Clean up the temporary key
     rm /tmp/${CLUSTER}.mon.keyring


### PR DESCRIPTION
When you configure the clustername with a non-default value (default: ceph) the current ceph-mon mkfs creates a directory under /var/lib/ceph/mon/ceph-${hostname}. When the exec (line 141) for ceph-mon starts it looks inside the directory: /var/lib/ceph/mon/${CLUSTER}-${HOSTNAME}. Result is that the cluster will never start with a non-default clustername

The mkfs populates the directory correct when you use --mon-data.