### PR TITLE
daemon: move the entrypoints at the end of the Dockerfile

### DIFF
--- a/ceph-releases/jewel/ubuntu/14.04/daemon/Dockerfile
+++ b/ceph-releases/jewel/ubuntu/14.04/daemon/Dockerfile
@@ -7,9 +7,6 @@
 FROM ceph/base:tag-build-master-jewel-ubuntu-14.04
 MAINTAINER Sébastien Han "seb@redhat.com"
 
-# Add bootstrap script, ceph defaults key/values for KV store
-ADD entrypoint.sh config.*.sh ceph.defaults /
-
 ADD my_init/my_init /sbin/my_init
 ADD 2.sh /etc/runit/2
 
@@ -20,6 +17,9 @@ ADD ./confd/conf.d/* /etc/confd/conf.d/
 RUN chmod +x /sbin/my_init && \
     mkdir -p /etc/container_environment && \
     chmod +x /etc/runit/2
+
+# Add bootstrap script, ceph defaults key/values for KV store
+ADD entrypoint.sh config.*.sh ceph.defaults /
 
 # Add volumes for Ceph config and data
 VOLUME ["/etc/ceph","/var/lib/ceph"]


### PR DESCRIPTION
While running a dev env, we usually modify entrypoint files so we better
have the entrypoint being called at the end of the Dockerfile.
This speeds up the build process.

Signed-off-by: Sébastien Han <seb@redhat.com>