### PR TITLE
Fix for issue #171

### DIFF
--- a/daemon/Dockerfile
+++ b/daemon/Dockerfile
@@ -7,7 +7,7 @@
 FROM ceph/base
 MAINTAINER Sébastien Han "seb@redhat.com"
 
-# patch is only needed until PR #7531 is merged in ceph/ceph (and backported
+# patch is only needed until PR #7351 is merged in ceph/ceph (and backported
 # to the version used in ceph/ceph-docker)
 RUN apt-get update && apt-get -y install runit && \
     apt-get install patch && \

--- a/daemon/Dockerfile
+++ b/daemon/Dockerfile
@@ -8,7 +8,8 @@ FROM ceph/base
 MAINTAINER Sébastien Han "seb@redhat.com"
 
 RUN apt-get update && apt-get -y install runit && \
-apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    apt-get install patch && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Add bootstrap script
 ADD entrypoint.sh /entrypoint.sh
@@ -27,6 +28,10 @@ ADD ceph.defaults /
 # Add templates for confd
 ADD ./confd/templates/* /etc/confd/templates/
 ADD ./confd/conf.d/* /etc/confd/conf.d/
+
+# Patch out ceph-disk, to allow overrides to user and group names
+ADD ./ceph-disk.patch /ceph-disk.patch
+RUN cd /usr/sbin && patch -p1 -n -u < /ceph-disk.patch
 
 # Add volumes for Ceph config and data
 VOLUME ["/etc/ceph","/var/lib/ceph"]

--- a/daemon/Dockerfile
+++ b/daemon/Dockerfile
@@ -10,7 +10,7 @@ MAINTAINER Sébastien Han "seb@redhat.com"
 # patch is only needed until PR #7351 is merged in ceph/ceph (and backported
 # to the version used in ceph/ceph-docker)
 RUN apt-get update && apt-get -y install runit && \
-    apt-get install patch && \
+    apt-get -y install patch && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Add bootstrap script

--- a/daemon/Dockerfile
+++ b/daemon/Dockerfile
@@ -7,6 +7,8 @@
 FROM ceph/base
 MAINTAINER Sébastien Han "seb@redhat.com"
 
+# patch is only needed until PR #7531 is merged in ceph/ceph (and backported
+# to the version used in ceph/ceph-docker)
 RUN apt-get update && apt-get -y install runit && \
     apt-get install patch && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
@@ -30,6 +32,8 @@ ADD ./confd/templates/* /etc/confd/templates/
 ADD ./confd/conf.d/* /etc/confd/conf.d/
 
 # Patch out ceph-disk, to allow overrides to user and group names
+# This can be removed once PR #7351 is merged in ceph/ceph (and backported to
+# the version used by ceph/ceph-docker)
 ADD ./ceph-disk.patch /ceph-disk.patch
 RUN cd /usr/sbin && patch -p1 -n -u < /ceph-disk.patch
 

--- a/daemon/ceph-disk.patch
+++ b/daemon/ceph-disk.patch
@@ -1,5 +1,5 @@
---- old/ceph-disk	2015-11-10 12:12:02.000000000 +0000
-+++ new/ceph-disk	2016-01-25 14:58:55.700330570 +0000
+--- old/ceph-disk	2016-01-25 19:30:35.767030687 +0000
++++ new/ceph-disk	2016-01-25 19:38:43.060430771 +0000
 @@ -147,6 +147,10 @@
      LOG_NAME = os.path.basename(sys.argv[0])
  LOG = logging.getLogger(LOG_NAME)
@@ -11,7 +11,7 @@
  
  ###### lock ########
  
-@@ -841,12 +845,34 @@
+@@ -841,12 +845,38 @@
      return osd_id
  
  def get_ceph_user():
@@ -21,6 +21,8 @@
 -        return 'ceph'
 -    except KeyError:
 -        return 'root'
++    global CEPH_PREF_USER
++
 +    if CEPH_PREF_USER != None:
 +        try:
 +            pwd.getpwnam(CEPH_PREF_USER)
@@ -36,6 +38,8 @@
 +            return 'root'
 +
 +def get_ceph_group():
++    global CEPH_PREF_GROUP
++
 +    if CEPH_PREF_GROUP != None:
 +        try:
 +            grp.getgrnam(CEPH_PREF_GROUP)
@@ -52,7 +56,7 @@
  
  def path_set_context(path):
      # restore selinux context to default policy values
-@@ -1947,7 +1973,7 @@
+@@ -1947,7 +1977,7 @@
              '--osd-uuid', fsid,
              '--keyring', os.path.join(path, 'keyring'),
              '--setuser', get_ceph_user(),
@@ -61,31 +65,34 @@
              ],
          )
      # TODO ceph-osd --mkfs removes the monmap file?
-@@ -3233,6 +3259,18 @@
+@@ -3233,6 +3263,18 @@
          default='/etc/ceph',
          help='directory in which ceph configuration files are found (default /etc/ceph)',
          )
 +    parser.add_argument(
-+	'--setuser',
++        '--setuser',
 +        metavar='USER',
-+	default=None,
-+	help='use the given user for subprocesses, rather than ceph or root'
-+	)
++        default=None,
++        help='use the given user for subprocesses, rather than ceph or root'
++        )
 +    parser.add_argument(
-+	'--setgroup',
++        '--setgroup',
 +        metavar='GROUP',
-+	default=None,
-+	help='use the given group for subprocesses, rather than ceph or root'
-+	)
++        default=None,
++        help='use the given group for subprocesses, rather than ceph or root'
++    )
      parser.set_defaults(
          # we want to hold on to this, for later
          prog=parser.prog,
-@@ -3525,6 +3563,8 @@
- 
+@@ -3526,6 +3568,11 @@
      setup_statedir(args.statedir)
      setup_sysconfdir(args.sysconfdir)
-+    CEPH_PREF_USER=args.setuser
-+    CEPH_PREF_GROUP=args.setgroup
  
++    global CEPH_PREF_USER
++    CEPH_PREF_USER = args.setuser
++    global CEPH_PREF_GROUP
++    CEPH_PREF_GROUP = args.setgroup
++
      if args.verbose:
          args.func(args)
+     else:

--- a/daemon/ceph-disk.patch
+++ b/daemon/ceph-disk.patch
@@ -1,0 +1,91 @@
+--- old/ceph-disk	2015-11-10 12:12:02.000000000 +0000
++++ new/ceph-disk	2016-01-25 14:58:55.700330570 +0000
+@@ -147,6 +147,10 @@
+     LOG_NAME = os.path.basename(sys.argv[0])
+ LOG = logging.getLogger(LOG_NAME)
+ 
++# Allow user-preferred values for subprocess user and group
++CEPH_PREF_USER = None
++CEPH_PREF_GROUP = None
++
+ 
+ ###### lock ########
+ 
+@@ -841,12 +845,34 @@
+     return osd_id
+ 
+ def get_ceph_user():
+-    try:
+-        pwd.getpwnam('ceph')
+-        grp.getgrnam('ceph')
+-        return 'ceph'
+-    except KeyError:
+-        return 'root'
++    if CEPH_PREF_USER != None:
++        try:
++            pwd.getpwnam(CEPH_PREF_USER)
++            return CEPH_PREF_USER
++        except KeyError:
++            print "No such user: " + CEPH_PREF_USER
++            sys.exit(2)
++    else:
++        try:
++            pwd.getpwnam('ceph')
++            return 'ceph'
++        except KeyError:
++            return 'root'
++
++def get_ceph_group():
++    if CEPH_PREF_GROUP != None:
++        try:
++            grp.getgrnam(CEPH_PREF_GROUP)
++            return CEPH_PREF_GROUP
++        except KeyError:
++            print "No such group: " + CEPH_PREF_GROUP
++            sys.exit(2)
++    else:
++        try:
++            grp.getgrnam('ceph')
++            return 'ceph'
++        except KeyError:
++            return 'root'
+ 
+ def path_set_context(path):
+     # restore selinux context to default policy values
+@@ -1947,7 +1973,7 @@
+             '--osd-uuid', fsid,
+             '--keyring', os.path.join(path, 'keyring'),
+             '--setuser', get_ceph_user(),
+-            '--setgroup', get_ceph_user(),
++            '--setgroup', get_ceph_group(),
+             ],
+         )
+     # TODO ceph-osd --mkfs removes the monmap file?
+@@ -3233,6 +3259,18 @@
+         default='/etc/ceph',
+         help='directory in which ceph configuration files are found (default /etc/ceph)',
+         )
++    parser.add_argument(
++	'--setuser',
++        metavar='USER',
++	default=None,
++	help='use the given user for subprocesses, rather than ceph or root'
++	)
++    parser.add_argument(
++	'--setgroup',
++        metavar='GROUP',
++	default=None,
++	help='use the given group for subprocesses, rather than ceph or root'
++	)
+     parser.set_defaults(
+         # we want to hold on to this, for later
+         prog=parser.prog,
+@@ -3525,6 +3563,8 @@
+ 
+     setup_statedir(args.statedir)
+     setup_sysconfdir(args.sysconfdir)
++    CEPH_PREF_USER=args.setuser
++    CEPH_PREF_GROUP=args.setgroup
+ 
+     if args.verbose:
+         args.func(args)

--- a/daemon/entrypoint.sh
+++ b/daemon/entrypoint.sh
@@ -354,7 +354,7 @@ function osd_disk {
     chown ceph. ${OSD_DEVICE}2
   fi
 
-  ceph-disk -v activate ${OSD_DEVICE}1
+  ceph-disk -v --setuser ceph --setgroup disk activate ${OSD_DEVICE}1
   OSD_ID=$(cat /var/lib/ceph/osd/$(ls -ltr /var/lib/ceph/osd/ | tail -n1 | awk -v pattern="$CLUSTER" '$0 ~ pattern {print $9}')/whoami)
   OSD_WEIGHT=$(df -P -k /var/lib/ceph/osd/${CLUSTER}-$OSD_ID/ | tail -1 | awk '{ d= $2/1073741824 ; r = sprintf("%.2f", d); print r }')
   ceph ${CEPH_OPTS} --name=osd.${OSD_ID} --keyring=/var/lib/ceph/osd/${CLUSTER}-${OSD_ID}/keyring osd crush create-or-move -- ${OSD_ID} ${OSD_WEIGHT} ${CRUSH_LOCATION}

--- a/daemon/entrypoint.sh
+++ b/daemon/entrypoint.sh
@@ -384,7 +384,7 @@ function osd_activate {
   mkdir -p /var/lib/ceph/osd
   chown ceph. /var/lib/ceph/osd
   chown ceph. ${OSD_DEVICE}2
-  ceph-disk -v activate ${OSD_DEVICE}1
+  ceph-disk -v --setuser ceph --setgroup disk activate ${OSD_DEVICE}1
   OSD_ID=$(cat /var/lib/ceph/osd/$(ls -ltr /var/lib/ceph/osd/ | tail -n1 | awk -v pattern="$CLUSTER" '$0 ~ pattern {print $9}')/whoami)
   OSD_WEIGHT=$(df -P -k /var/lib/ceph/osd/${CLUSTER}-$OSD_ID/ | tail -1 | awk '{ d= $2/1073741824 ; r = sprintf("%.2f", d); print r }')
   ceph ${CEPH_OPTS} --name=osd.${OSD_ID} --keyring=/var/lib/ceph/osd/${CLUSTER}-${OSD_ID}/keyring osd crush create-or-move -- ${OSD_ID} ${OSD_WEIGHT} ${CRUSH_LOCATION}
@@ -396,7 +396,7 @@ function osd_activate {
       echo "OSD (PID ${OSD_PID}) is running, waiting till it exits"
       while [ -e /proc/${OSD_PID} ]; do sleep 1;done
   else
-      exec /usr/bin/ceph-osd ${CEPH_OPTS} -f -d -i ${OSD_ID} --setuser ceph --setgroup ceph
+      exec /usr/bin/ceph-osd ${CEPH_OPTS} -f -d -i ${OSD_ID} --setuser ceph --setgroup disk
   fi
 }
 

--- a/daemon/entrypoint.sh
+++ b/daemon/entrypoint.sh
@@ -366,7 +366,7 @@ function osd_disk {
       echo "OSD (PID ${OSD_PID}) is running, waiting till it exits"
       while [ -e /proc/${OSD_PID} ]; do sleep 1;done
   else
-      exec /usr/bin/ceph-osd ${CEPH_OPTS} -f -d -i ${OSD_ID} --setuser ceph --setgroup ceph
+      exec /usr/bin/ceph-osd ${CEPH_OPTS} -f -d -i ${OSD_ID} --setuser ceph --setgroup disk
   fi
 }
 


### PR DESCRIPTION
This pull provides a patch to ceph-disk, allowing the permissions to be overridden.  A disk-type OSD will then run with perms ceph:disk, so it can get raw block dev access for the journal file.