### PR TITLE
daemon: fix osd_journal variable

### DIFF
--- a/daemon/ceph.defaults
+++ b/daemon/ceph.defaults
@@ -26,7 +26,7 @@
 /mon/mon_osd_report_timeout 300
 
 #osd
-/osd/journal_size 100
+/osd/osd_journal_size 100
 
 # these 2 should be passed at runtime to the container.
 #/osd/cluster_network 198.100.128.0/19


### PR DESCRIPTION
use the proper name
fixes: #264

Signed-off-by: Sébastien Han <seb@redhat.com>