### PR TITLE
Disable osd check max obj name len in jewel:demo

### DIFF
--- a/ceph-releases/jewel/ubuntu/14.04/demo/entrypoint.sh
+++ b/ceph-releases/jewel/ubuntu/14.04/demo/entrypoint.sh
@@ -78,6 +78,14 @@ public network = ${CEPH_PUBLIC_NETWORK}
 cluster network = ${CEPH_PUBLIC_NETWORK}
 ENDHERE
 
+		# For ext4
+		if [ "$(findmnt -n -o FSTYPE -T /var/lib/ceph)" = "ext4" ]; then
+			cat <<ENDHERE >> /etc/ceph/${CLUSTER}.conf
+osd max object name len = 256
+osd max object namespace len = 64
+ENDHERE
+		fi
+
     # Generate administrator key
     ceph-authtool /etc/ceph/${CLUSTER}.client.admin.keyring --create-keyring --gen-key -n client.admin --set-uid=0 --cap mon 'allow *' --cap osd 'allow *' --cap mds 'allow'
 


### PR DESCRIPTION
Since jewel, certain limitations apply to OSD object name lengths: specifically if ext4 is in use for block devices or a directory based OSD is configured, OSD's must be configured to limit object name length:

```
osd max object name len = 256
osd max object namespace len = 64
```

Or, disable the check:

```
osd check max object name len on startup = false
```

When using ceph/demo, I think most of users are using an ext4 fs. So we should
open this setting by default.

> More discussions can be found here:
> 
> https://bugs.launchpad.net/charms/+source/ceph-osd/+bug/1580320
> http://ceph.com/releases/v10-2-0-jewel-released/

If we don't add this, though `ceph/demo` will be ok in a few minutes, but it will soon be `HEALTH_ERR`, and all the `ceph-osd` exits.

```
ps aux | grep ceph-osd
# will find nothing

root@docker-dev01:/# ceph osd tree
ID WEIGHT  TYPE NAME             UP/DOWN REWEIGHT PRIMARY-AFFINITY
-1 1.00000 root default
-2 1.00000     host docker-dev01
 0 1.00000         osd.0            down        0          1.00000
```

with osd error log

```
root@docker-dev01:/# tail /var/log/ceph/ceph-osd.0.log
2016-06-19 09:35:39.223214 7f279fb8f800 -1 journal FileJournal::_open: disabling aio for non-block journal.  Use journal_force_aio to force use of aio anyway
2016-06-19 09:35:39.223216 7f279fb8f800  1 journal _open /var/lib/ceph/osd/ceph-0/journal fd 18: 104857600 bytes, block size 4096 bytes, directio = 1, aio = 0
2016-06-19 09:35:39.223333 7f279fb8f800  1 journal _open /var/lib/ceph/osd/ceph-0/journal fd 18: 104857600 bytes, block size 4096 bytes, directio = 1, aio = 0
2016-06-19 09:35:39.223813 7f279fb8f800  1 filestore(/var/lib/ceph/osd/ceph-0) upgrade
2016-06-19 09:35:39.223995 7f279fb8f800 -1 osd.0 0 backend (filestore) is unable to support max object name[space] len
2016-06-19 09:35:39.223998 7f279fb8f800 -1 osd.0 0    osd max object name len = 2048
2016-06-19 09:35:39.223999 7f279fb8f800 -1 osd.0 0    osd max object namespace len = 256
2016-06-19 09:35:39.224000 7f279fb8f800 -1 osd.0 0 (36) File name too long
2016-06-19 09:35:39.224401 7f279fb8f800  1 journal close /var/lib/ceph/osd/ceph-0/journal
2016-06-19 09:35:39.225362 7f279fb8f800 -1  ** ERROR: osd init failed: (36) File name too long
```