### PR TITLE
Update KV store when monmap is successfully pulled

### DIFF
--- a/daemon/config.kv.sh
+++ b/daemon/config.kv.sh
@@ -56,7 +56,8 @@ function get_mon_config {
 
     echo "Trying to get the most recent monmap..."
     if timeout 5 ceph ${CEPH_OPTS} mon getmap -o /etc/ceph/monmap; then
-      echo "Monmap successfully retrieved."
+      echo "Monmap successfully retrieved.  Updating KV store."
+      uuencode /etc/ceph/monmap - | kviator --kvstore=${KV_TYPE} --client=${KV_IP}:${KV_PORT} put ${CLUSTER_PATH}/monmap -
     else
       echo "Peers not found, using initial monmap."
     fi


### PR DESCRIPTION
The monmap is stored in the KV store, but there's no obvious means to update it when it changes.  This patch updates the monmap whenever it's successfully pulled from peers, meaning the KV store's version will update when a mon restarts.  A bit awkward, but it ensures that if several new mons are added the KV store's monmap isn't too old.