### PR TITLE
Fix bug of NETWORK_AUTO_DETECT

### DIFF
--- a/ceph-releases/jewel/ubuntu/14.04/daemon/entrypoint.sh
+++ b/ceph-releases/jewel/ubuntu/14.04/daemon/entrypoint.sh
@@ -154,8 +154,8 @@ function start_mon {
       fi
     # best effort, only works with ipv4
     else
-      MON_IP=$(grep -o '[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}' /proc/net/fib_trie | grep -vE "^127|255$|0$" | head -1)
-      CEPH_PUBLIC_NETWORK=$(grep -o '[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}/[0-9]\{1,2\}' /proc/net/fib_trie | grep -vE "^127|0$" | head -1)
+      MON_IP=$(grep -o '[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}' /proc/net/fib_trie | grep -vEw "^127|255$|0$" | head -1)
+      CEPH_PUBLIC_NETWORK=$(grep -o '[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}/[0-9]\{1,2\}' /proc/net/fib_trie | grep -vE "^127|^0" | head -1)
     fi
   fi
 


### PR DESCRIPTION
Hi,

1.
If we got some IP address such as 10.1.86.10, end with zero.
It match the rule "grep -v "0$" " and MON_IP won't set anything.
Using grep -w can help us.

2.
CEPH_PUBLIC_NETWORK alwayls grep the network 0.0.0.0/1.
Maybe using "grep -vE "^127|^0" " is a better choice.