### PR TITLE
daemon: fix osd_dir path per distro

### DIFF
--- a/ceph-releases/jewel/centos/7/daemon/my_init
+++ b/ceph-releases/jewel/centos/7/daemon/my_init
@@ -1,1 +1,0 @@
-../../../ubuntu/14.04/daemon/my_init

--- a/ceph-releases/jewel/centos/7/daemon/my_init/LICENSE.txt
+++ b/ceph-releases/jewel/centos/7/daemon/my_init/LICENSE.txt
@@ -1,0 +1,19 @@
+Copyright (c) 2013-2014 Phusion
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/ceph-releases/jewel/centos/7/daemon/my_init/my_init
+++ b/ceph-releases/jewel/centos/7/daemon/my_init/my_init
@@ -220,7 +220,7 @@ def run_startup_files():
 
 def start_runit():
 	info("Booting runit daemon...")
-	pid = os.spawnl(os.P_NOWAIT, "/usr/bin/svdir", "/usr/bin/runsvdir",
+	pid = os.spawnl(os.P_NOWAIT, "/usr/sbin/svdir", "/usr/sbin/runsvdir",
 		"-P", "/etc/service")
 	info("Runit started as PID %d" % pid)
 	return pid
@@ -234,13 +234,13 @@ def wait_for_runit_or_interrupt(pid):
 
 def shutdown_runit_services():
 	debug("Begin shutting down runit services...")
-	os.system("/usr/bin/sv down /etc/service/*")
+	os.system("/usr/sbin/sv down /etc/service/*")
 
 def wait_for_runit_services():
 	debug("Waiting for runit services to exit...")
 	done = False
 	while not done:
-		done = os.system("/usr/bin/sv status /etc/service/* | grep -q '^run:'") != 0
+		done = os.system("/usr/sbin/sv status /etc/service/* | grep -q '^run:'") != 0
 		if not done:
 			time.sleep(0.1)
 


### PR DESCRIPTION
In a previous comment I was thinking that using non-full path would work
(to call the binaries). However it seems that we need fullpath.
Updating the path with the correct location for redhat and debian based
systems.

Signed-off-by: Sébastien Han <seb@redhat.com>