### PR TITLE
daemon: better osd scenario prediction

### DIFF
--- a/ceph-releases/jewel/ubuntu/14.04/daemon/README.md
+++ b/ceph-releases/jewel/ubuntu/14.04/daemon/README.md
@@ -66,6 +66,22 @@ $ sudo docker run -d --net=host \
 ceph/daemon populate_kvstore
 ```
 
+
+Zap a device
+------------
+
+Sometimes you might want to destroy partition tables from a disk.
+For this you can use the `zap_device` scenario that works as follow:
+
+```
+docker run -d --privileged=true \
+-v /dev/:/dev/
+-e OSD_DEVICE=/dev/sdd 
+ceph/daemon
+zap_device
+```
+
+
 Deploy a monitor
 ----------------
 


### PR DESCRIPTION
When 'osd' is only set in the docker run command as $1 we need to detect
which scenario is desired. The commit splits the logic into a new
function and makes the overall detection clearer in term of code
readability.

Half fix for #324

Signed-off-by: Sébastien Han <seb@redhat.com>