### PR TITLE
Throw a warning about hostname -s == 'default'

### DIFF
--- a/ceph-releases/jewel/ubuntu/14.04/demo/entrypoint.sh
+++ b/ceph-releases/jewel/ubuntu/14.04/demo/entrypoint.sh
@@ -155,6 +155,12 @@ function bootstrap_osd {
     chown -R ceph. /var/lib/ceph/osd/${CLUSTER}-0
     ceph-osd ${CEPH_OPTS} -i 0 --mkfs --setuser ceph --setgroup ceph
     ceph ${CEPH_OPTS} auth get-or-create osd.0 osd 'allow *' mon 'allow profile osd' -o /var/lib/ceph/osd/${CLUSTER}-0/keyring
+    if [ $(hostname -s) == 'default' ]
+    then
+      echo "A hostname of 'default' as used by docker-machine conflicts with ceph."
+      echo "Rename your machine to fix this issue."
+      echo "https://github.com/ceph/ceph-docker/issues/168"
+    fi
     ceph ${CEPH_OPTS} osd crush add 0 1 root=default host=$(hostname -s)
   fi
 

--- a/ceph-releases/jewel/ubuntu/14.04/demo/entrypoint.sh
+++ b/ceph-releases/jewel/ubuntu/14.04/demo/entrypoint.sh
@@ -156,7 +156,7 @@ function bootstrap_osd {
     ceph-osd ${CEPH_OPTS} -i 0 --mkfs --setuser ceph --setgroup ceph
     ceph ${CEPH_OPTS} auth get-or-create osd.0 osd 'allow *' mon 'allow profile osd' -o /var/lib/ceph/osd/${CLUSTER}-0/keyring
     if [ $(hostname -s) == 'default' ]; then
-      echo "A hostname of 'default' as used by docker-machine conflicts with ceph."
+      echo "A hostname of 'default' as used by docker-machine conflicts with Ceph."
       echo "Rename your machine to fix this issue."
       echo "https://github.com/ceph/ceph-docker/issues/168"
     fi

--- a/ceph-releases/jewel/ubuntu/14.04/demo/entrypoint.sh
+++ b/ceph-releases/jewel/ubuntu/14.04/demo/entrypoint.sh
@@ -155,8 +155,7 @@ function bootstrap_osd {
     chown -R ceph. /var/lib/ceph/osd/${CLUSTER}-0
     ceph-osd ${CEPH_OPTS} -i 0 --mkfs --setuser ceph --setgroup ceph
     ceph ${CEPH_OPTS} auth get-or-create osd.0 osd 'allow *' mon 'allow profile osd' -o /var/lib/ceph/osd/${CLUSTER}-0/keyring
-    if [ $(hostname -s) == 'default' ]
-    then
+    if [ $(hostname -s) == 'default' ]; then
       echo "A hostname of 'default' as used by docker-machine conflicts with ceph."
       echo "Rename your machine to fix this issue."
       echo "https://github.com/ceph/ceph-docker/issues/168"


### PR DESCRIPTION
This PR doesn't solve the issue, but at least gives users a hint as to what's going on and how to fix it.

```
$ docker run --net=host -e MON_IP=192.168.99.101 -e CEPH_PUBLIC_NETWORK=192.168.99.0/24 b5d4a5cf6fa2
creating /etc/ceph/ceph.client.admin.keyring
creating /etc/ceph/ceph.mon.keyring
monmaptool: monmap file /etc/ceph/ceph.monmap
monmaptool: set fsid to c28732cf-18a8-45cd-98ff-a218bd18bb2b
monmaptool: writing epoch 0 to /etc/ceph/ceph.monmap (1 monitors)
creating /tmp/ceph.mon.keyring
importing contents of /etc/ceph/ceph.client.admin.keyring into /tmp/ceph.mon.keyring
importing contents of /etc/ceph/ceph.mon.keyring into /tmp/ceph.mon.keyring
ceph-mon: set fsid to c28732cf-18a8-45cd-98ff-a218bd18bb2b
ceph-mon: created monfs at /var/lib/ceph/mon/ceph-default for mon.default
'/var/lib/ceph/mon/ceph-default' already exists and is not empty: monitor may already exist
set pool 0 size to 1
0
2016-07-20 16:55:57.969410 7f20ffbf4800 -1 journal FileJournal::_open: disabling aio for non-block journal.  Use journal_force_aio to force use of aio anyway
2016-07-20 16:55:57.991209 7f20ffbf4800 -1 journal FileJournal::_open: disabling aio for non-block journal.  Use journal_force_aio to force use of aio anyway
2016-07-20 16:55:57.992330 7f20ffbf4800 -1 filestore(/var/lib/ceph/osd/ceph-0) could not find #-1:7b3f43c4:::osd_superblock:0# in index: (2) No such file or directory
2016-07-20 16:55:58.004823 7f20ffbf4800 -1 created object store /var/lib/ceph/osd/ceph-0 for osd.0 fsid c28732cf-18a8-45cd-98ff-a218bd18bb2b
A hostname of 'default' as used by docker-machine conflicts with ceph.
Rename your machine to fix this issue.
https://github.com/ceph/ceph-docker/issues/168
Error EINVAL: (22) Invalid argument
```