### PR TITLE
entrypoint: stricter osd PID check

### DIFF
--- a/ceph-releases/jewel/ubuntu/14.04/daemon/entrypoint.sh
+++ b/ceph-releases/jewel/ubuntu/14.04/daemon/entrypoint.sh
@@ -550,7 +550,7 @@ function osd_activate {
 
   # ceph-disk activiate has exec'ed /usr/bin/ceph-osd ${CEPH_OPTS} -f -d -i ${OSD_ID}
   # wait till docker stop or ceph-osd is killed
-  OSD_PID=$(ps -ef |grep ceph-osd |grep osd.${OSD_ID} |awk '{print $2}')
+  OSD_PID=$(pgrep -U ceph -f "^/usr/bin/ceph-osd \-\-cluster $CLUSTER.*\-i ${OSD_ID} \-\-setuser")
   if [ -n "${OSD_PID}" ]; then
       echo "OSD (PID ${OSD_PID}) is running, waiting till it exits"
       while [ -e /proc/${OSD_PID} ]; do sleep 1;done


### PR DESCRIPTION
This fixes #358 

It is similar to the regex suggested by @leseb with the following changes:
- it tests that the user is ceph, which translates to some arbitrary uid that is shared by instances of this container. This means that we are only contending with other instances of the container, not other commands.
- it checks the $CLUSTER in case there are two osds with the same IDs on the same host but in different clusters

I tested it and it appears to work both when there is a PID (I deliberately launched the container twice) and when there isn't. I never encountered a case where the PID was present without having had a duplicate container. The comments seem to suggest that ceph-disk activate may launch it? It's not a race, I added a delay to make sure.
