### PR TITLE
CI: build daemon image on travis and test it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+language: python
+python:
+  - 2.7
+
+branches:
+  only:
+    - master
+    - /^build-master-*/
+
+services:
+  - docker
+
+before_install:
+  - sudo ./travis-builds/build_imgs.sh
+
+# NOTE(leseb): somehow putting everything in a 'script' task does not work
+# so we have to split it up that way.
+# It seems that we have an issue when not running 'docker run' from an install step
+install:
+  - docker run -d --name ceph-mon --net=host -v /etc/ceph:/etc/ceph -v /var/lib/ceph:/var/lib/ceph -e MON_IP=127.0.0.1 -e CEPH_PUBLIC_NETWORK=127.0.0.0/8 daemon mon
+  - sudo ./travis-builds/bootstrap_osd.sh
+  - docker run -d --name ceph-osd -v /etc/ceph:/etc/ceph -v /var/lib/ceph:/var/lib/ceph daemon osd_directory
+  - docker run -d --name ceph-mds --net=host -v /etc/ceph:/etc/ceph -v /var/lib/ceph:/var/lib/ceph -e CEPHFS_CREATE=1 daemon mds
+  - docker run -d --name ceph-rgw --net=host -v /etc/ceph:/etc/ceph -v /var/lib/ceph:/var/lib/ceph daemon rgw
+
+script:
+  - sudo ./travis-builds/validate_cluster.sh

--- a/travis-builds/bootstrap_osd.sh
+++ b/travis-builds/bootstrap_osd.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -xe
+
+
+# FUNCTIONS
+function do_aio_conf {
+  # set pools replica size to 1 since we only have a single osd
+  # also use a really low pg count
+  echo "osd pool default size = 1" >> /etc/ceph/ceph.conf
+  echo "osd pool default pg num = 8" >> /etc/ceph/ceph.conf
+  echo "osd pool default pgp num = 8" >> /etc/ceph/ceph.conf
+}
+
+function bootstrap_osd {
+  mkdir -p /var/lib/ceph/osd/ceph-0
+  chown -R 64045:64045 /var/lib/ceph/osd/*
+  docker exec ceph-mon ceph osd create
+  docker exec ceph-mon ceph-osd -i 0 --mkfs
+  docker exec ceph-mon ceph auth get-or-create osd.0 osd 'allow *' mon 'allow profile osd' -o /var/lib/ceph/osd/ceph-0/keyring
+  docker exec ceph-mon ceph osd crush add 0 1 root=default host=$(hostname -s)
+  docker exec ceph-mon ceph-osd -i 0 -k /var/lib/ceph/osd/ceph-0/keyring
+}
+
+
+# MAIN
+do_aio_conf
+bootstrap_osd

--- a/travis-builds/build_imgs.sh
+++ b/travis-builds/build_imgs.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -xe
+
+
+# FUNCTIONS
+# NOTE (leseb): how to choose between directory for multiple change?
+# using "head" as a temporary solution
+function copy_dirs {
+  dir_to_test=$(git show --name-only | tr " " "\n" | awk -F '/' '/ceph-releases/ {print $1,"/",$2,"/",$3,"/",$4}' | tr -d " " | sort -u | uniq)
+  if [[ $(echo $dir_to_test | tr -d " " | wc -l) -ne 1 ]]; then
+    dir_to_test=$(git show --name-only | tr " " "\n" | awk -F '/' '/ceph-releases/ {print $1,"/",$2,"/",$3,"/",$4}' | tr -d " " | sort -u | uniq | head -1)
+  fi
+  if [[ ! -z $dir_to_test ]]; then
+    cp -Lrv $dir_to_test/base/* base
+    cp -Lrv $dir_to_test/daemon/* daemon
+  fi
+}
+
+function build_base_img {
+  pushd base
+  docker build -t base .
+  popd
+}
+
+function build_daemon_img {
+  pushd daemon
+  sed -i 's|FROM .*|FROM base|g' Dockerfile
+  docker build -t daemon .
+  popd
+}
+
+
+# MAIN
+copy_dirs
+build_base_img
+build_daemon_img

--- a/travis-builds/validate_cluster.sh
+++ b/travis-builds/validate_cluster.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -xe
+
+
+# FUNCTIONS
+function ceph_status {
+  echo "waiting for ceph to be ready"
+  until docker exec ceph-mon ceph health | grep HEALTH_OK; do
+    echo -n "."
+    sleep 1
+  done
+}
+
+function test_mon {
+  docker exec ceph-mon ceph -s | grep -q 'quorum'
+}
+
+function test_osd {
+  docker exec ceph-mon ceph -s | grep -q "1 osds: 1 up, 1 in"
+}
+
+function test_rgw {
+  docker exec ceph-mon ceph osd dump | grep -q "rgw"
+}
+
+function test_mds {
+  docker exec ceph-mon ceph osd dump | grep -q cephfs
+  docker exec ceph-mon ceph -s | grep -q 'up:active'
+}
+
+
+# MAIN
+ceph_status # wait for the cluster to stabilize
+
+test_mon
+test_osd
+test_rgw
+test_mds
+
+if [[ "$(docker ps | grep ceph- | wc -l)" -ne 4 ]]; then
+  docker ps | grep ceph-
+  echo "looks like one container died :("
+  echo "please see the previous output to figure out which one"
+  exit 1
+fi
+
+docker exec ceph-mon ceph -s


### PR DESCRIPTION
We rely on Travis's infrastructure to build the 'daemon' image and run
all the ceph daemons. So we run a monitor, an osd (with directory
scenario, a mds and one rgw).
We have a validation script to make they all started properly. During
the validation sequence, we wait for 20 seconds to let the cluster
stabilize and populate the pgs.

Signed-off-by: Sébastien Han <seb@redhat.com>