### PR TITLE
ceph/daemon failed to start in directory mode

### DIFF
--- a/daemon/entrypoint.sh
+++ b/daemon/entrypoint.sh
@@ -250,9 +250,11 @@ function osd_directory {
   for OSD_ID in $(ls /var/lib/ceph/osd |  awk 'BEGIN { FS = "-" } ; { print $2 }'); do
     if [ -n "${JOURNAL_DIR}" ]; then
        OSD_J="${JOURNAL_DIR}/journal.${OSD_ID}"
+       chown -R ceph. ${JOURNAL_DIR}
     else
        if [ -n "${JOURNAL}" ]; then
           OSD_J=${JOURNAL}
+          chown -R ceph. $(dirname ${JOURNAL_DIR})
        else
           OSD_J=/var/lib/ceph/osd/${CLUSTER}-${OSD_ID}/journal
        fi
@@ -260,6 +262,7 @@ function osd_directory {
 
     # Check to see if our OSD has been initialized
     if [ ! -e /var/lib/ceph/osd/${CLUSTER}-${OSD_ID}/keyring ]; then
+      chown ceph. /var/lib/ceph/osd/${CLUSTER}-${OSD_ID}
       # Create OSD key and file structure
       ceph-osd ${CEPH_OPTS} -i $OSD_ID --mkfs --mkkey --mkjournal --osd-journal ${OSD_J} --setuser ceph --setgroup ceph
 

--- a/daemon/entrypoint.sh
+++ b/daemon/entrypoint.sh
@@ -181,6 +181,7 @@ function start_mon {
 function start_osd {
    get_config
    check_config
+   create_socket_dir
 
    if [ ${CEPH_GET_ADMIN_KEY} -eq "1" ]; then
      get_admin_key
@@ -274,7 +275,6 @@ function osd_directory {
       echo "done adding key"
       chown ceph. /var/lib/ceph/osd/${CLUSTER}-${OSD_ID}/keyring
       chmod 0600 /var/lib/ceph/osd/${CLUSTER}-${OSD_ID}/keyring
-      create_socket_dir
 
       # Add the OSD to the CRUSH map
       if [ ! -n "${HOSTNAME}" ]; then
@@ -316,7 +316,6 @@ function osd_disk {
 
   mkdir -p /var/lib/ceph/osd
   chown ceph. /var/lib/ceph/osd
-  create_socket_dir
 
   # TODO:
   # -  add device format check (make sure only one device is passed
@@ -357,7 +356,6 @@ function osd_activate {
 
   mkdir -p /var/lib/ceph/osd
   chown ceph. /var/lib/ceph/osd
-  create_socket_dir
   chown ceph. ${OSD_DEVICE}2
   ceph-disk -v activate ${OSD_DEVICE}1
   OSD_ID=$(cat /var/lib/ceph/osd/$(ls -ltr /var/lib/ceph/osd/ | tail -n1 | awk -v pattern="$CLUSTER" '$0 ~ pattern {print $9}')/whoami)


### PR DESCRIPTION
If ceph/daemon runs with non-default journal location ie: JOURNAL_DIR=/DIR or JOURNAL=/dir/journal, then when ceph-osd initialize the file structure for new OSD it falls with error:
```
Started ceph osd service.
static: does not generate config
warning: unable to create /var/run/ceph: (13) Permission denied
2015-12-29 12:27:09.427907 7fcd376f2940  0 set uid:gid to 64045:64045
2015-12-29 12:27:09.430167 7fcd376f2940 -1 asok(0x5618fe910000) AdminSocketConfigObs::init: failed: AdminSocket::bind_and_listen: failed to bind the UNIX domain socket to '/var/run/ceph/ceph-osd.0.asok': (2) No such file or directory
2015-12-29 12:27:09.430457 7fcd376f2940 -1 filestore(/var/lib/ceph/osd/ceph-0) mkfs: failed to open /var/lib/ceph/osd/ceph-0/fsid: (13) Permission denied
2015-12-29 12:27:09.430467 7fcd376f2940 -1 OSD::mkfs: ObjectStore::mkfs failed with error -13
2015-12-29 12:27:09.430492 7fcd376f2940 -1  ** ERROR: error creating empty object store in /var/lib/ceph/osd/ceph-0: (13) Permission denied
```