### PR TITLE
Fix reversion that breaks multiple OSDs on a device

### DIFF
--- a/daemon/entrypoint.sh
+++ b/daemon/entrypoint.sh
@@ -404,7 +404,7 @@ function osd_activate {
   chown ceph. /var/lib/ceph/osd
   if [[ ! -z "${OSD_JOURNAL}" ]]; then
     chown ceph. ${OSD_JOURNAL}
-    ceph-disk -v --setuser ceph --setgroup disk activate $(dev_part ${OSD_DEVICE} 1)
+    ceph-disk -v --setuser ceph --setgroup disk activate ${OSD_DEVICE}
   else
     chown ceph. $(dev_part ${OSD_DEVICE} 2)
     ceph-disk -v --setuser ceph --setgroup disk activate $(dev_part ${OSD_DEVICE} 1)


### PR DESCRIPTION
Fix a reversion in the code.  If OSD_JOURNAL is specified, we should use
the provided OSD_DEVICE with no modification.  If you've picked a journal,
we can assume you know what you're doing.

Without this, it's impossible to run multiple OSDs on a single disk (useful
for NVMe).

Signed-off-by: Mike Shuey <shuey@purdue.edu>