### PR TITLE
Fix to run ceph/daemon osd on Centos.

### DIFF
--- a/daemon/entrypoint.sh
+++ b/daemon/entrypoint.sh
@@ -265,11 +265,13 @@ function osd_disk {
     ceph-disk -v prepare ${OSD_DEVICE}
   fi
 
-  ceph-disk -v activate ${OSD_DEVICE}1
+  ceph-disk -v activate --mark-init none ${OSD_DEVICE}1
   OSD_ID=$(cat /var/lib/ceph/osd/$(ls -ltr /var/lib/ceph/osd/ | tail -n1 | awk -v pattern="$CLUSTER" '$0 ~ pattern {print $9}')/whoami)
   OSD_WEIGHT=$(df -P -k /var/lib/ceph/osd/${CLUSTER}-$OSD_ID/ | tail -1 | awk '{ d= $2/1073741824 ; r = sprintf("%.2f", d); print r }')
   ceph ${CEPH_OPTS} --name=osd.${OSD_ID} --keyring=/var/lib/ceph/osd/${CLUSTER}-${OSD_ID}/keyring osd crush create-or-move -- ${OSD_ID} ${OSD_WEIGHT} ${CRUSH_LOCATION}
 
+  killall -9 -w ceph-osd
+  rm -f /var/run/ceph/ceph-osd.0.asok
   exec /usr/bin/ceph-osd ${CEPH_OPTS} -f -d -i ${OSD_ID}
 }
 


### PR DESCRIPTION
From entrypoint.sh, 'ceph-disk activate' call is made to 
activate the disk and later start the ceph-osd process
as a daemon. Currently as systemd is not initalised
as part of base Centos image, this seizes to run and errors out.

Also, another call is made from entrypoint.sh after the 
initialization to kick start ceph osd process in the 
foreground for the ceph-osd docker container to continuously run.
As a result, there are two calls made to run ceph-osd and
this will result in the container erroring out and exiting.
This patch aims to fix the same.

Signed-off-by: Deepthi Dharwar <ddharwar@redhat.com>
Signed-off-by: Sébastien Han <seb@redhat.com>