### PR TITLE
Use the official ceph-docker images for Kubernetes examples

### DIFF
--- a/examples/kubernetes/ceph-mds-v1-dp.yaml
+++ b/examples/kubernetes/ceph-mds-v1-dp.yaml
@@ -4,7 +4,7 @@ apiVersion: extensions/v1beta1
 metadata:
   labels:
     app: ceph
-    daemon: mds 
+    daemon: mds
   name: ceph-mds
   namespace: ceph
 spec:
@@ -35,8 +35,7 @@ spec:
             secretName: ceph-bootstrap-rgw-keyring
       containers:
         - name: ceph-mon
-          image: quay.io/cornelius/ceph-daemon-test:latest
-#         image: quay.io/acaleph/ceph-daemon:kubernetes
+          image: ceph/daemon:latest
           ports:
             - containerPort: 6800
           env:

--- a/examples/kubernetes/ceph-mon-check-v1-dp.yaml
+++ b/examples/kubernetes/ceph-mon-check-v1-dp.yaml
@@ -33,8 +33,7 @@ spec:
             secretName: ceph-bootstrap-rgw-keyring
       containers:
         - name: ceph-mon
-        #image: quay.io/acaleph/ceph-daemon:kubernetes
-          image: quay.io/cornelius/ceph-daemon-test:latest
+          image: ceph/daemon:latest
           imagePullPolicy: Always
           ports:
             - containerPort: 6789

--- a/examples/kubernetes/ceph-mon-v1-dp.yaml
+++ b/examples/kubernetes/ceph-mon-v1-dp.yaml
@@ -49,7 +49,7 @@ spec:
             secretName: ceph-bootstrap-rgw-keyring
       containers:
         - name: ceph-mon
-          image: quay.io/cornelius/ceph-daemon-test:latest
+          image: ceph/daemon:latest
 #          imagePullPolicy: Always
           lifecycle:
             preStop:

--- a/examples/kubernetes/ceph-mon-v1-ds.yaml
+++ b/examples/kubernetes/ceph-mon-v1-ds.yaml
@@ -34,9 +34,8 @@ spec:
             secretName: ceph-bootstrap-rgw-keyring
       containers:
         - name: ceph-mon
-          image: quay.io/cornelius/ceph-daemon-test:latest
-#         image: quay.io/acaleph/ceph-daemon:kubernetes
-#          imagePullPolicy: Always
+          image: ceph/daemon:latest
+          imagePullPolicy: Always
           lifecycle:
             preStop:
                 exec:

--- a/examples/kubernetes/ceph-osd-v1-ds.yaml
+++ b/examples/kubernetes/ceph-osd-v1-ds.yaml
@@ -42,8 +42,8 @@ spec:
 #            path: /home/core/data/ceph/osd
       containers:
         - name: osd-pod
-          image: quay.io/cornelius/ceph-daemon-test:latest
-#          imagePullPolicy: Always
+          image: ceph/daemon:latest
+          imagePullPolicy: Always
           volumeMounts:
             - name: devices
               mountPath: /dev


### PR DESCRIPTION
A minor update to the Kubernetes resources to use the official repo. It is using the `latest` tag but should partly solve the issue raised in #342 