### PR TITLE
Add an appropriate default option for BTRFS

### DIFF
--- a/daemon/ceph.defaults
+++ b/daemon/ceph.defaults
@@ -33,6 +33,7 @@
 #/osd/public_network 198.100.128.0/19
 /osd/osd_mkfs_type xfs
 /osd/osd_mkfs_options_xfs "-f -i size=2048"
+/osd/osd_mkfs_options_btrfs "-f"
 /osd/osd_mon_heartbeat_interval 30
 
 #crush


### PR DESCRIPTION
As-is, BTRFS filesystems can't always be created for OSDs - pre-existing data won't be appropriately wiped.  Turns out -f was specified for XFS filesystems, so do the same thing for BTRFS ones.