### PR TITLE
daemon: multiple osd in one container

### DIFF
--- a/daemon/entrypoint.sh
+++ b/daemon/entrypoint.sh
@@ -33,6 +33,7 @@ set -e
 : ${KV_PORT:=4001} # PORT 8500 for Consul
 
 CEPH_OPTS="--cluster ${CLUSTER}"
+MOUNT_OPTS="-t xfs -o noatime,inode64"
 
 # ceph config file exists or die
 function check_config {
@@ -226,6 +227,9 @@ function start_osd {
       activate)
          osd_activate
          ;;
+      devices)
+         osd_disks
+         ;;
       *)
          if [[ ! -d /var/lib/ceph/osd || -n "$(find /var/lib/ceph/osd -prune -empty)" ]]; then
             echo "No bootstrapped OSDs found; trying ceph-disk"
@@ -400,7 +404,7 @@ function osd_activate {
   chown ceph. /var/lib/ceph/osd
   if [[ ! -z "${OSD_JOURNAL}" ]]; then
     chown ceph. ${OSD_JOURNAL}
-    ceph-disk -v --setuser ceph --setgroup disk activate ${OSD_DEVICE}
+    ceph-disk -v --setuser ceph --setgroup disk activate $(dev_part ${OSD_DEVICE} 1)
   else
     chown ceph. $(dev_part ${OSD_DEVICE} 2)
     ceph-disk -v --setuser ceph --setgroup disk activate $(dev_part ${OSD_DEVICE} 1)
@@ -417,6 +421,102 @@ function osd_activate {
       while [ -e /proc/${OSD_PID} ]; do sleep 1;done
   else
       exec /usr/bin/ceph-osd ${CEPH_OPTS} -f -d -i ${OSD_ID} --setuser ceph --setgroup disk
+  fi
+}
+
+#############
+# OSD_DISKS #
+#############
+function get_osd_dev {
+  for i in ${OSD_DISKS}
+   do
+    osd_id=$(echo ${i}|sed 's/\(.*\):\(.*\)/\1/')
+    osd_dev="/dev/$(echo ${i}|sed 's/\(.*\):\(.*\)/\2/')"
+    if [ ${osd_id} = ${1} ]; then
+      echo -n "${osd_dev}"
+    fi
+  done
+}
+
+function set_osd_run {
+  mkdir -p /etc/service/${1}-${2}
+  cat >/etc/service/${1}-${2}/run <<EOF
+#!/bin/bash
+echo "store-daemon: starting daemon on ${HOSTNAME}..."
+exec /usr/bin/ceph-osd ${CEPH_OPTS} -f -d -i ${2} --setuser ceph --setgroup disk
+EOF
+  chmod +x /etc/service/${1}-${2}/run
+}
+
+function osd_disks {
+  if [[ ! -d /var/lib/ceph/osd ]]; then
+    echo "ERROR- could not find the osd directory, did you bind mount the OSD data directory?"
+    echo "ERROR- use -v <host_osd_data_dir>:/var/lib/ceph/osd"
+    exit 1
+  fi
+
+  if [[  -z ${OSD_DISKS} ]]; then
+    echo "ERROR- could not find the osd devices, did you configure OSD disks?"
+    echo "ERROR- use -e OSD_DISKS=\"0:sdd 1:sde 2:sdf\""
+    exit 1
+  fi
+
+  # make sure ceph owns the directory
+  chown ceph. /var/lib/ceph/osd
+
+  # check if anything is there, if not create an osd with directory
+  if [[ -z "$(find /var/lib/ceph/osd -prune -empty)" ]]; then
+    echo "Mount existing and prepared OSD disks for ceph-cluster ${CLUSTER}"
+    for OSD_ID in $(ls /var/lib/ceph/osd |  awk 'BEGIN { FS = "-" } ; { print $2 }'); do
+      OSD_DEV=$(get_osd_dev ${OSD_ID})
+      if [[ -z ${OSD_DEV} ]]; then
+        echo "No device mapping for ${CLUSTER}-${OSD_ID} for ceph-cluster ${CLUSTER}"
+        exit 1
+      fi
+      mount ${MOUNT_OPTS} $(dev_part ${OSD_DEV} 1) /var/lib/ceph/osd/${CLUSTER}-${OSD_ID}/
+      xOSD_ID=$(cat /var/lib/ceph/osd/${CLUSTER}-${OSD_ID}/whoami)
+      if [[ "${OSD_ID}" != "${xOSD_ID}" ]]; then
+        echo "Device ${OSD_DEV} is corrupt for /var/lib/ceph/osd/${CLUSTER}-${OSD_ID}"
+        exit 1
+      fi
+      set_osd_run ${CLUSTER} ${OSD_ID}
+    done
+    exec /sbin/my_init
+  else
+    for i in ${OSD_DISKS}; do
+      OSD_ID=$(echo ${i}|sed 's/\(.*\):\(.*\)/\1/')
+      OSD_DEV="/dev/$(echo ${i}|sed 's/\(.*\):\(.*\)/\2/')"
+      if [[ "$(parted --script ${OSD_DEV} print | egrep '^ 1.*ceph data')" && ${OSD_FORCE_ZAP} -ne "1" ]]; then
+        echo "ERROR- It looks like this device is an OSD, set OSD_FORCE_ZAP=1 to use this device anyway and zap its content"
+        exit 1
+      elif [[ "$(parted --script ${OSD_DEV} print | egrep '^ 1.*ceph data')" && ${OSD_FORCE_ZAP} -eq "1" ]]; then
+        ceph-disk -v zap ${OSD_DEV}
+      fi
+
+      if [[ ! -z "${OSD_JOURNAL}" ]]; then
+        ceph-disk -v prepare ${OSD_DEV} ${OSD_JOURNAL}
+#        chown ceph. ${OSD_JOURNAL}
+        ceph-disk -v --setuser ceph --setgroup disk activate $(dev_part ${OSD_DEV} 1)
+      else
+        ceph-disk -v prepare ${OSD_DEV}
+#        chown ceph. $(dev_part ${OSD_DEV} 2)
+        ceph-disk -v --setuser ceph --setgroup disk activate $(dev_part ${OSD_DEV} 1)
+      fi
+
+      OSD_ID=$(cat /var/lib/ceph/osd/$(ls -ltr /var/lib/ceph/osd/ | tail -n1 | awk -v pattern="$CLUSTER" '$0 ~ pattern {print $9}')/whoami)
+      OSD_WEIGHT=$(df -P -k /var/lib/ceph/osd/${CLUSTER}-$OSD_ID/ | tail -1 | awk '{ d= $2/1073741824 ; r = sprintf("%.2f", d); print r }')
+      ceph ${CEPH_OPTS} --name=osd.${OSD_ID} --keyring=/var/lib/ceph/osd/${CLUSTER}-${OSD_ID}/keyring osd crush create-or-move -- ${OSD_ID} ${OSD_WEIGHT} ${CRUSH_LOCATION}
+
+      # ceph-disk activiate has exec'ed /usr/bin/ceph-osd ${CEPH_OPTS} -f -d -i ${OSD_ID}
+      # wait till docker stop or ceph-osd is killed
+      OSD_PID=$(ps -ef |grep ceph-osd |grep osd.${OSD_ID} |awk '{print $2}')
+      if [ -n "${OSD_PID}" ]; then
+          echo "OSD (PID ${OSD_PID}) is running, waiting till it exits"
+          while [ -e /proc/${OSD_PID} ]; do sleep 1;done
+      fi
+      set_osd_run ${CLUSTER} ${OSD_ID}
+    done
+    exec /sbin/my_init
   fi
 }
 


### PR DESCRIPTION
Feature proposed by @oll-78.
It brings the ability to run multiple OSDs within a single container.
I thought we were already able to do so but didn't find any mention in
the code. The only thing I recall is a patch from @dmitryint in #24 but
since I never used it I'll let either @dmitryint or @Ulexus comment on
this. It seems that this patch uses ceph-disk instead.

Signed-off-by: Oleg Lazo <oll@niif.spb.su>
Signed-off-by: Sébastien Han <seb@redhat.com>