### PR TITLE
Missing cluster name argument

### DIFF
--- a/daemon/entrypoint.sh
+++ b/daemon/entrypoint.sh
@@ -232,8 +232,8 @@ function osd_directory {
 
   # check if anything is there, if not create an osd with directory
   if [[ -n "$(find /var/lib/ceph/osd -prune -empty)" ]]; then
-    echo "Creating osd with ceph osd create"
-    OSD_ID=$(ceph osd create)
+    echo "Creating osd with ceph --cluster ${CLUSTER} osd create"
+    OSD_ID=$(ceph --cluster ${CLUSTER} osd create)
     if [ "$OSD_ID" -eq "$OSD_ID" ] 2>/dev/null; then
         echo "OSD created with ID: ${OSD_ID}"
     else


### PR DESCRIPTION
Introduced in #184 OSD creation doesn't take into account custom cluster name