### PR TITLE
Use KV store with any cluster name

### DIFF
--- a/daemon/confd/src/ceph.conf.toml.in
+++ b/daemon/confd/src/ceph.conf.toml.in
@@ -1,6 +1,6 @@
 [template]
 src = "ceph.conf.tmpl"
-dest = "/etc/ceph/ceph.conf"
+dest = "/etc/ceph/@CLUSTER@.conf"
 keys = [
  "/auth/",
  "/global/",

--- a/daemon/config.kv.sh
+++ b/daemon/config.kv.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -e
 
+sed -r "s/@CLUSTER@/${CLUSTER:-ceph}/g" \
+  /etc/confd/src/ceph.conf.toml.in > /etc/confd/conf.d/ceph.conf.toml
+
 function get_admin_key {
    kviator --kvstore=${KV_TYPE} --client=${KV_IP}:${KV_PORT} get ${CLUSTER_PATH}/adminKeyring > /etc/ceph/${CLUSTER}.client.admin.keyring
 }


### PR DESCRIPTION
* confd create a /etc/ceph/ceph.conf file but for cluser name different
  of 'ceph' the configuration file must be /etc/ceph/$CLUSTER.conf