### PR TITLE
base: remove 'arg' so travis is happy

### DIFF
--- a/ceph-releases/jewel/ubuntu/14.04/base/Dockerfile
+++ b/ceph-releases/jewel/ubuntu/14.04/base/Dockerfile
@@ -5,7 +5,6 @@
 FROM ubuntu:trusty
 MAINTAINER Sébastien Han "seb@redhat.com"
 
-ARG DEBIAN_FRONTEND=noninteractive
 ENV ETCDCTL_VERSION v2.2.4
 ENV ETCDCTL_ARCH linux-amd64
 ENV CEPH_VERSION jewel
@@ -19,7 +18,7 @@ ADD https://github.com/AcalephStorage/kviator/releases/download/v${KVIATOR_VERSI
 ADD https://github.com/kelseyhightower/confd/releases/download/v${CONFD_VERSION}/confd-${CONFD_VERSION}-linux-amd64 /usr/local/bin/confd
 
 # install prerequisites
-RUN apt-get update &&  apt-get install -y wget unzip uuid-runtime python-setuptools udev && \
+RUN DEBIAN_FRONTEND=noninteractive apt-get update &&  apt-get install -y wget unzip uuid-runtime python-setuptools udev && \
 \
 # install ceph
     wget -q -O- 'https://download.ceph.com/keys/release.asc' | apt-key add - && \


### PR DESCRIPTION
Travis is using Docker 1.8.x and thus does not support 'ARG' in the
Dockerfile. So instead re-using the old fashion way.

[ci skip]

Signed-off-by: Sébastien Han <seb@redhat.com>