### PR TITLE
daemon: add rbd-mirror daemon

### DIFF
--- a/ceph-releases/jewel/centos/7/base/Dockerfile
+++ b/ceph-releases/jewel/centos/7/base/Dockerfile
@@ -22,7 +22,7 @@ RUN yum install -y runit-2.1.1-7.el7.centos.x86_64
 RUN rpm --import 'https://download.ceph.com/keys/release.asc'
 RUN rpm -Uvh http://download.ceph.com/rpm-${CEPH_VERSION}/el7/noarch/ceph-release-1-1.el7.noarch.rpm
 RUN yum install -y epel-release && yum clean all
-RUN yum install -y ceph ceph-radosgw sharutils python34 && yum clean all
+RUN yum install -y ceph ceph-radosgw rbd-mirror sharutils python34 && yum clean all
 
 # Install etcdctl
 RUN curl -L --remote-name https://github.com/coreos/etcd/releases/download/${ETCDCTL_VERSION}/etcd-${ETCDCTL_VERSION}-${ETCDCTL_ARCH}.tar.gz && tar xfz etcd-${ETCDCTL_VERSION}-${ETCDCTL_ARCH}.tar.gz -C /tmp/ etcd-${ETCDCTL_VERSION}-${ETCDCTL_ARCH}/etcdctl

--- a/ceph-releases/jewel/fedora/24/base/Dockerfile
+++ b/ceph-releases/jewel/fedora/24/base/Dockerfile
@@ -17,7 +17,7 @@ ADD https://github.com/AcalephStorage/kviator/releases/download/v${KVIATOR_VERSI
 ADD https://github.com/kelseyhightower/confd/releases/download/v${CONFD_VERSION}/confd-${CONFD_VERSION}-linux-amd64 /usr/local/bin/confd
 
 # install prerequisites
-RUN dnf install -y ceph ceph-radosgw sharutils wget unzip && dnf clean all && \
+RUN dnf install -y ceph ceph-radosgw rbd-mirror sharutils wget unzip && dnf clean all && \
 \
 # Install etcdctl
     wget -q -O- "https://github.com/coreos/etcd/releases/download/${ETCDCTL_VERSION}/etcd-${ETCDCTL_VERSION}-${ETCDCTL_ARCH}.tar.gz" |tar xfz - -C/tmp/ etcd-${ETCDCTL_VERSION}-${ETCDCTL_ARCH}/etcdctl && \

--- a/ceph-releases/jewel/ubuntu/14.04/base/Dockerfile
+++ b/ceph-releases/jewel/ubuntu/14.04/base/Dockerfile
@@ -23,7 +23,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update &&  apt-get install -y wget un
 # install ceph
     wget -q -O- 'https://download.ceph.com/keys/release.asc' | apt-key add - && \
     echo "deb http://download.ceph.com/debian-$CEPH_VERSION/ trusty main" | tee /etc/apt/sources.list.d/ceph-$CEPH_VERSION.list && \
-    apt-get update && apt-get install -y --force-yes ceph radosgw && \
+    apt-get update && apt-get install -y --force-yes ceph radosgw rbd-mirror && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
 \
 # Install etcdctl

--- a/ceph-releases/jewel/ubuntu/14.04/daemon/README.md
+++ b/ceph-releases/jewel/ubuntu/14.04/daemon/README.md
@@ -408,6 +408,25 @@ $ sudo docker run -d --net=host \
 ceph/daemon restapi
 ```
 
+Deploy a RBD mirror
+-----------------
+
+This is pretty straighforward. The `--net=host` is not mandatory, with KV we do:
+
+```
+$ sudo docker run -d --net=host \
+-e KV_TYPE=etcd \
+-e KV_IP=192.168.0.20 \
+ceph/daemon rbd_mirror
+```
+
+Without KV we do:
+
+```
+$ sudo docker run -d --net=host \
+ceph/daemon rbd_mirror
+```
+
 List of available options:
 
 * `RESTAPI_IP` is the IP address to listen on (DEFAULT: 0.0.0.0)

--- a/ceph-releases/jewel/ubuntu/14.04/daemon/entrypoint.sh
+++ b/ceph-releases/jewel/ubuntu/14.04/daemon/entrypoint.sh
@@ -759,6 +759,25 @@ ENDHERE
 
 
 ##############
+# RBD MIRROR #
+##############
+
+function start_rbd_mirror {
+  get_config
+  check_config
+  create_socket_dir
+
+  # ensure we have the admin key
+  get_admin_key
+  check_admin_key
+
+  # start rbd-mirror
+  exec /usr/bin/rbd-mirror ${CEPH_OPTS} -d --setuser ceph --setgroup ceph
+
+}
+
+
+##############
 # ZAP DEVICE #
 ##############
 
@@ -825,6 +844,9 @@ case "$CEPH_DAEMON" in
   restapi)
     start_restapi
     ;;
+  rbd_mirror)
+    start_rbd_mirror
+    ;;
   zap_device)
     zap_device
     ;;
@@ -832,8 +854,8 @@ case "$CEPH_DAEMON" in
   if [ ! -n "$CEPH_DAEMON" ]; then
     echo "ERROR- One of CEPH_DAEMON or a daemon parameter must be defined as the name "
     echo "of the daemon you want to deploy."
-    echo "Valid values for CEPH_DAEMON are MON, OSD, OSD_DIRECTORY, OSD_CEPH_DISK, OSD_CEPH_DISK_PREPARE, OSD_CEPH_DISK_ACTIVATE, OSD_CEPH_ACTIVATE_JOURNAL, MDS, RGW, RESTAPI, ZAP_DEVICE"
-    echo "Valid values for the daemon parameter are mon, osd, osd_directory, osd_ceph_disk, osd_ceph_disk_prepare, osd_ceph_disk_activate, osd_ceph_activate_journal, mds, rgw, restapi, zap_device"
+    echo "Valid values for CEPH_DAEMON are MON, OSD, OSD_DIRECTORY, OSD_CEPH_DISK, OSD_CEPH_DISK_PREPARE, OSD_CEPH_DISK_ACTIVATE, OSD_CEPH_ACTIVATE_JOURNAL, MDS, RGW, RESTAPI, ZAP_DEVICE, RBD_MIRROR"
+    echo "Valid values for the daemon parameter are mon, osd, osd_directory, osd_ceph_disk, osd_ceph_disk_prepare, osd_ceph_disk_activate, osd_ceph_activate_journal, mds, rgw, restapi, zap_device, rbd_mirror"
     exit 1
   fi
   ;;

--- a/ceph-releases/jewel/ubuntu/16.04/base/Dockerfile
+++ b/ceph-releases/jewel/ubuntu/16.04/base/Dockerfile
@@ -23,7 +23,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y wget unz
 # install ceph
     wget -q -O- 'https://download.ceph.com/keys/release.asc' | apt-key add - && \
     echo "deb http://download.ceph.com/debian-$CEPH_VERSION/ xenial main" | tee /etc/apt/sources.list.d/ceph-$CEPH_VERSION.list && \
-    apt-get update && apt-get install -y --force-yes ceph radosgw && \
+    apt-get update && apt-get install -y --force-yes ceph radosgw rbd-mirror && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
 \
 # Install etcdctl


### PR DESCRIPTION
rbd-mirror is use to asyncrhonously replicate ceph block images from one
cluster to another. It is usually used to overcome ceph's synchronous
nature and for disaster recovery purpose.

Signed-off-by: Sébastien Han <seb@redhat.com>