### PR TITLE
daemon: new directory mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install:
   - sudo ./travis-builds/prepare_osd_fs.sh
   - docker run -d --name ceph-mon --net=host -v /etc/ceph:/etc/ceph -v /var/lib/ceph:/var/lib/ceph -e MON_IP=$(ip -4 -o a | awk '/eth|ens|eno|enp/ { sub ("/..", "", $4); print $4 }') -e CEPH_PUBLIC_NETWORK=$(grep -o '[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}/[0-9]\{1,2\}' /proc/net/fib_trie | grep -vE "^127|0$" | head -1) daemon mon
   - sudo ./travis-builds/bootstrap_osd.sh
-  - docker run -d --name ceph-osd --net=host -v /etc/ceph:/etc/ceph -v /var/lib/ceph:/var/lib/ceph daemon osd_directory
+  - docker run -d --name ceph-osd --net=host -v /etc/ceph:/etc/ceph -v /var/lib/ceph:/var/lib/ceph daemon osd_directory_single
   - docker run -d --name ceph-mds --net=host -v /etc/ceph:/etc/ceph -v /var/lib/ceph:/var/lib/ceph -e CEPHFS_CREATE=1 daemon mds
   - docker run -d --name ceph-rgw --net=host -v /etc/ceph:/etc/ceph -v /var/lib/ceph:/var/lib/ceph daemon rgw
 

--- a/travis-builds/bootstrap_osd.sh
+++ b/travis-builds/bootstrap_osd.sh
@@ -18,6 +18,7 @@ function bootstrap_osd {
   docker exec ceph-mon ceph-osd -i 0 --mkfs
   docker exec ceph-mon ceph auth get-or-create osd.0 osd 'allow *' mon 'allow profile osd' -o /var/lib/ceph/osd/ceph-0/keyring
   docker exec ceph-mon ceph osd crush add 0 1 root=default host=$(hostname -s)
+  chown -R 64045:64045 /var/lib/ceph/osd/*
 }
 
 


### PR DESCRIPTION
the current directory mode aims to run multiple osd processes in a
single container. It uses runit, which is hard to find and not packaged
for some distros. This commit introduces a simple directory mode that
will only run one osd process per container. Prior to do that it will
check if a lock is already held by another osd process. If so it won't
start the osd and will just try to find another one to run. If nothing
is found or all the osds available are already running with exit the
container explaining that all the osds are already running.

Signed-off-by: Sébastien Han <seb@redhat.com>