### PR TITLE
Compute names for partition block devices correctly

### DIFF
--- a/daemon/entrypoint.sh
+++ b/daemon/entrypoint.sh
@@ -56,6 +56,15 @@ mkdir -p /var/run/ceph
 chown ceph. /var/run/ceph
 }
 
+# Calculate proper device names, given a device and partition number
+function dev_part {
+  if [[ "${1:0-1:1}" == [0-9] ]]; then
+    echo "${1}p${2}"
+  else
+    echo "${1}${2}"
+  fi
+}
+
 
 ###########################
 # Configuration generator #
@@ -354,10 +363,10 @@ function osd_disk_prepare {
     chown ceph. ${OSD_JOURNAL}
   else
     ceph-disk -v prepare ${OSD_DEVICE}
-    chown ceph. ${OSD_DEVICE}2
+    chown ceph. $(dev_part ${OSD_DEVICE} 2)
   fi
 
-  ceph-disk -v --setuser ceph --setgroup disk activate ${OSD_DEVICE}1
+  ceph-disk -v --setuser ceph --setgroup disk activate $(dev_part ${OSD_DEVICE} 1)
   OSD_ID=$(cat /var/lib/ceph/osd/$(ls -ltr /var/lib/ceph/osd/ | tail -n1 | awk -v pattern="$CLUSTER" '$0 ~ pattern {print $9}')/whoami)
   OSD_WEIGHT=$(df -P -k /var/lib/ceph/osd/${CLUSTER}-$OSD_ID/ | tail -1 | awk '{ d= $2/1073741824 ; r = sprintf("%.2f", d); print r }')
   ceph ${CEPH_OPTS} --name=osd.${OSD_ID} --keyring=/var/lib/ceph/osd/${CLUSTER}-${OSD_ID}/keyring osd crush create-or-move -- ${OSD_ID} ${OSD_WEIGHT} ${CRUSH_LOCATION}
@@ -383,11 +392,11 @@ function osd_activate {
   fi
 
   # wait till partition exists
-  timeout 10  bash -c "while [ ! -e ${OSD_DEVICE}1 ]; do sleep 1; done"
+  timeout 10  bash -c "while [ ! -e $(dev_part ${OSD_DEVICE} 1) ]; do sleep 1; done"
   mkdir -p /var/lib/ceph/osd
   chown ceph. /var/lib/ceph/osd
-  chown ceph. ${OSD_DEVICE}2
-  ceph-disk -v --setuser ceph --setgroup disk activate ${OSD_DEVICE}1
+  chown ceph. $(dev_part ${OSD_DEVICE} 2)
+  ceph-disk -v --setuser ceph --setgroup disk activate $(dev_part ${OSD_DEVICE} 1)
   OSD_ID=$(cat /var/lib/ceph/osd/$(ls -ltr /var/lib/ceph/osd/ | tail -n1 | awk -v pattern="$CLUSTER" '$0 ~ pattern {print $9}')/whoami)
   OSD_WEIGHT=$(df -P -k /var/lib/ceph/osd/${CLUSTER}-$OSD_ID/ | tail -1 | awk '{ d= $2/1073741824 ; r = sprintf("%.2f", d); print r }')
   ceph ${CEPH_OPTS} --name=osd.${OSD_ID} --keyring=/var/lib/ceph/osd/${CLUSTER}-${OSD_ID}/keyring osd crush create-or-move -- ${OSD_ID} ${OSD_WEIGHT} ${CRUSH_LOCATION}


### PR DESCRIPTION
Add a dev_part function to properly compute the numbered partition on the named block device, and use it throughout.  This seems to fix issue #226 .