### PR TITLE
properly store binaries with kviator

### DIFF
--- a/daemon/Dockerfile
+++ b/daemon/Dockerfile
@@ -9,8 +9,7 @@ MAINTAINER Sébastien Han "seb@redhat.com"
 
 # patch is only needed until PR #7351 is merged in ceph/ceph (and backported
 # to the version used in ceph/ceph-docker)
-RUN apt-get update && apt-get -y install runit && \
-    apt-get -y install patch sharutils && \
+RUN apt-get update && apt-get -y install runit patch sharutils && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Add bootstrap script

--- a/daemon/Dockerfile
+++ b/daemon/Dockerfile
@@ -10,7 +10,7 @@ MAINTAINER Sébastien Han "seb@redhat.com"
 # patch is only needed until PR #7351 is merged in ceph/ceph (and backported
 # to the version used in ceph/ceph-docker)
 RUN apt-get update && apt-get -y install runit && \
-    apt-get -y install patch && \
+    apt-get -y install patch sharutils && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Add bootstrap script

--- a/daemon/config.kv.sh
+++ b/daemon/config.kv.sh
@@ -51,7 +51,7 @@ function get_mon_config {
 
     if [ ! -f /etc/ceph/monmap ]; then
       echo "Monmap is missing. Adding initial monmap..."
-      kviator --kvstore=${KV_TYPE} --client=${KV_IP}:${KV_PORT} get ${CLUSTER_PATH}/monmap > /etc/ceph/monmap
+      kviator --kvstore=${KV_TYPE} --client=${KV_IP}:${KV_PORT} get ${CLUSTER_PATH}/monmap | uudecode -o /etc/ceph/monmap
     fi
 
     echo "Trying to get the most recent monmap..."
@@ -100,7 +100,7 @@ function get_mon_config {
     kviator --kvstore=${KV_TYPE} --client=${KV_IP}:${KV_PORT} put ${CLUSTER_PATH}/bootstrapMdsKeyring - < /var/lib/ceph/bootstrap-mds/${CLUSTER}.keyring
     kviator --kvstore=${KV_TYPE} --client=${KV_IP}:${KV_PORT} put ${CLUSTER_PATH}/bootstrapRgwKeyring - < /var/lib/ceph/bootstrap-rgw/${CLUSTER}.keyring
 
-    kviator --kvstore=${KV_TYPE} --client=${KV_IP}:${KV_PORT} put ${CLUSTER_PATH}/monmap - < /etc/ceph/monmap
+    uuencode /etc/ceph/monmap - | kviator --kvstore=${KV_TYPE} --client=${KV_IP}:${KV_PORT} put ${CLUSTER_PATH}/monmap -
 
     echo "Completed initialization for ${MON_NAME}"
     kviator --kvstore=${KV_TYPE} --client=${KV_IP}:${KV_PORT} put ${CLUSTER_PATH}/monSetupComplete true > /dev/null 2>&1


### PR DESCRIPTION
kviator can't store binary data (see ceph/ceph-docker #220 ).  This works around that limit via sharutils and uuencoding/decoding the monmap.