### PR TITLE
add support for bluestore and dmcrypt

### DIFF
--- a/ceph-releases/jewel/ubuntu/14.04/daemon/README.md
+++ b/ceph-releases/jewel/ubuntu/14.04/daemon/README.md
@@ -197,6 +197,36 @@ $ sudo docker run -d --net=host \
 ceph/daemon osd
 ```
 
+Using bluestore:
+
+```
+$ sudo docker run -d --net=host \
+--privileged=true \
+--pid=host \
+-v /etc/ceph:/etc/ceph \
+-v /var/lib/ceph/:/var/lib/ceph/ \
+-v /dev/:/dev/ \
+-e OSD_DEVICE=/dev/vdd \
+-e OSD_TYPE=disk \
+-e OSD_BLUESTORE=1 \
+ceph/daemon osd
+```
+
+Using dmcrypt:
+
+```
+$ sudo docker run -d --net=host \
+--privileged=true \
+--pid=host \
+-v /etc/ceph:/etc/ceph \
+-v /var/lib/ceph/:/var/lib/ceph/ \
+-v /dev/:/dev/ \
+-e OSD_DEVICE=/dev/vdd \
+-e OSD_TYPE=disk \
+-e OSD_DMCRYPT=1 \
+ceph/daemon osd
+```
+
 With KV backend:
 
 ```
@@ -208,6 +238,36 @@ $ sudo docker run -d --net=host \
 -e OSD_TYPE=disk \
 -e KV_TYPE=etcd \
 -e KV_IP=192.168.0.20 \
+ceph/daemon osd
+```
+
+Using bluestore with KV backend:
+
+```
+$ sudo docker run -d --net=host \
+--privileged=true \
+--pid=host \
+-v /dev/:/dev/ \
+-e OSD_DEVICE=/dev/vdd \
+-e OSD_TYPE=disk \
+-e KV_TYPE=etcd \
+-e KV_IP=192.168.0.20 \
+-e OSD_BLUESTORE=1 \
+ceph/daemon osd
+```
+
+Using dmcrypt with KV backend:
+
+```
+$ sudo docker run -d --net=host \
+--privileged=true \
+--pid=host \
+-v /dev/:/dev/ \
+-e OSD_DEVICE=/dev/vdd \
+-e OSD_TYPE=disk \
+-e KV_TYPE=etcd \
+-e KV_IP=192.168.0.20 \
+-e OSD_DMCRYPT=1 \
 ceph/daemon osd
 ```
 


### PR DESCRIPTION
This new scenario only works with OSD_DISK.
You can now prepare osd disks with either bluestore or dmcrypt:

* set `OSD_BLUESTORE=1` to use bluestore
* set `OSD_DMCRYPT=1` to encrypt osd directory data

For dmcrypt the admin key must be present on the node so the encrypted
key can be stored on the monitor store during the preparation stage.

Signed-off-by: Sébastien Han <seb@redhat.com>