### PR TITLE
osd_trying_to_determine_scenario better OSD detect

### DIFF
--- a/ceph-releases/jewel/ubuntu/14.04/daemon/entrypoint.sh
+++ b/ceph-releases/jewel/ubuntu/14.04/daemon/entrypoint.sh
@@ -79,25 +79,19 @@ function dev_part {
 }
 
 function osd_trying_to_determine_scenario {
-  if [[ ! -d /var/lib/ceph/osd || -n "$(find /var/lib/ceph/osd -prune -empty)" ]]; then
-    echo "No bootstrapped OSDs found; trying ceph-disk"
-    osd_disk
-    return
-  fi
-
   if [ -z "${OSD_DEVICE}" ]; then
     echo "Bootstrapped OSD(s) found; using OSD directory"
     osd_directory
     return
-  fi
-
-  if $(parted --script ${OSD_DEVICE} print | egrep -sq '^ 1.*ceph data'); then
+  elif $(parted --script ${OSD_DEVICE} print | egrep -sq '^ 1.*ceph data'); then
     echo "Bootstrapped OSD found; activating ${OSD_DEVICE}"
     osd_activate
+    return
   else
     echo "Device detected, assuming ceph-disk scenario is desired"
     echo "Preparing and activating ${OSD_DEVICE}"
     osd_disk
+    return
   fi
 }
 

--- a/ceph-releases/jewel/ubuntu/14.04/daemon/entrypoint.sh
+++ b/ceph-releases/jewel/ubuntu/14.04/daemon/entrypoint.sh
@@ -82,16 +82,13 @@ function osd_trying_to_determine_scenario {
   if [ -z "${OSD_DEVICE}" ]; then
     echo "Bootstrapped OSD(s) found; using OSD directory"
     osd_directory
-    return
   elif $(parted --script ${OSD_DEVICE} print | egrep -sq '^ 1.*ceph data'); then
     echo "Bootstrapped OSD found; activating ${OSD_DEVICE}"
     osd_activate
-    return
   else
     echo "Device detected, assuming ceph-disk scenario is desired"
     echo "Preparing and activating ${OSD_DEVICE}"
     osd_disk
-    return
   fi
 }
 


### PR DESCRIPTION
Sometimes the old code used to go into osd_disk function when already an OSD.
So it should go to osd_activate function.

My suggested change will most likely better detect already prepared OSD's.

Note that I haven't tested this code yet in a live node, but it's such a minor change, I don't see why it shouldn't work.
I can test it if you deem it necessary, otherwise it will get tested it as soon as it's merged pushed to docker hub :-)
