### PR TITLE
Fix daemon entrypoint script for non-Ubuntu distros.

### DIFF
--- a/ceph-releases/jewel/ubuntu/14.04/daemon/entrypoint.sh
+++ b/ceph-releases/jewel/ubuntu/14.04/daemon/entrypoint.sh
@@ -436,7 +436,7 @@ EOF
     chmod +x /etc/service/${CLUSTER}-${OSD_ID}/run
   done
 
-exec /usr/bin/runsvdir -P /etc/service
+exec /sbin/my_init
 }
 
 


### PR DESCRIPTION
It looks like the current entrypoint script will only work on Ubuntu, and that my_init is designed to provide distribution-independence.

I tested this change on CentOS 7 (and Kubernetes).