### PR TITLE
Fix osd startup failure in fedora

### DIFF
--- a/ceph-releases/jewel/fedora/24/base/Dockerfile
+++ b/ceph-releases/jewel/fedora/24/base/Dockerfile
@@ -35,6 +35,12 @@ RUN dnf install -y ceph ceph-radosgw rbd-mirror nfs-ganesha-rgw nfs-ganesha-vfs 
 ADD https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl /usr/local/bin/kubectl
 RUN chmod +x /usr/local/bin/kubectl
 
+# Install runit
+RUN dnf install -y gcc glibc-static
+RUN cd / && mkdir -p /package && wget -q -O- "http://smarden.org/runit/runit-2.1.2.tar.gz" |tar xfz - -C/package/ && cd /package/admin/runit-2.1.2/ && ./package/install
+RUN mkdir -p /etc/service && chmod +x /etc/service/
+RUN dnf remove -y gcc glibc-static
+
 ADD https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 /usr/local/bin/jq
 RUN chmod +x /usr/local/bin/jq
 

--- a/ceph-releases/jewel/ubuntu/14.04/daemon/my_init/my_init
+++ b/ceph-releases/jewel/ubuntu/14.04/daemon/my_init/my_init
@@ -1,5 +1,5 @@
 #!/usr/bin/python3 -u
-import os, os.path, sys, stat, signal, errno, argparse, time, json, re
+import os, os.path, sys, stat, signal, errno, argparse, time, json, re, shutil
 
 KILL_PROCESS_TIMEOUT = 5
 KILL_ALL_PROCESSES_TIMEOUT = 5
@@ -55,6 +55,13 @@ def is_exe(path):
 		return os.path.isfile(path) and os.access(path, os.X_OK)
 	except OSError:
 		return False
+
+def find_exec_file(filename):
+	try:
+		return shutil.which(filename)
+	except shutil.Error:
+		error("%s executable not found\n" % filename)
+		sys.exit(1)
 
 def import_envvars(clear_existing_environment = True, override_existing_environment = True):
 	new_env = {}
@@ -219,8 +226,9 @@ def run_startup_files():
 		run_command_killable_and_import_envvars("/etc/rc.local")
 
 def start_runit():
+	runsvdir_file = find_exec_file('runsvdir')
 	info("Booting runit daemon...")
-	pid = os.spawnl(os.P_NOWAIT, "/usr/bin/runsvdir", "/usr/bin/runsvdir",
+	pid = os.spawnl(os.P_NOWAIT, runsvdir_file, runsvdir_file,
 		"-P", "/etc/service")
 	info("Runit started as PID %d" % pid)
 	return pid
@@ -233,14 +241,16 @@ def wait_for_runit_or_interrupt(pid):
 		return (False, None)
 
 def shutdown_runit_services():
+	sv_file = find_exec_file('sv')
 	debug("Begin shutting down runit services...")
-	os.system("/usr/bin/sv down /etc/service/*")
+	os.system(sv_file + " down /etc/service/*")
 
 def wait_for_runit_services():
+	sv_file = find_exec_file('sv')
 	debug("Waiting for runit services to exit...")
 	done = False
 	while not done:
-		done = os.system("/usr/bin/sv status /etc/service/* | grep -q '^run:'") != 0
+		done = os.system(sv_file + " status /etc/service/* | grep -q '^run:'") != 0
 		if not done:
 			time.sleep(0.1)
 


### PR DESCRIPTION
Runit is not part of the default package in fedora. This patch builds it
from source in the fedora base image.
This fixes #381 

Signed-off-by: Ganesh Maharaj Mahalingam <ganesh.mahalingam@intel.com>