### PR TITLE
fix bug about OSD_ID

### DIFF
--- a/ceph-releases/jewel/ubuntu/14.04/daemon/entrypoint.sh
+++ b/ceph-releases/jewel/ubuntu/14.04/daemon/entrypoint.sh
@@ -408,7 +408,7 @@ function osd_activate {
     chown ceph. $(dev_part ${OSD_DEVICE} 2)
     ceph-disk -v --setuser ceph --setgroup disk activate $(dev_part ${OSD_DEVICE} 1)
   fi
-  OSD_ID=$(cat /var/lib/ceph/osd/$(ls -ltr /var/lib/ceph/osd/ | tail -n1 | awk -v pattern="$CLUSTER" '$0 ~ pattern {print $9}')/whoami)
+  OSD_ID=$(ceph-disk list |grep "$(dev_part ${OSD_DEVICE} 1) ceph data" | awk -F, '{print $4}'|awk -F. '{print $2}')
   OSD_WEIGHT=$(df -P -k /var/lib/ceph/osd/${CLUSTER}-$OSD_ID/ | tail -1 | awk '{ d= $2/1073741824 ; r = sprintf("%.2f", d); print r }')
   ceph ${CEPH_OPTS} --name=osd.${OSD_ID} --keyring=/var/lib/ceph/osd/${CLUSTER}-${OSD_ID}/keyring osd crush create-or-move -- ${OSD_ID} ${OSD_WEIGHT} ${CRUSH_LOCATION}
 


### PR DESCRIPTION
I set up a ceph-docker,when a osd container down,I plan restart it,so I change a environment of OSD_TYPE from disk to activate in docker-compose.yml,but it can't start success,because it can't get correct osd_id of itself.

when I create 3 osd,this folder will be created 
/var/ceph/lib/osd/ceph-0
/var/ceph/lib/osd/ceph-1
/var/ceph/lib/osd/ceph-2
the osd_activate function will only get the biggest osd_id from /var/ceph/lib/osd/ceph-2
the OSD_ID is 2
so,I change it get osd_id from ceph-disk
thanks