### PR TITLE
Use localhost since everything runs in one container

### DIFF
--- a/ceph-releases/jewel/ubuntu/14.04/demo/entrypoint.sh
+++ b/ceph-releases/jewel/ubuntu/14.04/demo/entrypoint.sh
@@ -155,12 +155,7 @@ function bootstrap_osd {
     chown -R ceph. /var/lib/ceph/osd/${CLUSTER}-0
     ceph-osd ${CEPH_OPTS} -i 0 --mkfs --setuser ceph --setgroup ceph
     ceph ${CEPH_OPTS} auth get-or-create osd.0 osd 'allow *' mon 'allow profile osd' -o /var/lib/ceph/osd/${CLUSTER}-0/keyring
-    if [ $(hostname -s) == 'default' ]; then
-      echo "A hostname of 'default' as used by docker-machine conflicts with Ceph."
-      echo "Rename your machine to fix this issue."
-      echo "https://github.com/ceph/ceph-docker/issues/168"
-    fi
-    ceph ${CEPH_OPTS} osd crush add 0 1 root=default host=$(hostname -s)
+    ceph ${CEPH_OPTS} osd crush add 0 1 root=default host=localhost
   fi
 
   # start OSD


### PR DESCRIPTION
A followup from https://github.com/ceph/ceph-docker/pull/339

This is working for me with the default hostname for docker-machine. Is there any reason we can't just lock this down to localhost?