### PR TITLE
ceph/daemon centos: Backport change ip and network detecting logic

### DIFF
--- a/daemon/README.md
+++ b/daemon/README.md
@@ -72,7 +72,7 @@ List of available options:
 * `CEPH_PUBLIC_NETWORK`: CIDR of the host running Docker, it should be in the same network as the `MON_IP`
 * `CEPH_CLUSTER_NETWORK`: CIDR of a secondary interface of the host running Docker. Used for the OSD replication traffic
 * `MON_IP`: IP address of the host running Docker
-* `MON_IP_AUTO_DETECT`: Whether and how to attempt IP autodetection.
+* `NETWORK_AUTO_DETECT`: Whether and how to attempt IP autodetection. Meant to use without '--net=host'.
     *  0 = Do not detect (default)
     *  1 = Detect IPv6, fallback to IPv4 (if no globally-routable IPv6 address detected)
     *  4 = Detect IPv4 only

--- a/daemon/entrypoint.sh
+++ b/daemon/entrypoint.sh
@@ -7,7 +7,7 @@ set -e
 : ${CEPH_GET_ADMIN_KEY:=0}
 : ${HOSTNAME:=$(hostname -s)}
 : ${MON_NAME:=${HOSTNAME}}
-: ${MON_IP_AUTO_DETECT:=0}
+: ${NETWORK_AUTO_DETECT:=0}
 : ${MDS_NAME:=mds-${HOSTNAME}}
 : ${OSD_FORCE_ZAP:=0}
 : ${OSD_JOURNAL_SIZE:=100}
@@ -71,24 +71,40 @@ esac
 #######
 
 function start_mon {
-  if [ ! -n "$CEPH_PUBLIC_NETWORK" ]; then
+  if [[ ! -n "$CEPH_PUBLIC_NETWORK" && ${NETWORK_AUTO_DETECT} -eq 0 ]]; then
     echo "ERROR- CEPH_PUBLIC_NETWORK must be defined as the name of the network for the OSDs"
     exit 1
   fi
 
-  if [ ${MON_IP_AUTO_DETECT} -eq 1 ]; then
-    MON_IP=$(ip -6 -o a | grep scope.global | awk '/eth/ { sub ("/..", "", $4); print $4 }' | head -n1)
-    if [ -z "$MON_IP" ]; then
-      MON_IP=$(ip -4 -o a | awk '/eth/ { sub ("/..", "", $4); print $4 }')
-    fi
-  elif [ ${MON_IP_AUTO_DETECT} -eq 4 ]; then
-    MON_IP=$(ip -4 -o a | awk '/eth/ { sub ("/..", "", $4); print $4 }')
-  elif [ ${MON_IP_AUTO_DETECT} -eq 6 ]; then
-    MON_IP=$(ip -6 -o a | grep scope.global | awk '/eth/ { sub ("/..", "", $4); print $4 }' | head -n1)
+  if [[ ! -n "$MON_IP" && ${NETWORK_AUTO_DETECT} -eq 0 ]]; then
+    echo "ERROR- MON_IP must be defined as the IP address of the monitor"
+    exit 1
   fi
 
-  if [ ! -n "$MON_IP" ]; then
-    echo "ERROR- MON_IP must be defined as the IP address of the monitor"
+  if [ ${NETWORK_AUTO_DETECT} -ne 0 ]; then
+    if [ command -v ip ]; then
+      if [ ${NETWORK_AUTO_DETECT} -eq 1 ]; then
+        MON_IP=$(ip -6 -o a | grep scope.global | awk '/eth/ { sub ("/..", "", $4); print $4 }' | head -n1)
+        if [ -z "$MON_IP" ]; then
+          MON_IP=$(ip -4 -o a | awk '/eth/ { sub ("/..", "", $4); print $4 }')
+          CEPH_PUBLIC_NETWORK=$(ip r | grep -o '[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}/[0-9]\{1,2\}' | head -1)
+        fi
+      elif [ ${NETWORK_AUTO_DETECT} -eq 4 ]; then
+        MON_IP=$(ip -4 -o a | awk '/eth/ { sub ("/..", "", $4); print $4 }')
+        CEPH_PUBLIC_NETWORK=$(ip r | grep -o '[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}/[0-9]\{1,2\}' | head -1)
+      elif [ ${NETWORK_AUTO_DETECT} -eq 6 ]; then
+        MON_IP=$(ip -6 -o a | grep scope.global | awk '/eth/ { sub ("/..", "", $4); print $4 }' | head -n1)
+        CEPH_PUBLIC_NETWORK=$(ip r | grep -o '[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}/[0-9]\{1,2\}' | head -1)
+      fi
+    # best effort, only works with ipv4
+    else
+      MON_IP=$(grep -o '[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}' /proc/net/fib_trie | grep -vE "^127|255$|0$")
+      CEPH_PUBLIC_NETWORK=$(grep -o '[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}/[0-9]\{1,2\}' /proc/net/fib_trie | grep -vE "^127|0$" | head -1)
+    fi
+  fi
+
+  if [[ -z "$MON_IP" || -z "$CEPH_PUBLIC_NETWORK" ]]; then
+    echo "ERROR- it looks like we have not been able to discover the network settings"
     exit 1
   fi
 


### PR DESCRIPTION
Backporting this patch to suit centos Ceph-hammer version.

Implementing the network detection for k8s scenarios. Now we do not use
the MON_IP_AUTODETECT anymore but use a more general variable called
NETWORK_AUTO_DETECT. Updating the doc.

Signed-off-by: Sébastien Han <seb@redhat.com>
Signed-off-by: Deepthi Dharwar <ddharwar@redhat.com>