### PR TITLE
adds sample files for running kubernetes on coreos

### DIFF
--- a/examples/kubernetes-coreos/50-rbd.rules
+++ b/examples/kubernetes-coreos/50-rbd.rules
@@ -1,0 +1,2 @@
+KERNEL=="rbd[0-9]*", ENV{DEVTYPE}=="disk", PROGRAM="/opt/bin/ceph-rbdnamer %k", SYMLINK+="rbd/%c{1}/%c{2}"
+KERNEL=="rbd[0-9]*", ENV{DEVTYPE}=="partition", PROGRAM="/opt/bin/ceph-rbdnamer %k", SYMLINK+="rbd/%c{1}/%c{2}-part%n"

--- a/examples/kubernetes-coreos/Dockerfile
+++ b/examples/kubernetes-coreos/Dockerfile
@@ -1,0 +1,14 @@
+FROM busybox
+MAINTAINER Pat Christopher "coffeepac@gmail.com"
+
+ADD ceph /
+ADD rbd /
+ADD rados /
+ADD ceph-disk /
+ADD ceph-rbdnamer /
+ADD 50-rbd.rules /
+
+ADD startup.sh /
+RUN mkdir -p /opt/bin
+RUN mkdir -p /etc/udev/rules.d/
+ENTRYPOINT ["/startup.sh"]

--- a/examples/kubernetes-coreos/README.md
+++ b/examples/kubernetes-coreos/README.md
@@ -1,0 +1,24 @@
+#  Ceph on CoreOS for Kubernetes
+
+This project enables running Ceph systems on Kubernetes on CoreOS and accessing Ceph resources via Kubernetes.  Installation can occur
+in several ways:
+- manually execute the image built by the included Dockerfile:  sudo /usr/bin/docker run --rm -v /opt/bin:/opt/bin coffeepac/ceph-Instal
+- modify 'install-job.yaml' to have at least one job per node in the kubernetes cluster.  This is only a best effort as Kubernetes
+  may schedule several of the pods for a single high performing node
+    kubectl create -f install-job.yaml
+      this currently pulls the latest tag which will sleep for 30d after the install is complete.  Should have a separate tag for the job
+- install the daemon-set.  this will install the required ceph utilities once on each node and then sleep for 30 days.  Its not ideal but
+  it will also install the ceph components to any future node.
+    kubectl create -f install-ds.yaml
+      this assumes a 'ceph' namespace exists.  If not you'll have to create one:
+      kubectl create namespace ceph
+
+  Once the tools are installed you can follow the kubernetes example.
+
+#  Additional Kubenetes configuration
+
+There are two additional pieces of configuration that have to happen:
+- the kubelet and apiserver need to be run with the flag 'allow-privileged'
+- the kubelet's need to have the following added to the Unit file:
+  Environment=PATH=/opt/bin/:/usr/bin/:/usr/sbin:$PATH
+

--- a/examples/kubernetes-coreos/ceph
+++ b/examples/kubernetes-coreos/ceph
@@ -1,0 +1,2 @@
+#!/bin/sh
+/usr/bin/docker run --rm -v /etc/ceph:/etc/ceph ceph/base ceph "$@"

--- a/examples/kubernetes-coreos/ceph-disk
+++ b/examples/kubernetes-coreos/ceph-disk
@@ -1,0 +1,2 @@
+#!/bin/sh
+/usr/bin/docker run --rm --privileged=true -v /etc/ceph:/etc/ceph -v /dev:/dev ceph/base ceph-disk "$@"

--- a/examples/kubernetes-coreos/ceph-rbdnamer
+++ b/examples/kubernetes-coreos/ceph-rbdnamer
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+DEV=$1
+NUM=`echo $DEV | sed 's#p.*##g' | tr -d 'a-z'`
+POOL=`cat /sys/devices/rbd/$NUM/pool`
+IMAGE=`cat /sys/devices/rbd/$NUM/name`
+SNAP=`cat /sys/devices/rbd/$NUM/current_snap`
+if [ "$SNAP" = "-" ]; then
+        echo -n "$POOL $IMAGE"
+else
+        echo -n "$POOL $IMAGE@$SNAP"
+fi

--- a/examples/kubernetes-coreos/install-ds.yaml
+++ b/examples/kubernetes-coreos/install-ds.yaml
@@ -1,0 +1,34 @@
+---
+kind: DaemonSet
+apiVersion: extensions/v1beta1
+metadata:
+  labels:
+    app: ceph
+    daemon: install
+  name: ceph-install
+  namespace: ceph
+spec:
+  template:
+    metadata:
+      name: ceph-install
+      namespace: ceph
+      labels:
+        app: ceph-install
+        daemon: install
+    spec:
+      serviceAccount: default
+      volumes:
+      - name: etc
+        hostPath:
+          path: /etc
+      - name: opt
+        hostPath:
+          path: /opt
+      containers:
+      - name: install-ceph
+        image: quay.io/coffeepac/ceph-install:latest
+        volumeMounts:
+        - mountPath: /etc
+          name: etc
+        - mountPath: /opt
+          name: opt

--- a/examples/kubernetes-coreos/install-job.yaml
+++ b/examples/kubernetes-coreos/install-job.yaml
@@ -1,0 +1,25 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ceph-install
+spec:
+  template:
+    metadata:
+      name: ceph-install
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: ceph-install
+        image: quay.io/coffeepac/ceph-install:latest
+        volumeMounts:
+        - mountPath: /etc
+          name: etc
+        - mountPath: /opt
+          name: opt
+      volumes:
+      - name: etc
+        hostPath:
+          path: /etc
+      - name: opt
+        hostPath:
+          path: /opt

--- a/examples/kubernetes-coreos/rados
+++ b/examples/kubernetes-coreos/rados
@@ -1,0 +1,2 @@
+#!/bin/sh
+/usr/bin/docker run --rm -v /etc/ceph:/etc/ceph ceph/base rados "$@"

--- a/examples/kubernetes-coreos/rbd
+++ b/examples/kubernetes-coreos/rbd
@@ -1,0 +1,2 @@
+#!/bin/sh
+/usr/bin/docker run --rm -v /etc/ceph:/etc/ceph -v /sys:/sys --net=host --privileged=true ceph/base rbd "$@"

--- a/examples/kubernetes-coreos/startup.sh
+++ b/examples/kubernetes-coreos/startup.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+#  borrowed from ceph-docker/exmample/coreos/tools
+set -e
+
+checksum()
+{
+	md5sum $1 | awk '{print $1}'
+}
+
+for UTIL in ceph rbd ceph-rbdnamer rados ceph-disk; do
+
+    if [ ! -e /opt/bin/$UTIL ] || [ "$(checksum /opt/bin/$UTIL)" != "$(checksum /$UTIL)" ]; then
+    	echo "Installing $UTIL to /opt/bin"
+    	cp -pf /$UTIL /opt/bin
+    fi
+
+done
+
+if [ ! -e /etc/udev/rules.d/50-rbd.rules ] || [ "$(checksum /etc/udev/rules.d/50-rbd.rules)" != "$(checksum /50-rbd.rules)" ]; then
+    echo "Installing 50-rbd.rules to /etc/udev/rules.d/"
+    cp -pf /50-rbd.rules /etc/udev/rules.d/
+fi
+
+#  there's no current way to have a daemon set that is 'run once per node' so we'll have it sleep forever
+echo "Begin sleep of 30 days"
+while true; do sleep 30d; done


### PR DESCRIPTION
this is an accumlation of files in the coreos example directory
and additional pieces required to make it work.  the goal was to
have a simple and reliable way to both run ceph on kubernetes on
coreos and be able to access ceph resources (CephFS and RBD) from
any kubernetes node.