### PR TITLE
ci: execute local builds instead of figuring out what to build

### DIFF
--- a/travis-builds/build_imgs.sh
+++ b/travis-builds/build_imgs.sh
@@ -6,26 +6,29 @@ set -xe
 # NOTE (leseb): how to choose between directory for multiple change?
 # using "head" as a temporary solution
 function copy_dirs {
-  dir_to_test=$(git diff --name-only HEAD~1 | tr " " "\n" | awk -F '/' '/ceph-releases/ {print $1,"/",$2,"/",$3,"/",$4}' | tr -d " " | sort -u | uniq)
-  if [[ "$(echo $dir_to_test | tr " " "\n" | wc -l)" -ne 1 ]]; then
-    if [[ "$(echo $dir_to_test | tr " " "\n" | grep "jewel/ubuntu/14.04")" ]]; then
-      dir_to_test=$(git diff --name-only HEAD~1 | tr " " "\n" | awk -F '/' '/ceph-releases/ {print $1,"/",$2,"/",$3,"/",$4}' | tr -d " " | sort -u | uniq | grep "jewel/ubuntu/14.04")
-    else
-      dir_to_test=$(git diff --name-only HEAD~1 | tr " " "\n" | awk -F '/' '/ceph-releases/ {print $1,"/",$2,"/",$3,"/",$4}' | tr -d " " | sort -u | uniq | head -1)
+  # if base, daemon and demo exit we are testing a pushed branch and not a PR
+  if [[ ! -d daemon && ! -d base && ! -d demo ]]; then
+    dir_to_test=$(git diff --name-only HEAD~1 | tr " " "\n" | awk -F '/' '/ceph-releases/ {print $1,"/",$2,"/",$3,"/",$4}' | tr -d " " | sort -u | uniq)
+    if [[ "$(echo $dir_to_test | tr " " "\n" | wc -l)" -ne 1 ]]; then
+      if [[ "$(echo $dir_to_test | tr " " "\n" | grep "jewel/ubuntu/14.04")" ]]; then
+        dir_to_test=$(git diff --name-only HEAD~1 | tr " " "\n" | awk -F '/' '/ceph-releases/ {print $1,"/",$2,"/",$3,"/",$4}' | tr -d " " | sort -u | uniq | grep "jewel/ubuntu/14.04")
+      else
+        dir_to_test=$(git diff --name-only HEAD~1 | tr " " "\n" | awk -F '/' '/ceph-releases/ {print $1,"/",$2,"/",$3,"/",$4}' | tr -d " " | sort -u | uniq | head -1)
+      fi
     fi
-  fi
-  if [[ ! -z "$dir_to_test" ]]; then
-    mkdir -p {base,daemon,demo}
-    cp -Lrv $dir_to_test/base/* base
-    cp -Lrv $dir_to_test/daemon/* daemon
-    cp -Lrv $dir_to_test/demo/* demo
-  else
-    echo "looks like your commit did not bring any changes"
-    echo "building jewel ubuntu 14.04 anyway"
-    mkdir -p {base,daemon,demo}
-    cp -Lrv ceph-releases/jewel/ubuntu/14.04/base/* base
-    cp -Lrv ceph-releases/jewel/ubuntu/14.04/daemon/* daemon
-    cp -Lrv ceph-releases/jewel/ubuntu/14.04/demo/* demo
+    if [[ ! -z "$dir_to_test" ]]; then
+      mkdir -p {base,daemon,demo}
+      cp -Lrv $dir_to_test/base/* base
+      cp -Lrv $dir_to_test/daemon/* daemon
+      cp -Lrv $dir_to_test/demo/* demo
+    else
+      echo "looks like your commit did not bring any changes"
+      echo "building jewel ubuntu 14.04 anyway"
+      mkdir -p {base,daemon,demo}
+      cp -Lrv ceph-releases/jewel/ubuntu/14.04/base/* base
+      cp -Lrv ceph-releases/jewel/ubuntu/14.04/daemon/* daemon
+      cp -Lrv ceph-releases/jewel/ubuntu/14.04/demo/* demo
+    fi
   fi
 }
 


### PR DESCRIPTION
Travis is configured to build on master and all the branches. If Travis
is testing a branch like build-master-jewel-centos-7 we don't need to
figure out which image to build since root path of base, daemon and demo
exist. If we don't do this we will always build other images.

Signed-off-by: Sébastien Han <seb@redhat.com>