### PR TITLE
Fix READMEs for 'centos' branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Ceph-related dockerfiles
 
 ## Core Components:
 
-* [`ceph/base`](base/):  Ceph base container image.  This is nothing but a fresh install of the latest Ceph on Ubuntu LTS (14.04)
+* [`ceph/base`](base/):  Ceph base container image.  This is nothing but a fresh install of the latest Ceph on CentOS (latest)
 * [`ceph/mds`](mds/): Ceph MDS (Metadata server)
 * [`ceph/mon`](mon/): Ceph Mon(itor)
 * [`ceph/osd`](osd/): Ceph OSD (object storage daemon)

--- a/base/README.md
+++ b/base/README.md
@@ -1,6 +1,6 @@
 # ceph-base
 
-Ceph base image (ubuntu 14.04 with the latest Ceph release installed).
+Ceph base image (CentOS (latest) with the latest Ceph release installed).
 
 ## Docker Hub/Registry location
 


### PR DESCRIPTION
'centos' branch READMEs still carry Ubuntu as the OS name
causing confusing for readers visiting github, thus fixing
it here

Signed-off-by: Deepak C Shetty <deepakcs@redhat.com>