### PR TITLE
clean up markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,25 @@
-docker-ceph
-===========
+# docker-ceph
 
 Ceph-related Docker files.
 
 ## Core Components:
 
-* [`ceph/base`](ceph-releases/jewel/ubuntu/14.04/base/):  Ceph base container image.  This is nothing but a fresh install of the latest Ceph + Ganesha on Ubuntu LTS (14.04)
-* [`ceph/daemon`](ceph-releases/jewel/ubuntu/14.04/daemon/): All-in-one container for all core daemons.
+- [`ceph/base`](ceph-releases/jewel/ubuntu/14.04/base/): Ceph base container image. This is nothing but a fresh install of the latest Ceph + Ganesha on Ubuntu LTS (14.04)
+- [`ceph/daemon`](ceph-releases/jewel/ubuntu/14.04/daemon/): All-in-one container for all core daemons.
 
 ## Utilities and convenience wrappers
 
-* [`ceph/config`](config/): _DEPRECATED (not maintained anymore since the logic is now embedded in the daemon image)_ Initializes and distributes cluster configuration
-* [`ceph/docker-registry`](docker-registry/): Rados backed docker-registry images repository
-* [`ceph/rados`](rados/): Convenience wrapper to execute the `rados` CLI tool
-* [`ceph/rbd`](rbd/): Convenience wrapper to execute the `rbd` CLI tool
-* [`ceph/rbd-lock`](rbd-lock/): Convenience wrapper to block waiting for an rbd lock
-* [`ceph/rbd-unlock`](rbd-unlock/): Convenience wrapper to release an rbd lock
-* [`ceph/rbd-volume`](rbd-volume/): Convenience wrapper to mount an rbd volume
+- [`ceph/config`](config/): _DEPRECATED (not maintained anymore since the logic is now embedded in the daemon image)_ Initializes and distributes cluster configuration
+- [`ceph/docker-registry`](docker-registry/): Rados backed docker-registry images repository
+- [`ceph/rados`](rados/): Convenience wrapper to execute the `rados` CLI tool
+- [`ceph/rbd`](rbd/): Convenience wrapper to execute the `rbd` CLI tool
+- [`ceph/rbd-lock`](rbd-lock/): Convenience wrapper to block waiting for an rbd lock
+- [`ceph/rbd-unlock`](rbd-unlock/): Convenience wrapper to release an rbd lock
+- [`ceph/rbd-volume`](rbd-volume/): Convenience wrapper to mount an rbd volume
 
 ## Demo
 
-* [`ceph/demo`](ceph-releases/jewel/ubuntu/14.04/demo/): Demonstration cluster for testing and learning.  This container runs all the major ceph and ganesha components installed, bootstrapped, and executed for you to play with.  (not intended for use in building a production cluster)
+- [`ceph/demo`](ceph-releases/jewel/ubuntu/14.04/demo/): Demonstration cluster for testing and learning. This container runs all the major ceph and ganesha components installed, bootstrapped, and executed for you to play with. (not intended for use in building a production cluster)
 
 # How to contribute?!
 
@@ -28,22 +27,20 @@ The following assumes that you already forked the repository, added the correct 
 
 ## Prepare your development environment
 
-Simply execute `./generate-dev-env.sh CEPH_RELEASE DISTRO DISTRO_VERSION`.
-For example if you run `./generate-dev-env.sh jewel ubuntu 16.04` the script will:
+Simply execute `./generate-dev-env.sh CEPH_RELEASE DISTRO DISTRO_VERSION`. For example if you run `./generate-dev-env.sh jewel ubuntu 16.04` the script will:
 
-* hardlink the files from `ceph-releases/jewel/ubuntu/16.04/{base,daemon,demo}` in `./base`, `./daemon` and `./demo`.
-* create a file in `{base,daemon,demo}/SOURCE_TREE` which will remind you the version you are working on.
+- hardlink the files from `ceph-releases/jewel/ubuntu/16.04/{base,daemon,demo}` in `./base`, `./daemon` and `./demo`.
+- create a file in `{base,daemon,demo}/SOURCE_TREE` which will remind you the version you are working on.
 
 From this, you can start modifying your code and building your images locally.
 
 ## My code is ready, what's next?
 
-Contributions must go in the 'ceph-releases' tree, in the appropriate Ceph version, distribution and distribution version.
-So once you are done, we can just run:
+Contributions must go in the 'ceph-releases' tree, in the appropriate Ceph version, distribution and distribution version. So once you are done, we can just run:
 
-* `cp -av base $(cat base/SOURCE_TREE)`
-* `cp -av daemon $(cat base/SOURCE_TREE)`
-* `cp -av demo $(cat base/SOURCE_TREE)`
+- `cp -av base $(cat base/SOURCE_TREE)`
+- `cp -av daemon $(cat base/SOURCE_TREE)`
+- `cp -av demo $(cat base/SOURCE_TREE)`
 
 We identified 2 types of contributions:
 
@@ -53,36 +50,25 @@ The code only changes the `base` image content of a specific distro, nothing to 
 
 ### New functionality contributions
 
-If you look at the ceph-releases directory you will notice that for each release the daemon image's content is symlinked to the Ubuntu daemon 14.04.
-Even if we support multi-distro, Ubuntu 14.04 remains the default.
-It would nice if you could get familiar with this approach.
-This basically means that if you are testing on CentOS then you should update the Ubuntu image instead.
-All the changes in the entrypoints *should not* diverse from one distro to another, so this should be safe :).
-We are currently **only** bringing new functionality in the `jewel` release.
+If you look at the ceph-releases directory you will notice that for each release the daemon image's content is symlinked to the Ubuntu daemon 14.04. Even if we support multi-distro, Ubuntu 14.04 remains the default. It would nice if you could get familiar with this approach. This basically means that if you are testing on CentOS then you should update the Ubuntu image instead. All the changes in the entrypoints _should not_ diverse from one distro to another, so this should be safe :). We are currently **only** bringing new functionality in the `jewel` release.
 
 # CI
 
 We use Travis to run several tests on each pull request:
 
-* we build both `base` and `daemon` images
-* we run all the ceph processes in a container based on the images we just built
-* we execute a validation script at the end to make sure Ceph is healthy
+- we build both `base` and `daemon` images
+- we run all the ceph processes in a container based on the images we just built
+- we execute a validation script at the end to make sure Ceph is healthy
 
-For each PR, we try to detect which Ceph release is being impacted.
-Since we can only produce a single CI build with Travis, ideally this change will only be on a single release and distro.
-If we have multiple ceph release and distro, we can only test one, since we have to build `base` and `daemon`.
-By default, we just pick up the first line that comes from the changes.
+For each PR, we try to detect which Ceph release is being impacted. Since we can only produce a single CI build with Travis, ideally this change will only be on a single release and distro. If we have multiple ceph release and distro, we can only test one, since we have to build `base` and `daemon`. By default, we just pick up the first line that comes from the changes.
 
 You can check the files in `travis-builds` to learn more about the entire process.
 
-If you don’t want to run a build for a particular commit, because all you are changing is the README for example, add `[ci skip]` to the git commit message.
-Commits that have `[ci skip]` anywhere in the commit messages are ignored by Travis CI.
+If you don't want to run a build for a particular commit, because all you are changing is the README for example, add `[ci skip]` to the git commit message. Commits that have `[ci skip]` anywhere in the commit messages are ignored by Travis CI.
 
 # Images workflow
 
-Once your contribution is done and merged in master. Either @Ulexus or @leseb will execute `ceph-docker-workflow.sh`, this will basically compare the content of each tag/branch to master.
-If any difference is found it will push the appropriate changes in each individual branches.
-Ultimately new pushed tags will trigger a Docker build on the Docker Hub.
+Once your contribution is done and merged in master. Either @Ulexus or @leseb will execute `ceph-docker-workflow.sh`, this will basically compare the content of each tag/branch to master. If any difference is found it will push the appropriate changes in each individual branches. Ultimately new pushed tags will trigger a Docker build on the Docker Hub.
 
 # Video demonstration
 

--- a/ceph-releases/hammer/centos/7/base/README.md
+++ b/ceph-releases/hammer/centos/7/base/README.md
@@ -4,12 +4,10 @@ Ceph base image (CentOS (latest) with the latest Ceph release installed).
 
 ## Docker Hub/Registry location
 
-https://registry.hub.docker.com/u/ceph/base/
+<https://registry.hub.docker.com/u/ceph/base/>
 
 ## Usage (example)
 
 ```bash
 $ docker run -i -t ceph/base
 ```
-
- 

--- a/ceph-releases/hammer/centos/7/base/README.md
+++ b/ceph-releases/hammer/centos/7/base/README.md
@@ -9,5 +9,5 @@ Ceph base image (CentOS (latest) with the latest Ceph release installed).
 ## Usage (example)
 
 ```bash
-$ docker run -i -t ceph/base
+docker run -i -t ceph/base
 ```

--- a/ceph-releases/hammer/fedora/23/base/README.md
+++ b/ceph-releases/hammer/fedora/23/base/README.md
@@ -4,11 +4,10 @@ Ceph base image (Fedora 23 with the latest Ceph release installed).
 
 ## Docker Hub/Registry location
 
-https://registry.hub.docker.com/u/ceph/base/
+<https://registry.hub.docker.com/u/ceph/base/>
 
 ## Usage (example)
 
 ```bash
 $ docker run -i -t ceph/base:fedora
 ```
- 

--- a/ceph-releases/hammer/fedora/23/base/README.md
+++ b/ceph-releases/hammer/fedora/23/base/README.md
@@ -9,5 +9,5 @@ Ceph base image (Fedora 23 with the latest Ceph release installed).
 ## Usage (example)
 
 ```bash
-$ docker run -i -t ceph/base:fedora
+docker run -i -t ceph/base:fedora
 ```

--- a/ceph-releases/hammer/ubuntu/14.04/base/README.md
+++ b/ceph-releases/hammer/ubuntu/14.04/base/README.md
@@ -9,5 +9,5 @@ Ceph base image (ubuntu 14.04 with the latest Ceph release installed).
 ## Usage (example)
 
 ```bash
-$ docker run -i -t ceph/base
+docker run -i -t ceph/base
 ```

--- a/ceph-releases/hammer/ubuntu/14.04/base/README.md
+++ b/ceph-releases/hammer/ubuntu/14.04/base/README.md
@@ -4,12 +4,10 @@ Ceph base image (ubuntu 14.04 with the latest Ceph release installed).
 
 ## Docker Hub/Registry location
 
-https://registry.hub.docker.com/u/ceph/base/
+<https://registry.hub.docker.com/u/ceph/base/>
 
 ## Usage (example)
 
 ```bash
 $ docker run -i -t ceph/base
 ```
-
- 

--- a/ceph-releases/hammer/ubuntu/14.04/daemon/README.md
+++ b/ceph-releases/hammer/ubuntu/14.04/daemon/README.md
@@ -1,47 +1,37 @@
-Daemon container
-================
+# Daemon container
 
-This Dockerfile may be used to bootstrap a Ceph cluster with all the Ceph daemons running.
-To run a certain type of daemon, simply use the name of the daemon as `$1`.
-Valid values are:
+This Dockerfile may be used to bootstrap a Ceph cluster with all the Ceph daemons running. To run a certain type of daemon, simply use the name of the daemon as `$1`. Valid values are:
 
-* `mon` deploys a Ceph monitor
-* `osd` deploys an OSD using the method specified by `OSD_TYPE`
-* `osd_directory` deploys an OSD using a prepared directory (used in scenario where the operator doesn't want to use `--privileged=true`)
-* `osd_ceph_disk` deploys an OSD using ceph-disk, so you have to provide a whole device (ie: /dev/sdb)
-* `mds` deploys a MDS
-* `rgw` deploys a Rados Gateway
+- `mon` deploys a Ceph monitor
+- `osd` deploys an OSD using the method specified by `OSD_TYPE`
+- `osd_directory` deploys an OSD using a prepared directory (used in scenario where the operator doesn't want to use `--privileged=true`)
+- `osd_ceph_disk` deploys an OSD using ceph-disk, so you have to provide a whole device (ie: /dev/sdb)
+- `mds` deploys a MDS
+- `rgw` deploys a Rados Gateway
 
-
-Usage
------
+## Usage
 
 You can use this container to bootstrap any Ceph daemon.
 
-* `CLUSTER` is the name of the cluster (DEFAULT: ceph)
-* `HOSTNAME` is the hostname of the machine  (DEFAULT: $(hostname))
+- `CLUSTER` is the name of the cluster (DEFAULT: ceph)
+- `HOSTNAME` is the hostname of the machine (DEFAULT: $(hostname))
 
-
-KV backends
------------
+## KV backends
 
 We currently support 2 KV backends to store our configuration flags, keys and maps:
 
-* etcd
-* consul
+- etcd
+- consul
 
-Prior to deploy your monitors, you have to populate your kv store with the help of the script `populate.sh` in examples/confd.
-As soon as this done, you can bootstrap your first monitor.
+Prior to deploy your monitors, you have to populate your kv store with the help of the script `populate.sh` in examples/confd. As soon as this done, you can bootstrap your first monitor.
 
 Important variables in `populate.sh` to change when you bootstrap an OSD:
 
-* `/osd/osd_journal_size`
-* `/osd/cluster_network`
-* `/osd/public_network`
+- `/osd/osd_journal_size`
+- `/osd/cluster_network`
+- `/osd/public_network`
 
-
-Deploy a monitor
-----------------
+## Deploy a monitor
 
 Without KV store, run:
 
@@ -68,41 +58,43 @@ ceph/daemon mon
 
 List of available options:
 
-* `MON_NAME`: name of the monitor (default to hostname)
-* `CEPH_PUBLIC_NETWORK`: CIDR of the host running Docker, it should be in the same network as the `MON_IP`
-* `CEPH_CLUSTER_NETWORK`: CIDR of a secondary interface of the host running Docker. Used for the OSD replication traffic
-* `MON_IP`: IP address of the host running Docker
-* `MON_IP_AUTO_DETECT`: Whether and how to attempt IP autodetection.
-    *  0 = Do not detect (default)
-    *  1 = Detect IPv6, fallback to IPv4 (if no globally-routable IPv6 address detected)
-    *  4 = Detect IPv4 only
-    *  6 = Detect IPv6 only
+- `MON_NAME`: name of the monitor (default to hostname)
+- `CEPH_PUBLIC_NETWORK`: CIDR of the host running Docker, it should be in the same network as the `MON_IP`
+- `CEPH_CLUSTER_NETWORK`: CIDR of a secondary interface of the host running Docker. Used for the OSD replication traffic
+- `MON_IP`: IP address of the host running Docker
+- `MON_IP_AUTO_DETECT`: Whether and how to attempt IP autodetection.
 
+  - 0 = Do not detect (default)
+  - 1 = Detect IPv6, fallback to IPv4 (if no globally-routable IPv6 address detected)
+  - 4 = Detect IPv4 only
+  - 6 = Detect IPv6 only
 
-Deploy an OSD
--------------
+## Deploy an OSD
 
 There are four available `OSD_TYPE` values:
 
-* `<none>` - if no `OSD_TYPE` is set; one of `disk`, `activate` or `directory` will be used based on autodetection of the current OSD bootstrap state
-* `activate` - the daemon expects to be passed a block device of a `ceph-disk`-prepared disk (via the `OSD_DEVICE` environment variable); no bootstrapping will be performed
-* `directory` - the daemon expects to find the OSD filesystem(s) already mounted in `/var/lib/ceph/osd/`
-* `disk` - the daemon expects to be passed a block device via the `OSD_DEVICE` environment variable
+- `<none>` - if no `OSD_TYPE` is set; one of `disk`, `activate` or `directory` will be used based on autodetection of the current OSD bootstrap state
+- `activate` - the daemon expects to be passed a block device of a `ceph-disk`-prepared disk (via the `OSD_DEVICE` environment variable); no bootstrapping will be performed
+- `directory` - the daemon expects to find the OSD filesystem(s) already mounted in `/var/lib/ceph/osd/`
+- `disk` - the daemon expects to be passed a block device via the `OSD_DEVICE` environment variable
 
 Options for OSDs (TODO: consolidate these options between the types):
-* `JOURNAL_DIR` - if provided, new OSDs will be bootstrapped to use the specified directory as a common journal area.  This is usually used to store the journals for more than one OSD on a common, separate disk.  This currently only applies to the `directory` OSD type.
-* `JOURNAL` - if provided, the new OSD will be bootstrapped to use the specified journal file (if you do not wish to use the default).  This is currently only supported by the `directory` OSD type
-* `OSD_DEVICE` - mandatory for `activate` and `disk` OSD types; this specifies which block device to use as the OSD
-* `OSD_JOURNAL` - optional override of the OSD journal file. this only applies to the `activate` and `disk` OSD types
 
-### Without OSD_TYPE ###
+- `JOURNAL_DIR` - if provided, new OSDs will be bootstrapped to use the specified directory as a common journal area. This is usually used to store the journals for more than one OSD on a common, separate disk. This currently only applies to the `directory` OSD type.
+- `JOURNAL` - if provided, the new OSD will be bootstrapped to use the specified journal file (if you do not wish to use the default). This is currently only supported by the `directory` OSD type
+- `OSD_DEVICE` - mandatory for `activate` and `disk` OSD types; this specifies which block device to use as the OSD
+- `OSD_JOURNAL` - optional override of the OSD journal file. this only applies to the `activate` and `disk` OSD types
+
+### Without OSD_TYPE
 
 If the operator does not specify an `OSD_TYPE` autodetection happens:
+
 - `disk` is used if no bootstrapped OSD is found. `OSD_FORCE_ZAP=1` must be set at this point.
 - `activate` is used if a bootstrapped OSD is found and `OSD_DEVICE` is also provided.
 - `directory` is used if a bootstrapped OSD is found and no `OSD_DEVICE` is provided.
 
 Without KV backend:
+
 ```
 $ sudo docker run -d --net=host \
 --privileged=true \
@@ -115,6 +107,7 @@ ceph/daemon osd
 ```
 
 With KV backend:
+
 ```
 $ sudo docker run -d --net=host \
 --privileged=true \
@@ -127,7 +120,7 @@ $ sudo docker run -d --net=host \
 ceph/daemon osd
 ```
 
-### Ceph disk ###
+### Ceph disk
 
 Without KV backend:
 
@@ -158,19 +151,15 @@ ceph/daemon osd
 
 List of available options:
 
-* `OSD_DEVICE` is the OSD device
-* `OSD_JOURNAL` is the journal for a given OSD
-* `HOSTNAME` is used to place the OSD in the CRUSH map
+- `OSD_DEVICE` is the OSD device
+- `OSD_JOURNAL` is the journal for a given OSD
+- `HOSTNAME` is used to place the OSD in the CRUSH map
 
 If you do not want to use `--privileged=true`, please fall back on the second example.
 
+### Ceph disk activate
 
-### Ceph disk activate ###
-
-This function is balance between ceph-disk and osd directory where the operator can use ceph-disk outside of the container (directly on the host) to prepare the devices.
-Devices will be prepared with `ceph-disk prepare`, then they will get activated inside the container.
-A priviledged container is still required as ceph-disk needs to access /dev/.
-So this has minimum value compare to the ceph-disk but might fit some use cases where the operators want to prepare their devices outside of a container.
+This function is balance between ceph-disk and osd directory where the operator can use ceph-disk outside of the container (directly on the host) to prepare the devices. Devices will be prepared with `ceph-disk prepare`, then they will get activated inside the container. A priviledged container is still required as ceph-disk needs to access /dev/. So this has minimum value compare to the ceph-disk but might fit some use cases where the operators want to prepare their devices outside of a container.
 
 ```
 $ sudo docker run -d --net=host \
@@ -183,70 +172,66 @@ $ sudo docker run -d --net=host \
 ceph/daemon osd
 ```
 
+### Ceph OSD directory
 
-### Ceph OSD directory ###
+There are a number of environment variables which are used to configure the execution of the OSD:
 
-There are a number of environment variables which are used to configure
-the execution of the OSD:
+- `CLUSTER` is the name of the ceph cluster (defaults to `ceph`)
 
-*  `CLUSTER` is the name of the ceph cluster (defaults to `ceph`)
+If the OSD is not already created (key, configuration, OSD data), the following environment variables will control its creation:
 
-If the OSD is not already created (key, configuration, OSD data), the
-following environment variables will control its creation:
+- `WEIGHT` is the of the OSD when it is added to the CRUSH map (default is `1.0`)
+- `JOURNAL` is the location of the journal (default is the `journal` file inside the OSD data directory)
+- `HOSTNAME` is the name of the host; it is used as a flag when adding the OSD to the CRUSH map
 
-* `WEIGHT` is the of the OSD when it is added to the CRUSH map (default is `1.0`)
-* `JOURNAL` is the location of the journal (default is the `journal` file inside the OSD data directory)
-* `HOSTNAME` is the name of the host; it is used as a flag when adding the OSD to the CRUSH map
-
-The old option `OSD_ID` is now unused.  Instead, the script will scan for each directory in `/var/lib/ceph/osd` of the form `<cluster>-<osd-id>`.
+The old option `OSD_ID` is now unused. Instead, the script will scan for each directory in `/var/lib/ceph/osd` of the form `<cluster>-<osd-id>`.
 
 To create your OSDs simply run the following command:
 
 `docker exec <mon-container-id> ceph osd create`.
 
+#### Multiple OSDs
 
-#### Multiple OSDs ####
-
-There is a problem when attempting run run multiple OSD containers on a single docker host.  See issue #19.
+There is a problem when attempting run run multiple OSD containers on a single docker host. See issue #19.
 
 There are two workarounds, at present:
-* Run each OSD with the `--pid=host` option
-* Run multiple OSDs within the same container
+
+- Run each OSD with the `--pid=host` option
+- Run multiple OSDs within the same container
 
 To run multiple OSDs within the same container, simply bind-mount each OSD datastore directory:
-* `docker run -v /osds/1:/var/lib/ceph/osd/ceph-1 -v /osds/2:/var/lib/ceph/osd/ceph-2`
 
+- `docker run -v /osds/1:/var/lib/ceph/osd/ceph-1 -v /osds/2:/var/lib/ceph/osd/ceph-2`
 
-#### BTRFS and journal ####
+#### BTRFS and journal
 
-If your OSD is BTRFS and you want to use PARALLEL journal mode, you will need to run this container with `--privileged` set to true.  Otherwise, `ceph-osd` will have insufficient permissions and it will revert to the slower WRITEAHEAD mode.
+If your OSD is BTRFS and you want to use PARALLEL journal mode, you will need to run this container with `--privileged` set to true. Otherwise, `ceph-osd` will have insufficient permissions and it will revert to the slower WRITEAHEAD mode.
 
+#### Note
 
-#### Note ####
+Re: [<https://github.com/Ulexus/docker-ceph/issues/5>]
 
-Re: [https://github.com/Ulexus/docker-ceph/issues/5]
-
-A user has reported a consterning (and difficult to diagnose) problem wherein the OSD crashes frequently due to Docker running out of sufficient open file handles.  This is understandable, as the OSDs use a great many ports during periods of high traffic.  It is, therefore, recommended that you increase the number of open file handles available to Docker.
+A user has reported a consterning (and difficult to diagnose) problem wherein the OSD crashes frequently due to Docker running out of sufficient open file handles. This is understandable, as the OSDs use a great many ports during periods of high traffic. It is, therefore, recommended that you increase the number of open file handles available to Docker.
 
 On CoreOS (and probably other systemd-based systems), you can do this by creating the a file named `/etc/systemd/system/docker.service.d/limits.conf` with content something like:
 
-      [Service]
-      LimitNOFILE=4096
+```
+[Service]
+LimitNOFILE=4096
+```
 
+## Deploy a MDS
 
-Deploy a MDS
-------------
-
-By default, the MDS does _NOT_ create a ceph filesystem.  If you wish to have this MDS create a ceph filesystem (it will only do this if the specified `CEPHFS_NAME` does not already exist), you _must_ set, at a minimum, `CEPHFS_CREATE=1`.  It is strongly recommended that you read the rest of this section, as well.
+By default, the MDS does _NOT_ create a ceph filesystem. If you wish to have this MDS create a ceph filesystem (it will only do this if the specified `CEPHFS_NAME` does not already exist), you _must_ set, at a minimum, `CEPHFS_CREATE=1`. It is strongly recommended that you read the rest of this section, as well.
 
 For most people, the defaults for the following optional environment variables are fine, but if you wish to customize the data and metadata pools in which your CephFS is stored, you may override the following as you wish:
 
-  * `CEPHFS_CREATE`: Whether to create the ceph filesystem (0 = no / 1 = yes), if it doesn't exist.  Defaults to 0 (no)
-  * `CEPHFS_NAME`: The name of the new ceph filesystem and the basis on which the later variables are created.  Defaults to `cephfs`
-  * `CEPHFS_DATA_POOL`:  The name of the data pool for the ceph filesystem.  If it does not exist, it will be created.  Defaults to `${CEPHFS_NAME}_data`
-  * `CEPHFS_DATA_POOL_PG`:  The number of placement groups for the data pool.  Defaults to `8`
-  * `CEPHFS_METADATA_POOL`:  The name of the metadata pool for the ceph filesystem.  If it does not exist, it will be created.  Defaults to `${CEPHFS_NAME}_metadata`
-  * `CEPHFS_METADATA_POOL_PG`:  The number of placement groups for the metadata pool.  Defaults to `8`
+- `CEPHFS_CREATE`: Whether to create the ceph filesystem (0 = no / 1 = yes), if it doesn't exist. Defaults to 0 (no)
+- `CEPHFS_NAME`: The name of the new ceph filesystem and the basis on which the later variables are created. Defaults to `cephfs`
+- `CEPHFS_DATA_POOL`: The name of the data pool for the ceph filesystem. If it does not exist, it will be created. Defaults to `${CEPHFS_NAME}_data`
+- `CEPHFS_DATA_POOL_PG`: The number of placement groups for the data pool. Defaults to `8`
+- `CEPHFS_METADATA_POOL`: The name of the metadata pool for the ceph filesystem. If it does not exist, it will be created. Defaults to `${CEPHFS_NAME}_metadata`
+- `CEPHFS_METADATA_POOL_PG`: The number of placement groups for the metadata pool. Defaults to `8`
 
 Without KV backend, run:
 
@@ -271,18 +256,11 @@ ceph/daemon mds
 
 List of available options:
 
-* `MDS_NAME` is the name the MDS server (DEFAULT: mds-$(hostname)).
-One thing to note is that metadata servers are not machine-restricted.
-They are not bound by their data directories and can move around the cluster.
-As a result, you can run more than one MDS on a single machine.
-If you plan to do so, you better set this variable and do something like: `mds-$(hostname)-a`, `mds-$(hostname)-b`etc...
+- `MDS_NAME` is the name the MDS server (DEFAULT: mds-$(hostname)). One thing to note is that metadata servers are not machine-restricted. They are not bound by their data directories and can move around the cluster. As a result, you can run more than one MDS on a single machine. If you plan to do so, you better set this variable and do something like: `mds-$(hostname)-a`, `mds-$(hostname)-b`etc...
 
+## Deploy a Rados Gateway
 
-Deploy a Rados Gateway
-----------------------
-
-For the Rados Gateway, we deploy it with `civetweb` enabled by default.
-However it is possible to use different CGI frontends by simply giving remote address and port.
+For the Rados Gateway, we deploy it with `civetweb` enabled by default. However it is possible to use different CGI frontends by simply giving remote address and port.
 
 Without kv backend, run:
 
@@ -305,20 +283,18 @@ ceph/daemon rgw
 
 List of available options:
 
-* `RGW_CIVETWEB_PORT` is the port to which civetweb is listening on (DEFAULT: 80)
-* `RGW_NAME`: default to hostname
+- `RGW_CIVETWEB_PORT` is the port to which civetweb is listening on (DEFAULT: 80)
+- `RGW_NAME`: default to hostname
 
 To enable an external CGI interface instead of civetweb set:
 
-* `RGW_REMOTE_CGI=1`
-* `RGW_REMOTE_CGI_HOST=192.168.0.1`
-* `RGW_REMOTE_CGI_PORT=9000`
+- `RGW_REMOTE_CGI=1`
+- `RGW_REMOTE_CGI_HOST=192.168.0.1`
+- `RGW_REMOTE_CGI_PORT=9000`
 
 And run the container like this `docker run -d -v /etc/ceph:/etc/ceph -v /var/lib/ceph/:/var/lib/ceph -e CEPH_DAEMON=RGW -e RGW_NAME=myrgw -p 9000:9000 -e RGW_REMOTE_CGI=1 -e RGW_REMOTE_CGI_HOST=192.168.0.1 -e RGW_REMOTE_CGI_PORT=9000 ceph/daemon`
 
-
-Deploy a REST API
------------------
+## Deploy a REST API
 
 This is pretty straighforward. The `--net=host` is not mandatory, if you don't use it do not forget to expose the `RESTAPI_PORT`.
 
@@ -331,11 +307,8 @@ ceph/daemon restapi
 
 List of available options:
 
-* `RESTAPI_IP` is the IP address to listen on (DEFAULT: 0.0.0.0)
-* `RESTAPI_PORT` is the listening port of the REST API (DEFAULT: 5000)
-* `RESTAPI_BASE_URL` is the base URL of the API (DEFAULT: /api/v0.1)
-* `RESTAPI_LOG_LEVEL` is the log level of the API (DEFAULT: warning)
-* `RESTAPI_LOG_FILE` is the location of the log file (DEFAULT: /var/log/ceph/ceph-restapi.log)
- 
- 
- 
+- `RESTAPI_IP` is the IP address to listen on (DEFAULT: 0.0.0.0)
+- `RESTAPI_PORT` is the listening port of the REST API (DEFAULT: 5000)
+- `RESTAPI_BASE_URL` is the base URL of the API (DEFAULT: /api/v0.1)
+- `RESTAPI_LOG_LEVEL` is the log level of the API (DEFAULT: warning)
+- `RESTAPI_LOG_FILE` is the location of the log file (DEFAULT: /var/log/ceph/ceph-restapi.log)

--- a/ceph-releases/hammer/ubuntu/14.04/daemon/README.md
+++ b/ceph-releases/hammer/ubuntu/14.04/daemon/README.md
@@ -36,7 +36,7 @@ Important variables in `populate.sh` to change when you bootstrap an OSD:
 Without KV store, run:
 
 ```
-$ sudo docker run -d --net=host \
+docker run -d --net=host \
 -v /etc/ceph:/etc/ceph \
 -v /var/lib/ceph/:/var/lib/ceph/ \
 -e MON_IP=192.168.0.20 \
@@ -47,7 +47,7 @@ ceph/daemon mon
 With KV store, run:
 
 ```
-$ sudo docker run -d --net=host \
+docker run -d --net=host \
 -v /var/lib/ceph/:/var/lib/ceph/ \
 -e MON_IP=192.168.0.20 \
 -e CEPH_PUBLIC_NETWORK=192.168.0.0/24 \
@@ -96,7 +96,7 @@ If the operator does not specify an `OSD_TYPE` autodetection happens:
 Without KV backend:
 
 ```
-$ sudo docker run -d --net=host \
+docker run -d --net=host \
 --privileged=true \
 -v /etc/ceph:/etc/ceph \
 -v /var/lib/ceph/:/var/lib/ceph/ \
@@ -109,7 +109,7 @@ ceph/daemon osd
 With KV backend:
 
 ```
-$ sudo docker run -d --net=host \
+docker run -d --net=host \
 --privileged=true \
 -v /var/lib/ceph/:/var/lib/ceph/ \
 -v /dev/:/dev/ \
@@ -125,7 +125,7 @@ ceph/daemon osd
 Without KV backend:
 
 ```
-$ sudo docker run -d --net=host \
+docker run -d --net=host \
 --privileged=true \
 -v /etc/ceph:/etc/ceph \
 -v /var/lib/ceph/:/var/lib/ceph/ \
@@ -138,7 +138,7 @@ ceph/daemon osd
 With KV backend:
 
 ```
-$ sudo docker run -d --net=host \
+docker run -d --net=host \
 --privileged=true \
 -v /var/lib/ceph/:/var/lib/ceph/ \
 -v /dev/:/dev/ \
@@ -162,7 +162,7 @@ If you do not want to use `--privileged=true`, please fall back on the second ex
 This function is balance between ceph-disk and osd directory where the operator can use ceph-disk outside of the container (directly on the host) to prepare the devices. Devices will be prepared with `ceph-disk prepare`, then they will get activated inside the container. A priviledged container is still required as ceph-disk needs to access /dev/. So this has minimum value compare to the ceph-disk but might fit some use cases where the operators want to prepare their devices outside of a container.
 
 ```
-$ sudo docker run -d --net=host \
+docker run -d --net=host \
 --privileged=true \
 -v /etc/ceph:/etc/ceph \
 -v /var/lib/ceph/:/var/lib/ceph/ \
@@ -236,7 +236,7 @@ For most people, the defaults for the following optional environment variables a
 Without KV backend, run:
 
 ```
-$ sudo docker run -d --net=host \
+docker run -d --net=host \
 -v /var/lib/ceph/:/var/lib/ceph/ \
 -v /etc/ceph:/etc/ceph \
 -e CEPHFS_CREATE=1 \
@@ -246,7 +246,7 @@ ceph/daemon mds
 Without KV backend, run:
 
 ```
-$ sudo docker run -d --net=host \
+docker run -d --net=host \
 -v /var/lib/ceph/:/var/lib/ceph/ \
 -e CEPHFS_CREATE=1 \
 -e KV_TYPE=etcd \
@@ -265,7 +265,7 @@ For the Rados Gateway, we deploy it with `civetweb` enabled by default. However 
 Without kv backend, run:
 
 ```
-$ sudo docker run -d --net=host \
+docker run -d --net=host \
 -v /var/lib/ceph/:/var/lib/ceph/ \
 -v /etc/ceph:/etc/ceph \
 ceph/daemon rgw
@@ -274,7 +274,7 @@ ceph/daemon rgw
 With kv backend, run:
 
 ```
-$ sudo docker run -d --net=host \
+docker run -d --net=host \
 -v /var/lib/ceph/:/var/lib/ceph/ \
 -e KV_TYPE=etcd \
 -e KV_IP=192.168.0.20 \
@@ -299,7 +299,7 @@ And run the container like this `docker run -d -v /etc/ceph:/etc/ceph -v /var/li
 This is pretty straighforward. The `--net=host` is not mandatory, if you don't use it do not forget to expose the `RESTAPI_PORT`.
 
 ```
-$ sudo docker run -d --net=host \
+docker run -d --net=host \
 -e KV_TYPE=etcd \
 -e KV_IP=192.168.0.20 \
 ceph/daemon restapi

--- a/ceph-releases/hammer/ubuntu/14.04/demo/README.md
+++ b/ceph-releases/hammer/ubuntu/14.04/demo/README.md
@@ -1,39 +1,30 @@
-Demo container
-==============
+# Demo container
 
 This Dockerfile may be used to bootstrap a Ceph cluster with all the Ceph daemons running.
 
 **/!\ THIS CONTAINER IS NOT RECOMMENDED FOR PRODUCTION USAGE /!\**
 
-The main purpose of this container is to quickly get a Ceph cluster up and running by reducing all the setup steps.
-The container provides all the Ceph daemons, so you can rapidly start playing with Ceph.
+The main purpose of this container is to quickly get a Ceph cluster up and running by reducing all the setup steps. The container provides all the Ceph daemons, so you can rapidly start playing with Ceph.
 
-
-Usage
------
+## Usage
 
 The environment variables `MON_NAME` and `MON_IP` are required:
 
-*  `MON_NAME` is the name of the monitor (DEFAULT: hostname)
-*  `MON_IP` is the IP address of the monitor (public)
-*  `RGW_NAME` is the name of rados gateway instance (DEFAULT: hostname)
-*  `RGW_CIVETWEB_PORT` is the port of the rados gateway (DEFAULT: 80)
-*  `CLUSTER` is the name of the cluster (DEFAULT: ceph)
-*  `CEPH_PUBLIC_NETWORK` is the network where the OSD should communicate
+- `MON_NAME` is the name of the monitor (DEFAULT: hostname)
+- `MON_IP` is the IP address of the monitor (public)
+- `RGW_NAME` is the name of rados gateway instance (DEFAULT: hostname)
+- `RGW_CIVETWEB_PORT` is the port of the rados gateway (DEFAULT: 80)
+- `CLUSTER` is the name of the cluster (DEFAULT: ceph)
+- `CEPH_PUBLIC_NETWORK` is the network where the OSD should communicate
 
-Commonly, you will want to bind-mount your host's `/etc/ceph` into the container.
-For example:
+Commonly, you will want to bind-mount your host's `/etc/ceph` into the container. For example:
 
 `docker run -d --net=host -v /etc/ceph:/etc/ceph -e MON_IP=192.168.0.20 -e CEPH_PUBLIC_NETWORK=192.168.0.0/24 ceph/demo`
 
-
-Tip
----
+## Tip
 
 If you get user_xattr error, try to remount your docker partition:
+
 ```
 $ sudo mount -o remount,user_xattr,rw $(df -P /var/lib/docker |tail -1 |tr -s ' ' |cut -d' ' -f6)
 ```
- 
- 
- 

--- a/ceph-releases/hammer/ubuntu/14.04/demo/README.md
+++ b/ceph-releases/hammer/ubuntu/14.04/demo/README.md
@@ -26,5 +26,5 @@ Commonly, you will want to bind-mount your host's `/etc/ceph` into the container
 If you get user_xattr error, try to remount your docker partition:
 
 ```
-$ sudo mount -o remount,user_xattr,rw $(df -P /var/lib/docker |tail -1 |tr -s ' ' |cut -d' ' -f6)
+sudo mount -o remount,user_xattr,rw $(df -P /var/lib/docker |tail -1 |tr -s ' ' |cut -d' ' -f6)
 ```

--- a/ceph-releases/hammer/ubuntu/16.04/base/README.md
+++ b/ceph-releases/hammer/ubuntu/16.04/base/README.md
@@ -9,5 +9,5 @@ Ceph base image (ubuntu 16.04 with the latest Ceph release installed).
 ## Usage (example)
 
 ```bash
-$ docker run -i -t ceph/base
+docker run -i -t ceph/base
 ```

--- a/ceph-releases/hammer/ubuntu/16.04/base/README.md
+++ b/ceph-releases/hammer/ubuntu/16.04/base/README.md
@@ -4,12 +4,10 @@ Ceph base image (ubuntu 16.04 with the latest Ceph release installed).
 
 ## Docker Hub/Registry location
 
-https://registry.hub.docker.com/u/ceph/base/
+<https://registry.hub.docker.com/u/ceph/base/>
 
 ## Usage (example)
 
 ```bash
 $ docker run -i -t ceph/base
 ```
-
- 

--- a/ceph-releases/infernalis/centos/7/base/README.md
+++ b/ceph-releases/infernalis/centos/7/base/README.md
@@ -4,12 +4,10 @@ Ceph base image (CentOS (latest) with the latest Ceph release installed).
 
 ## Docker Hub/Registry location
 
-https://registry.hub.docker.com/u/ceph/base/
+<https://registry.hub.docker.com/u/ceph/base/>
 
 ## Usage (example)
 
 ```bash
 $ docker run -i -t ceph/base
 ```
-
- 

--- a/ceph-releases/infernalis/centos/7/base/README.md
+++ b/ceph-releases/infernalis/centos/7/base/README.md
@@ -9,5 +9,5 @@ Ceph base image (CentOS (latest) with the latest Ceph release installed).
 ## Usage (example)
 
 ```bash
-$ docker run -i -t ceph/base
+docker run -i -t ceph/base
 ```

--- a/ceph-releases/infernalis/ubuntu/14.04/base/README.md
+++ b/ceph-releases/infernalis/ubuntu/14.04/base/README.md
@@ -9,5 +9,5 @@ Ceph base image (ubuntu 14.04 with the latest Ceph release installed).
 ## Usage (example)
 
 ```bash
-$ docker run -i -t ceph/base
+docker run -i -t ceph/base
 ```

--- a/ceph-releases/infernalis/ubuntu/14.04/base/README.md
+++ b/ceph-releases/infernalis/ubuntu/14.04/base/README.md
@@ -4,12 +4,10 @@ Ceph base image (ubuntu 14.04 with the latest Ceph release installed).
 
 ## Docker Hub/Registry location
 
-https://registry.hub.docker.com/u/ceph/base/
+<https://registry.hub.docker.com/u/ceph/base/>
 
 ## Usage (example)
 
 ```bash
 $ docker run -i -t ceph/base
 ```
-
- 

--- a/ceph-releases/infernalis/ubuntu/14.04/daemon/README.md
+++ b/ceph-releases/infernalis/ubuntu/14.04/daemon/README.md
@@ -1,47 +1,37 @@
-Daemon container
-================
+# Daemon container
 
-This Dockerfile may be used to bootstrap a Ceph cluster with all the Ceph daemons running.
-To run a certain type of daemon, simply use the name of the daemon as `$1`.
-Valid values are:
+This Dockerfile may be used to bootstrap a Ceph cluster with all the Ceph daemons running. To run a certain type of daemon, simply use the name of the daemon as `$1`. Valid values are:
 
-* `mon` deploys a Ceph monitor
-* `osd` deploys an OSD using the method specified by `OSD_TYPE`
-* `osd_directory` deploys an OSD using a prepared directory (used in scenario where the operator doesn't want to use `--privileged=true`)
-* `osd_ceph_disk` deploys an OSD using ceph-disk, so you have to provide a whole device (ie: /dev/sdb)
-* `mds` deploys a MDS
-* `rgw` deploys a Rados Gateway
+- `mon` deploys a Ceph monitor
+- `osd` deploys an OSD using the method specified by `OSD_TYPE`
+- `osd_directory` deploys an OSD using a prepared directory (used in scenario where the operator doesn't want to use `--privileged=true`)
+- `osd_ceph_disk` deploys an OSD using ceph-disk, so you have to provide a whole device (ie: /dev/sdb)
+- `mds` deploys a MDS
+- `rgw` deploys a Rados Gateway
 
-
-Usage
------
+## Usage
 
 You can use this container to bootstrap any Ceph daemon.
 
-* `CLUSTER` is the name of the cluster (DEFAULT: ceph)
-* `HOSTNAME` is the hostname of the machine  (DEFAULT: $(hostname))
+- `CLUSTER` is the name of the cluster (DEFAULT: ceph)
+- `HOSTNAME` is the hostname of the machine (DEFAULT: $(hostname))
 
-
-KV backends
------------
+## KV backends
 
 We currently support 2 KV backends to store our configuration flags, keys and maps:
 
-* etcd
-* consul
+- etcd
+- consul
 
-Prior to deploy your monitors, you have to populate your kv store with the help of the script `populate.sh` in examples/confd.
-As soon as this done, you can bootstrap your first monitor.
+Prior to deploy your monitors, you have to populate your kv store with the help of the script `populate.sh` in examples/confd. As soon as this done, you can bootstrap your first monitor.
 
 Important variables in `populate.sh` to change when you bootstrap an OSD:
 
-* `/osd/osd_journal_size`
-* `/osd/cluster_network`
-* `/osd/public_network`
+- `/osd/osd_journal_size`
+- `/osd/cluster_network`
+- `/osd/public_network`
 
-
-Deploy a monitor
-----------------
+## Deploy a monitor
 
 Without KV store, run:
 
@@ -68,41 +58,43 @@ ceph/daemon mon
 
 List of available options:
 
-* `MON_NAME`: name of the monitor (default to hostname)
-* `CEPH_PUBLIC_NETWORK`: CIDR of the host running Docker, it should be in the same network as the `MON_IP`
-* `CEPH_CLUSTER_NETWORK`: CIDR of a secondary interface of the host running Docker. Used for the OSD replication traffic
-* `MON_IP`: IP address of the host running Docker
-* `MON_IP_AUTO_DETECT`: Whether and how to attempt IP autodetection.
-    *  0 = Do not detect (default)
-    *  1 = Detect IPv6, fallback to IPv4 (if no globally-routable IPv6 address detected)
-    *  4 = Detect IPv4 only
-    *  6 = Detect IPv6 only
+- `MON_NAME`: name of the monitor (default to hostname)
+- `CEPH_PUBLIC_NETWORK`: CIDR of the host running Docker, it should be in the same network as the `MON_IP`
+- `CEPH_CLUSTER_NETWORK`: CIDR of a secondary interface of the host running Docker. Used for the OSD replication traffic
+- `MON_IP`: IP address of the host running Docker
+- `MON_IP_AUTO_DETECT`: Whether and how to attempt IP autodetection.
 
+  - 0 = Do not detect (default)
+  - 1 = Detect IPv6, fallback to IPv4 (if no globally-routable IPv6 address detected)
+  - 4 = Detect IPv4 only
+  - 6 = Detect IPv6 only
 
-Deploy an OSD
--------------
+## Deploy an OSD
 
 There are four available `OSD_TYPE` values:
 
-* `<none>` - if no `OSD_TYPE` is set; one of `disk`, `activate` or `directory` will be used based on autodetection of the current OSD bootstrap state
-* `activate` - the daemon expects to be passed a block device of a `ceph-disk`-prepared disk (via the `OSD_DEVICE` environment variable); no bootstrapping will be performed
-* `directory` - the daemon expects to find the OSD filesystem(s) already mounted in `/var/lib/ceph/osd/`
-* `disk` - the daemon expects to be passed a block device via the `OSD_DEVICE` environment variable
+- `<none>` - if no `OSD_TYPE` is set; one of `disk`, `activate` or `directory` will be used based on autodetection of the current OSD bootstrap state
+- `activate` - the daemon expects to be passed a block device of a `ceph-disk`-prepared disk (via the `OSD_DEVICE` environment variable); no bootstrapping will be performed
+- `directory` - the daemon expects to find the OSD filesystem(s) already mounted in `/var/lib/ceph/osd/`
+- `disk` - the daemon expects to be passed a block device via the `OSD_DEVICE` environment variable
 
 Options for OSDs (TODO: consolidate these options between the types):
-* `JOURNAL_DIR` - if provided, new OSDs will be bootstrapped to use the specified directory as a common journal area.  This is usually used to store the journals for more than one OSD on a common, separate disk.  This currently only applies to the `directory` OSD type.
-* `JOURNAL` - if provided, the new OSD will be bootstrapped to use the specified journal file (if you do not wish to use the default).  This is currently only supported by the `directory` OSD type
-* `OSD_DEVICE` - mandatory for `activate` and `disk` OSD types; this specifies which block device to use as the OSD
-* `OSD_JOURNAL` - optional override of the OSD journal file. this only applies to the `activate` and `disk` OSD types
 
-### Without OSD_TYPE ###
+- `JOURNAL_DIR` - if provided, new OSDs will be bootstrapped to use the specified directory as a common journal area. This is usually used to store the journals for more than one OSD on a common, separate disk. This currently only applies to the `directory` OSD type.
+- `JOURNAL` - if provided, the new OSD will be bootstrapped to use the specified journal file (if you do not wish to use the default). This is currently only supported by the `directory` OSD type
+- `OSD_DEVICE` - mandatory for `activate` and `disk` OSD types; this specifies which block device to use as the OSD
+- `OSD_JOURNAL` - optional override of the OSD journal file. this only applies to the `activate` and `disk` OSD types
+
+### Without OSD_TYPE
 
 If the operator does not specify an `OSD_TYPE` autodetection happens:
+
 - `disk` is used if no bootstrapped OSD is found. `OSD_FORCE_ZAP=1` must be set at this point.
 - `activate` is used if a bootstrapped OSD is found and `OSD_DEVICE` is also provided.
 - `directory` is used if a bootstrapped OSD is found and no `OSD_DEVICE` is provided.
 
 Without KV backend:
+
 ```
 $ sudo docker run -d --net=host \
 --privileged=true \
@@ -115,6 +107,7 @@ ceph/daemon osd
 ```
 
 With KV backend:
+
 ```
 $ sudo docker run -d --net=host \
 --privileged=true \
@@ -127,7 +120,7 @@ $ sudo docker run -d --net=host \
 ceph/daemon osd
 ```
 
-### Ceph disk ###
+### Ceph disk
 
 Without KV backend:
 
@@ -158,19 +151,15 @@ ceph/daemon osd
 
 List of available options:
 
-* `OSD_DEVICE` is the OSD device
-* `OSD_JOURNAL` is the journal for a given OSD
-* `HOSTNAME` is used to place the OSD in the CRUSH map
+- `OSD_DEVICE` is the OSD device
+- `OSD_JOURNAL` is the journal for a given OSD
+- `HOSTNAME` is used to place the OSD in the CRUSH map
 
 If you do not want to use `--privileged=true`, please fall back on the second example.
 
+### Ceph disk activate
 
-### Ceph disk activate ###
-
-This function is balance between ceph-disk and osd directory where the operator can use ceph-disk outside of the container (directly on the host) to prepare the devices.
-Devices will be prepared with `ceph-disk prepare`, then they will get activated inside the container.
-A priviledged container is still required as ceph-disk needs to access /dev/.
-So this has minimum value compare to the ceph-disk but might fit some use cases where the operators want to prepare their devices outside of a container.
+This function is balance between ceph-disk and osd directory where the operator can use ceph-disk outside of the container (directly on the host) to prepare the devices. Devices will be prepared with `ceph-disk prepare`, then they will get activated inside the container. A priviledged container is still required as ceph-disk needs to access /dev/. So this has minimum value compare to the ceph-disk but might fit some use cases where the operators want to prepare their devices outside of a container.
 
 ```
 $ sudo docker run -d --net=host \
@@ -183,70 +172,66 @@ $ sudo docker run -d --net=host \
 ceph/daemon osd
 ```
 
+### Ceph OSD directory
 
-### Ceph OSD directory ###
+There are a number of environment variables which are used to configure the execution of the OSD:
 
-There are a number of environment variables which are used to configure
-the execution of the OSD:
+- `CLUSTER` is the name of the ceph cluster (defaults to `ceph`)
 
-*  `CLUSTER` is the name of the ceph cluster (defaults to `ceph`)
+If the OSD is not already created (key, configuration, OSD data), the following environment variables will control its creation:
 
-If the OSD is not already created (key, configuration, OSD data), the
-following environment variables will control its creation:
+- `WEIGHT` is the of the OSD when it is added to the CRUSH map (default is `1.0`)
+- `JOURNAL` is the location of the journal (default is the `journal` file inside the OSD data directory)
+- `HOSTNAME` is the name of the host; it is used as a flag when adding the OSD to the CRUSH map
 
-* `WEIGHT` is the of the OSD when it is added to the CRUSH map (default is `1.0`)
-* `JOURNAL` is the location of the journal (default is the `journal` file inside the OSD data directory)
-* `HOSTNAME` is the name of the host; it is used as a flag when adding the OSD to the CRUSH map
-
-The old option `OSD_ID` is now unused.  Instead, the script will scan for each directory in `/var/lib/ceph/osd` of the form `<cluster>-<osd-id>`.
+The old option `OSD_ID` is now unused. Instead, the script will scan for each directory in `/var/lib/ceph/osd` of the form `<cluster>-<osd-id>`.
 
 To create your OSDs simply run the following command:
 
 `docker exec <mon-container-id> ceph osd create`.
 
+#### Multiple OSDs
 
-#### Multiple OSDs ####
-
-There is a problem when attempting run run multiple OSD containers on a single docker host.  See issue #19.
+There is a problem when attempting run run multiple OSD containers on a single docker host. See issue #19.
 
 There are two workarounds, at present:
-* Run each OSD with the `--pid=host` option
-* Run multiple OSDs within the same container
+
+- Run each OSD with the `--pid=host` option
+- Run multiple OSDs within the same container
 
 To run multiple OSDs within the same container, simply bind-mount each OSD datastore directory:
-* `docker run -v /osds/1:/var/lib/ceph/osd/ceph-1 -v /osds/2:/var/lib/ceph/osd/ceph-2`
 
+- `docker run -v /osds/1:/var/lib/ceph/osd/ceph-1 -v /osds/2:/var/lib/ceph/osd/ceph-2`
 
-#### BTRFS and journal ####
+#### BTRFS and journal
 
-If your OSD is BTRFS and you want to use PARALLEL journal mode, you will need to run this container with `--privileged` set to true.  Otherwise, `ceph-osd` will have insufficient permissions and it will revert to the slower WRITEAHEAD mode.
+If your OSD is BTRFS and you want to use PARALLEL journal mode, you will need to run this container with `--privileged` set to true. Otherwise, `ceph-osd` will have insufficient permissions and it will revert to the slower WRITEAHEAD mode.
 
+#### Note
 
-#### Note ####
+Re: [<https://github.com/Ulexus/docker-ceph/issues/5>]
 
-Re: [https://github.com/Ulexus/docker-ceph/issues/5]
-
-A user has reported a consterning (and difficult to diagnose) problem wherein the OSD crashes frequently due to Docker running out of sufficient open file handles.  This is understandable, as the OSDs use a great many ports during periods of high traffic.  It is, therefore, recommended that you increase the number of open file handles available to Docker.
+A user has reported a consterning (and difficult to diagnose) problem wherein the OSD crashes frequently due to Docker running out of sufficient open file handles. This is understandable, as the OSDs use a great many ports during periods of high traffic. It is, therefore, recommended that you increase the number of open file handles available to Docker.
 
 On CoreOS (and probably other systemd-based systems), you can do this by creating the a file named `/etc/systemd/system/docker.service.d/limits.conf` with content something like:
 
-      [Service]
-      LimitNOFILE=4096
+```
+[Service]
+LimitNOFILE=4096
+```
 
+## Deploy a MDS
 
-Deploy a MDS
-------------
-
-By default, the MDS does _NOT_ create a ceph filesystem.  If you wish to have this MDS create a ceph filesystem (it will only do this if the specified `CEPHFS_NAME` does not already exist), you _must_ set, at a minimum, `CEPHFS_CREATE=1`.  It is strongly recommended that you read the rest of this section, as well.
+By default, the MDS does _NOT_ create a ceph filesystem. If you wish to have this MDS create a ceph filesystem (it will only do this if the specified `CEPHFS_NAME` does not already exist), you _must_ set, at a minimum, `CEPHFS_CREATE=1`. It is strongly recommended that you read the rest of this section, as well.
 
 For most people, the defaults for the following optional environment variables are fine, but if you wish to customize the data and metadata pools in which your CephFS is stored, you may override the following as you wish:
 
-  * `CEPHFS_CREATE`: Whether to create the ceph filesystem (0 = no / 1 = yes), if it doesn't exist.  Defaults to 0 (no)
-  * `CEPHFS_NAME`: The name of the new ceph filesystem and the basis on which the later variables are created.  Defaults to `cephfs`
-  * `CEPHFS_DATA_POOL`:  The name of the data pool for the ceph filesystem.  If it does not exist, it will be created.  Defaults to `${CEPHFS_NAME}_data`
-  * `CEPHFS_DATA_POOL_PG`:  The number of placement groups for the data pool.  Defaults to `8`
-  * `CEPHFS_METADATA_POOL`:  The name of the metadata pool for the ceph filesystem.  If it does not exist, it will be created.  Defaults to `${CEPHFS_NAME}_metadata`
-  * `CEPHFS_METADATA_POOL_PG`:  The number of placement groups for the metadata pool.  Defaults to `8`
+- `CEPHFS_CREATE`: Whether to create the ceph filesystem (0 = no / 1 = yes), if it doesn't exist. Defaults to 0 (no)
+- `CEPHFS_NAME`: The name of the new ceph filesystem and the basis on which the later variables are created. Defaults to `cephfs`
+- `CEPHFS_DATA_POOL`: The name of the data pool for the ceph filesystem. If it does not exist, it will be created. Defaults to `${CEPHFS_NAME}_data`
+- `CEPHFS_DATA_POOL_PG`: The number of placement groups for the data pool. Defaults to `8`
+- `CEPHFS_METADATA_POOL`: The name of the metadata pool for the ceph filesystem. If it does not exist, it will be created. Defaults to `${CEPHFS_NAME}_metadata`
+- `CEPHFS_METADATA_POOL_PG`: The number of placement groups for the metadata pool. Defaults to `8`
 
 Without KV backend, run:
 
@@ -271,18 +256,11 @@ ceph/daemon mds
 
 List of available options:
 
-* `MDS_NAME` is the name the MDS server (DEFAULT: mds-$(hostname)).
-One thing to note is that metadata servers are not machine-restricted.
-They are not bound by their data directories and can move around the cluster.
-As a result, you can run more than one MDS on a single machine.
-If you plan to do so, you better set this variable and do something like: `mds-$(hostname)-a`, `mds-$(hostname)-b`etc...
+- `MDS_NAME` is the name the MDS server (DEFAULT: mds-$(hostname)). One thing to note is that metadata servers are not machine-restricted. They are not bound by their data directories and can move around the cluster. As a result, you can run more than one MDS on a single machine. If you plan to do so, you better set this variable and do something like: `mds-$(hostname)-a`, `mds-$(hostname)-b`etc...
 
+## Deploy a Rados Gateway
 
-Deploy a Rados Gateway
-----------------------
-
-For the Rados Gateway, we deploy it with `civetweb` enabled by default.
-However it is possible to use different CGI frontends by simply giving remote address and port.
+For the Rados Gateway, we deploy it with `civetweb` enabled by default. However it is possible to use different CGI frontends by simply giving remote address and port.
 
 Without kv backend, run:
 
@@ -305,20 +283,18 @@ ceph/daemon rgw
 
 List of available options:
 
-* `RGW_CIVETWEB_PORT` is the port to which civetweb is listening on (DEFAULT: 80)
-* `RGW_NAME`: default to hostname
+- `RGW_CIVETWEB_PORT` is the port to which civetweb is listening on (DEFAULT: 80)
+- `RGW_NAME`: default to hostname
 
 To enable an external CGI interface instead of civetweb set:
 
-* `RGW_REMOTE_CGI=1`
-* `RGW_REMOTE_CGI_HOST=192.168.0.1`
-* `RGW_REMOTE_CGI_PORT=9000`
+- `RGW_REMOTE_CGI=1`
+- `RGW_REMOTE_CGI_HOST=192.168.0.1`
+- `RGW_REMOTE_CGI_PORT=9000`
 
 And run the container like this `docker run -d -v /etc/ceph:/etc/ceph -v /var/lib/ceph/:/var/lib/ceph -e CEPH_DAEMON=RGW -e RGW_NAME=myrgw -p 9000:9000 -e RGW_REMOTE_CGI=1 -e RGW_REMOTE_CGI_HOST=192.168.0.1 -e RGW_REMOTE_CGI_PORT=9000 ceph/daemon`
 
-
-Deploy a REST API
------------------
+## Deploy a REST API
 
 This is pretty straighforward. The `--net=host` is not mandatory, if you don't use it do not forget to expose the `RESTAPI_PORT`.
 
@@ -331,11 +307,8 @@ ceph/daemon restapi
 
 List of available options:
 
-* `RESTAPI_IP` is the IP address to listen on (DEFAULT: 0.0.0.0)
-* `RESTAPI_PORT` is the listening port of the REST API (DEFAULT: 5000)
-* `RESTAPI_BASE_URL` is the base URL of the API (DEFAULT: /api/v0.1)
-* `RESTAPI_LOG_LEVEL` is the log level of the API (DEFAULT: warning)
-* `RESTAPI_LOG_FILE` is the location of the log file (DEFAULT: /var/log/ceph/ceph-restapi.log)
- 
- 
- 
+- `RESTAPI_IP` is the IP address to listen on (DEFAULT: 0.0.0.0)
+- `RESTAPI_PORT` is the listening port of the REST API (DEFAULT: 5000)
+- `RESTAPI_BASE_URL` is the base URL of the API (DEFAULT: /api/v0.1)
+- `RESTAPI_LOG_LEVEL` is the log level of the API (DEFAULT: warning)
+- `RESTAPI_LOG_FILE` is the location of the log file (DEFAULT: /var/log/ceph/ceph-restapi.log)

--- a/ceph-releases/infernalis/ubuntu/14.04/daemon/README.md
+++ b/ceph-releases/infernalis/ubuntu/14.04/daemon/README.md
@@ -36,7 +36,7 @@ Important variables in `populate.sh` to change when you bootstrap an OSD:
 Without KV store, run:
 
 ```
-$ sudo docker run -d --net=host \
+docker run -d --net=host \
 -v /etc/ceph:/etc/ceph \
 -v /var/lib/ceph/:/var/lib/ceph/ \
 -e MON_IP=192.168.0.20 \
@@ -47,7 +47,7 @@ ceph/daemon mon
 With KV store, run:
 
 ```
-$ sudo docker run -d --net=host \
+docker run -d --net=host \
 -v /var/lib/ceph/:/var/lib/ceph/ \
 -e MON_IP=192.168.0.20 \
 -e CEPH_PUBLIC_NETWORK=192.168.0.0/24 \
@@ -96,7 +96,7 @@ If the operator does not specify an `OSD_TYPE` autodetection happens:
 Without KV backend:
 
 ```
-$ sudo docker run -d --net=host \
+docker run -d --net=host \
 --privileged=true \
 -v /etc/ceph:/etc/ceph \
 -v /var/lib/ceph/:/var/lib/ceph/ \
@@ -109,7 +109,7 @@ ceph/daemon osd
 With KV backend:
 
 ```
-$ sudo docker run -d --net=host \
+docker run -d --net=host \
 --privileged=true \
 -v /var/lib/ceph/:/var/lib/ceph/ \
 -v /dev/:/dev/ \
@@ -125,7 +125,7 @@ ceph/daemon osd
 Without KV backend:
 
 ```
-$ sudo docker run -d --net=host \
+docker run -d --net=host \
 --privileged=true \
 -v /etc/ceph:/etc/ceph \
 -v /var/lib/ceph/:/var/lib/ceph/ \
@@ -138,7 +138,7 @@ ceph/daemon osd
 With KV backend:
 
 ```
-$ sudo docker run -d --net=host \
+docker run -d --net=host \
 --privileged=true \
 -v /var/lib/ceph/:/var/lib/ceph/ \
 -v /dev/:/dev/ \
@@ -162,7 +162,7 @@ If you do not want to use `--privileged=true`, please fall back on the second ex
 This function is balance between ceph-disk and osd directory where the operator can use ceph-disk outside of the container (directly on the host) to prepare the devices. Devices will be prepared with `ceph-disk prepare`, then they will get activated inside the container. A priviledged container is still required as ceph-disk needs to access /dev/. So this has minimum value compare to the ceph-disk but might fit some use cases where the operators want to prepare their devices outside of a container.
 
 ```
-$ sudo docker run -d --net=host \
+docker run -d --net=host \
 --privileged=true \
 -v /etc/ceph:/etc/ceph \
 -v /var/lib/ceph/:/var/lib/ceph/ \
@@ -236,7 +236,7 @@ For most people, the defaults for the following optional environment variables a
 Without KV backend, run:
 
 ```
-$ sudo docker run -d --net=host \
+docker run -d --net=host \
 -v /var/lib/ceph/:/var/lib/ceph/ \
 -v /etc/ceph:/etc/ceph \
 -e CEPHFS_CREATE=1 \
@@ -246,7 +246,7 @@ ceph/daemon mds
 Without KV backend, run:
 
 ```
-$ sudo docker run -d --net=host \
+docker run -d --net=host \
 -v /var/lib/ceph/:/var/lib/ceph/ \
 -e CEPHFS_CREATE=1 \
 -e KV_TYPE=etcd \
@@ -265,7 +265,7 @@ For the Rados Gateway, we deploy it with `civetweb` enabled by default. However 
 Without kv backend, run:
 
 ```
-$ sudo docker run -d --net=host \
+docker run -d --net=host \
 -v /var/lib/ceph/:/var/lib/ceph/ \
 -v /etc/ceph:/etc/ceph \
 ceph/daemon rgw
@@ -274,7 +274,7 @@ ceph/daemon rgw
 With kv backend, run:
 
 ```
-$ sudo docker run -d --net=host \
+docker run -d --net=host \
 -v /var/lib/ceph/:/var/lib/ceph/ \
 -e KV_TYPE=etcd \
 -e KV_IP=192.168.0.20 \
@@ -299,7 +299,7 @@ And run the container like this `docker run -d -v /etc/ceph:/etc/ceph -v /var/li
 This is pretty straighforward. The `--net=host` is not mandatory, if you don't use it do not forget to expose the `RESTAPI_PORT`.
 
 ```
-$ sudo docker run -d --net=host \
+docker run -d --net=host \
 -e KV_TYPE=etcd \
 -e KV_IP=192.168.0.20 \
 ceph/daemon restapi

--- a/ceph-releases/infernalis/ubuntu/14.04/demo/README.md
+++ b/ceph-releases/infernalis/ubuntu/14.04/demo/README.md
@@ -1,39 +1,30 @@
-Demo container
-==============
+# Demo container
 
 This Dockerfile may be used to bootstrap a Ceph cluster with all the Ceph daemons running.
 
 **/!\ THIS CONTAINER IS NOT RECOMMENDED FOR PRODUCTION USAGE /!\**
 
-The main purpose of this container is to quickly get a Ceph cluster up and running by reducing all the setup steps.
-The container provides all the Ceph daemons, so you can rapidly start playing with Ceph.
+The main purpose of this container is to quickly get a Ceph cluster up and running by reducing all the setup steps. The container provides all the Ceph daemons, so you can rapidly start playing with Ceph.
 
-
-Usage
------
+## Usage
 
 The environment variables `MON_NAME` and `MON_IP` are required:
 
-*  `MON_NAME` is the name of the monitor (DEFAULT: hostname)
-*  `MON_IP` is the IP address of the monitor (public)
-*  `RGW_NAME` is the name of rados gateway instance (DEFAULT: hostname)
-*  `RGW_CIVETWEB_PORT` is the port of the rados gateway (DEFAULT: 80)
-*  `CLUSTER` is the name of the cluster (DEFAULT: ceph)
-*  `CEPH_PUBLIC_NETWORK` is the network where the OSD should communicate
+- `MON_NAME` is the name of the monitor (DEFAULT: hostname)
+- `MON_IP` is the IP address of the monitor (public)
+- `RGW_NAME` is the name of rados gateway instance (DEFAULT: hostname)
+- `RGW_CIVETWEB_PORT` is the port of the rados gateway (DEFAULT: 80)
+- `CLUSTER` is the name of the cluster (DEFAULT: ceph)
+- `CEPH_PUBLIC_NETWORK` is the network where the OSD should communicate
 
-Commonly, you will want to bind-mount your host's `/etc/ceph` into the container.
-For example:
+Commonly, you will want to bind-mount your host's `/etc/ceph` into the container. For example:
 
 `docker run -d --net=host -v /etc/ceph:/etc/ceph -e MON_IP=192.168.0.20 -e CEPH_PUBLIC_NETWORK=192.168.0.0/24 ceph/demo`
 
-
-Tip
----
+## Tip
 
 If you get user_xattr error, try to remount your docker partition:
+
 ```
 $ sudo mount -o remount,user_xattr,rw $(df -P /var/lib/docker |tail -1 |tr -s ' ' |cut -d' ' -f6)
 ```
- 
- 
- 

--- a/ceph-releases/infernalis/ubuntu/14.04/demo/README.md
+++ b/ceph-releases/infernalis/ubuntu/14.04/demo/README.md
@@ -26,5 +26,5 @@ Commonly, you will want to bind-mount your host's `/etc/ceph` into the container
 If you get user_xattr error, try to remount your docker partition:
 
 ```
-$ sudo mount -o remount,user_xattr,rw $(df -P /var/lib/docker |tail -1 |tr -s ' ' |cut -d' ' -f6)
+sudo mount -o remount,user_xattr,rw $(df -P /var/lib/docker |tail -1 |tr -s ' ' |cut -d' ' -f6)
 ```

--- a/ceph-releases/infernalis/ubuntu/16.04/base/README.md
+++ b/ceph-releases/infernalis/ubuntu/16.04/base/README.md
@@ -9,5 +9,5 @@ Ceph base image (ubuntu 16.04 with the latest Ceph release installed).
 ## Usage (example)
 
 ```bash
-$ docker run -i -t ceph/base
+docker run -i -t ceph/base
 ```

--- a/ceph-releases/infernalis/ubuntu/16.04/base/README.md
+++ b/ceph-releases/infernalis/ubuntu/16.04/base/README.md
@@ -4,12 +4,10 @@ Ceph base image (ubuntu 16.04 with the latest Ceph release installed).
 
 ## Docker Hub/Registry location
 
-https://registry.hub.docker.com/u/ceph/base/
+<https://registry.hub.docker.com/u/ceph/base/>
 
 ## Usage (example)
 
 ```bash
 $ docker run -i -t ceph/base
 ```
-
- 

--- a/ceph-releases/jewel/centos/7/base/README.md
+++ b/ceph-releases/jewel/centos/7/base/README.md
@@ -4,12 +4,10 @@ Ceph base image (CentOS (latest) with the latest Ceph release installed).
 
 ## Docker Hub/Registry location
 
-https://registry.hub.docker.com/u/ceph/base/
+<https://registry.hub.docker.com/u/ceph/base/>
 
 ## Usage (example)
 
 ```bash
 $ docker run -i -t ceph/base
 ```
-
- 

--- a/ceph-releases/jewel/centos/7/base/README.md
+++ b/ceph-releases/jewel/centos/7/base/README.md
@@ -9,5 +9,5 @@ Ceph base image (CentOS (latest) with the latest Ceph release installed).
 ## Usage (example)
 
 ```bash
-$ docker run -i -t ceph/base
+docker run -i -t ceph/base
 ```

--- a/ceph-releases/jewel/fedora/24/base/README.md
+++ b/ceph-releases/jewel/fedora/24/base/README.md
@@ -9,5 +9,5 @@ Ceph base image (fedora 24 with the latest Ceph release installed).
 ## Usage (example)
 
 ```bash
-$ docker run -i -t ceph/base
+docker run -i -t ceph/base
 ```

--- a/ceph-releases/jewel/fedora/24/base/README.md
+++ b/ceph-releases/jewel/fedora/24/base/README.md
@@ -4,7 +4,7 @@ Ceph base image (fedora 24 with the latest Ceph release installed).
 
 ## Docker Hub/Registry location
 
-https://registry.hub.docker.com/u/ceph/base/
+<https://registry.hub.docker.com/u/ceph/base/>
 
 ## Usage (example)
 

--- a/ceph-releases/jewel/redhat/7.2/README.md
+++ b/ceph-releases/jewel/redhat/7.2/README.md
@@ -2,17 +2,19 @@
 
 ## Clone
 
+```bash
 git clone https://your_github_id:your_github_password@github.com/roofmonkey/rhcs
+```
 
 ## build docker image
 
-```console
+```bash
 docker build -t rhcs .
 ```
 
 ## prepare
 
-```console
+```bash
 mkdir -p /etc/ceph
 # for /var/lib/ceph
 mkdir -p /srv/ceph-var
@@ -24,17 +26,19 @@ rm -rf /etc/ceph/* /srv/ceph/* /srv/ceph-1/*
 ```
 
 ## start Ceph mon
-```console
+
+```bash
 docker run -ti --net=host -e MON_IP=10.1.4.12  -e CEPH_PUBLIC_NETWORK=10.1.4.0/24 -e CEPH_DAEMON=mon -e  -v /etc/ceph:/etc/ceph -v /srv/ceph-var:/var/lib/ceph rhcs
 ```
 
 ## start Ceph osd 0
 
-```console
+```bash
 docker run -ti --privileged --net=host -e MON_IP=10.1.4.12  -e CEPH_PUBLIC_NETWORK=10.1.4.0/24 -e CEPH_DAEMON=osd -e  OSD_TYPE=directory -v /srv/ceph:/var/lib/ceph/osd/ -v /etc/ceph:/etc/ceph -v /srv/ceph-var:/var/lib/ceph rhcs
 ```
 
 ## start Ceph osd 1
-```console
+
+```bash
 docker run -ti --privileged --net=host -e MON_IP=10.1.4.12  -e CEPH_PUBLIC_NETWORK=10.1.4.0/24 -e CEPH_DAEMON=osd -e  OSD_TYPE=directory -v /srv/ceph-1:/var/lib/ceph/osd/ -v /etc/ceph:/etc/ceph -v /srv/ceph-var:/var/lib/ceph rhcs
 ```

--- a/ceph-releases/jewel/ubuntu/14.04/base/README.md
+++ b/ceph-releases/jewel/ubuntu/14.04/base/README.md
@@ -9,5 +9,5 @@ Ceph base image (ubuntu 14.04 with the latest Ceph release installed).
 ## Usage (example)
 
 ```bash
-$ docker run -i -t ceph/base
+docker run -i -t ceph/base
 ```

--- a/ceph-releases/jewel/ubuntu/14.04/base/README.md
+++ b/ceph-releases/jewel/ubuntu/14.04/base/README.md
@@ -4,12 +4,10 @@ Ceph base image (ubuntu 14.04 with the latest Ceph release installed).
 
 ## Docker Hub/Registry location
 
-https://registry.hub.docker.com/u/ceph/base/
+<https://registry.hub.docker.com/u/ceph/base/>
 
 ## Usage (example)
 
 ```bash
 $ docker run -i -t ceph/base
 ```
-
- 

--- a/ceph-releases/jewel/ubuntu/14.04/daemon/README.md
+++ b/ceph-releases/jewel/ubuntu/14.04/daemon/README.md
@@ -22,8 +22,8 @@ You can use this container to bootstrap any Ceph daemon.
 If SELinux is enabled, run the following commands:
 
 ```
-$ sudo chcon -Rt svirt_sandbox_file_t /etc/ceph
-$ sudo chcon -Rt svirt_sandbox_file_t /var/lib/ceph
+sudo chcon -Rt svirt_sandbox_file_t /etc/ceph
+sudo chcon -Rt svirt_sandbox_file_t /var/lib/ceph
 ```
 
 ## KV backends
@@ -46,7 +46,7 @@ Note: `cluster_network` and `public_network` are currently not populated in the 
 ## Populate Key Value store
 
 ```
-$ sudo docker run -d --net=host \
+docker run -d --net=host \
 -e KV_TYPE=etcd \
 -e KV_IP=127.0.0.1 \
 -e KV_PORT=4001 \
@@ -71,7 +71,7 @@ A monitor requires some persistent storage for the docker container. If a KV sto
 Without KV store, run:
 
 ```
-$ sudo docker run -d --net=host \
+docker run -d --net=host \
 -v /etc/ceph:/etc/ceph \
 -v /var/lib/ceph/:/var/lib/ceph/ \
 -e MON_IP=192.168.0.20 \
@@ -82,7 +82,7 @@ ceph/daemon mon
 With KV store, run:
 
 ```
-$ sudo docker run -d --net=host \
+docker run -d --net=host \
 -v /var/lib/ceph:/var/lib/ceph \
 -e MON_IP=192.168.0.20 \
 -e CEPH_PUBLIC_NETWORK=192.168.0.0/24 \
@@ -132,7 +132,7 @@ If the operator does not specify an `OSD_TYPE` autodetection happens:
 Without KV backend:
 
 ```
-$ sudo docker run -d --net=host \
+docker run -d --net=host \
 --pid=host \
 --privileged=true \
 -v /etc/ceph:/etc/ceph \
@@ -146,7 +146,7 @@ ceph/daemon osd
 With KV backend:
 
 ```
-$ sudo docker run -d --net=host \
+docker run -d --net=host \
 --privileged=true \
 --pid=host \
 -v /dev/:/dev/ \
@@ -162,7 +162,7 @@ ceph/daemon osd
 Without KV backend:
 
 ```
-$ sudo docker run -d --net=host \
+docker run -d --net=host \
 --privileged=true \
 --pid=host \
 -v /etc/ceph:/etc/ceph \
@@ -176,7 +176,7 @@ ceph/daemon osd
 Using bluestore:
 
 ```
-$ sudo docker run -d --net=host \
+docker run -d --net=host \
 --privileged=true \
 --pid=host \
 -v /etc/ceph:/etc/ceph \
@@ -191,7 +191,7 @@ ceph/daemon osd
 Using dmcrypt:
 
 ```
-$ sudo docker run -d --net=host \
+docker run -d --net=host \
 --privileged=true \
 --pid=host \
 -v /etc/ceph:/etc/ceph \
@@ -206,7 +206,7 @@ ceph/daemon osd
 With KV backend:
 
 ```
-$ sudo docker run -d --net=host \
+docker run -d --net=host \
 --privileged=true \
 --pid=host \
 -v /dev/:/dev/ \
@@ -220,7 +220,7 @@ ceph/daemon osd
 Using bluestore with KV backend:
 
 ```
-$ sudo docker run -d --net=host \
+docker run -d --net=host \
 --privileged=true \
 --pid=host \
 -v /dev/:/dev/ \
@@ -235,7 +235,7 @@ ceph/daemon osd
 Using dmcrypt with KV backend:
 
 ```
-$ sudo docker run -d --net=host \
+docker run -d --net=host \
 --privileged=true \
 --pid=host \
 -v /dev/:/dev/ \
@@ -260,7 +260,7 @@ If you do not want to use `--privileged=true`, please fall back on the second ex
 This function is balance between ceph-disk and osd directory where the operator can use ceph-disk outside of the container (directly on the host) to prepare the devices. Devices will be prepared with `ceph-disk prepare`, then they will get activated inside the container. A priviledged container is still required as ceph-disk needs to access /dev/. So this has minimum value compare to the ceph-disk but might fit some use cases where the operators want to prepare their devices outside of a container.
 
 ```
-$ sudo docker run -d --net=host \
+docker run -d --net=host \
 --privileged=true \
 --pid=host \
 -v /etc/ceph:/etc/ceph \
@@ -347,7 +347,7 @@ For most people, the defaults for the following optional environment variables a
 Without KV backend, run:
 
 ```
-$ sudo docker run -d --net=host \
+docker run -d --net=host \
 -v /var/lib/ceph/:/var/lib/ceph/ \
 -v /etc/ceph:/etc/ceph \
 -e CEPHFS_CREATE=1 \
@@ -357,7 +357,7 @@ ceph/daemon mds
 With KV backend, run:
 
 ```
-$ sudo docker run -d --net=host \
+docker run -d --net=host \
 -e CEPHFS_CREATE=1 \
 -e KV_TYPE=etcd \
 -e KV_IP=192.168.0.20 \
@@ -375,7 +375,7 @@ For the Rados Gateway, we deploy it with `civetweb` enabled by default. However 
 Without kv backend, run:
 
 ```
-$ sudo docker run -d --net=host \
+docker run -d --net=host \
 -v /var/lib/ceph/:/var/lib/ceph/ \
 -v /etc/ceph:/etc/ceph \
 ceph/daemon rgw
@@ -384,7 +384,7 @@ ceph/daemon rgw
 With kv backend, run:
 
 ```
-$ sudo docker run -d --net=host \
+docker run -d --net=host \
 -e KV_TYPE=etcd \
 -e KV_IP=192.168.0.20 \
 ceph/daemon rgw
@@ -416,7 +416,7 @@ And run the container like this `docker run -d -v /etc/ceph:/etc/ceph -v /var/li
 This is pretty straighforward. The `--net=host` is not mandatory, if you don't use it do not forget to expose the `RESTAPI_PORT`.
 
 ```
-$ sudo docker run -d --net=host \
+docker run -d --net=host \
 -e KV_TYPE=etcd \
 -e KV_IP=192.168.0.20 \
 ceph/daemon restapi
@@ -427,7 +427,7 @@ ceph/daemon restapi
 This is pretty straighforward. The `--net=host` is not mandatory, with KV we do:
 
 ```
-$ sudo docker run -d --net=host \
+docker run -d --net=host \
 -e KV_TYPE=etcd \
 -e KV_IP=192.168.0.20 \
 ceph/daemon rbd_mirror
@@ -436,7 +436,7 @@ ceph/daemon rbd_mirror
 Without KV we do:
 
 ```
-$ sudo docker run -d --net=host \
+docker run -d --net=host \
 ceph/daemon rbd_mirror
 ```
 

--- a/ceph-releases/jewel/ubuntu/14.04/daemon/README.md
+++ b/ceph-releases/jewel/ubuntu/14.04/daemon/README.md
@@ -59,10 +59,9 @@ Sometimes you might want to destroy partition tables from a disk. For this you c
 
 ```
 docker run -d --privileged=true \
--v /dev/:/dev/
--e OSD_DEVICE=/dev/sdd
-ceph/daemon
-zap_device
+-v /dev/:/dev/ \
+-e OSD_DEVICE=/dev/sdd \
+ceph/daemon zap_device
 ```
 
 ## Deploy a monitor

--- a/ceph-releases/jewel/ubuntu/14.04/daemon/README.md
+++ b/ceph-releases/jewel/ubuntu/14.04/daemon/README.md
@@ -1,30 +1,23 @@
-Daemon container
-================
+# Daemon container
 
-This Dockerfile may be used to bootstrap a Ceph cluster with all the Ceph daemons running.
-To run a certain type of daemon, simply use the name of the daemon as `$1`.
-Valid values are:
+This Dockerfile may be used to bootstrap a Ceph cluster with all the Ceph daemons running. To run a certain type of daemon, simply use the name of the daemon as `$1`. Valid values are:
 
-* `mon` deploys a Ceph monitor
-* `osd` deploys an OSD using the method specified by `OSD_TYPE`
-* `osd_directory` deploys **one or multiple OSDs in a single container** using a prepared directory (used in scenario where the operator doesn't want to use `--privileged=true`)
-* `osd_directory_single` deploys an **single OSD per container** using a prepared directory (used in scenario where the operator doesn't want to use `--privileged=true`)
-* `osd_ceph_disk` deploys an OSD using ceph-disk, so you have to provide a whole device (ie: /dev/sdb)
-* `mds` deploys a MDS
-* `rgw` deploys a Rados Gateway
+- `mon` deploys a Ceph monitor
+- `osd` deploys an OSD using the method specified by `OSD_TYPE`
+- `osd_directory` deploys **one or multiple OSDs in a single container** using a prepared directory (used in scenario where the operator doesn't want to use `--privileged=true`)
+- `osd_directory_single` deploys an **single OSD per container** using a prepared directory (used in scenario where the operator doesn't want to use `--privileged=true`)
+- `osd_ceph_disk` deploys an OSD using ceph-disk, so you have to provide a whole device (ie: /dev/sdb)
+- `mds` deploys a MDS
+- `rgw` deploys a Rados Gateway
 
-
-Usage
------
+## Usage
 
 You can use this container to bootstrap any Ceph daemon.
 
-* `CLUSTER` is the name of the cluster (DEFAULT: ceph)
-* `HOSTNAME` is the hostname of the machine  (DEFAULT: $(hostname))
+- `CLUSTER` is the name of the cluster (DEFAULT: ceph)
+- `HOSTNAME` is the hostname of the machine (DEFAULT: $(hostname))
 
-
-SELinux
--------
+## SELinux
 
 If SELinux is enabled, run the following commands:
 
@@ -33,30 +26,24 @@ $ sudo chcon -Rt svirt_sandbox_file_t /etc/ceph
 $ sudo chcon -Rt svirt_sandbox_file_t /var/lib/ceph
 ```
 
-KV backends
------------
+## KV backends
 
 We currently support 2 KV backends to store our configuration flags, keys and maps:
 
-* etcd
-* consul
+- etcd
+- consul
 
-There is a `ceph.defaults` config file in the image that is used for defaults to bootstrap daemons.
-It will add the keys if they are not already present.
-You can either pre-populate the KV store with your own settings, or provide a ceph.defaults config file.
-To supply your own defaults, make sure to mount the /etc/ceph/ volume and place your ceph.defaults file there.
+There is a `ceph.defaults` config file in the image that is used for defaults to bootstrap daemons. It will add the keys if they are not already present. You can either pre-populate the KV store with your own settings, or provide a ceph.defaults config file. To supply your own defaults, make sure to mount the /etc/ceph/ volume and place your ceph.defaults file there.
 
 Important variables in `ceph.defaults` to add/change when you bootstrap an OSD:
 
-* `/osd/osd_journal_size`
-* `/osd/cluster_network`
-* `/osd/public_network`
+- `/osd/osd_journal_size`
+- `/osd/cluster_network`
+- `/osd/public_network`
 
-Note: `cluster_network` and `public_network` are currently not populated in the defaults, but can be passed as environment
-variables with `-e CEPH_PUBLIC_NETWORK=...` for more flexibility
+Note: `cluster_network` and `public_network` are currently not populated in the defaults, but can be passed as environment variables with `-e CEPH_PUBLIC_NETWORK=...` for more flexibility
 
-Populate Key Value store
-------------------------
+## Populate Key Value store
 
 ```
 $ sudo docker run -d --net=host \
@@ -66,34 +53,21 @@ $ sudo docker run -d --net=host \
 ceph/daemon populate_kvstore
 ```
 
+## Zap a device
 
-Zap a device
-------------
-
-Sometimes you might want to destroy partition tables from a disk.
-For this you can use the `zap_device` scenario that works as follow:
+Sometimes you might want to destroy partition tables from a disk. For this you can use the `zap_device` scenario that works as follow:
 
 ```
 docker run -d --privileged=true \
 -v /dev/:/dev/
--e OSD_DEVICE=/dev/sdd 
+-e OSD_DEVICE=/dev/sdd
 ceph/daemon
 zap_device
 ```
 
+## Deploy a monitor
 
-Deploy a monitor
-----------------
-
-A monitor requires some persistent storage for the docker container.  If a KV
-store is used, `/etc/ceph` will be auto-generated from data kept in the KV
-store.  `/var/lib/ceph`, however, *must* be provided by a docker volume.
-The ceph mon will periodically store data into `/var/lib/ceph`, including the
-latest copy of the CRUSH map.  If a mon restarts, it will attempt to download
-the latest monmap and CRUSH map from other peer monitors.  However, if all
-mon daemons have gone down, monitors must be able to recover their previous
-maps.  The docker volume used for `/var/lib/ceph` should be backed by some
-durable storage, and must be able to survive container and node restarts.
+A monitor requires some persistent storage for the docker container. If a KV store is used, `/etc/ceph` will be auto-generated from data kept in the KV store. `/var/lib/ceph`, however, _must_ be provided by a docker volume. The ceph mon will periodically store data into `/var/lib/ceph`, including the latest copy of the CRUSH map. If a mon restarts, it will attempt to download the latest monmap and CRUSH map from other peer monitors. However, if all mon daemons have gone down, monitors must be able to recover their previous maps. The docker volume used for `/var/lib/ceph` should be backed by some durable storage, and must be able to survive container and node restarts.
 
 Without KV store, run:
 
@@ -120,42 +94,44 @@ ceph/daemon mon
 
 List of available options:
 
-* `MON_NAME`: name of the monitor (default to hostname)
-* `CEPH_PUBLIC_NETWORK`: CIDR of the host running Docker, it should be in the same network as the `MON_IP`
-* `CEPH_CLUSTER_NETWORK`: CIDR of a secondary interface of the host running Docker. Used for the OSD replication traffic
-* `MON_IP`: IP address of the host running Docker
-* `NETWORK_AUTO_DETECT`: Whether and how to attempt IP and network autodetection. Meant to be used without `--net=host`.
-    *  0 = Do not detect (default)
-    *  1 = Detect IPv6, fallback to IPv4 (if no globally-routable IPv6 address detected)
-    *  4 = Detect IPv4 only
-    *  6 = Detect IPv6 only
+- `MON_NAME`: name of the monitor (default to hostname)
+- `CEPH_PUBLIC_NETWORK`: CIDR of the host running Docker, it should be in the same network as the `MON_IP`
+- `CEPH_CLUSTER_NETWORK`: CIDR of a secondary interface of the host running Docker. Used for the OSD replication traffic
+- `MON_IP`: IP address of the host running Docker
+- `NETWORK_AUTO_DETECT`: Whether and how to attempt IP and network autodetection. Meant to be used without `--net=host`.
 
+  - 0 = Do not detect (default)
+  - 1 = Detect IPv6, fallback to IPv4 (if no globally-routable IPv6 address detected)
+  - 4 = Detect IPv4 only
+  - 6 = Detect IPv6 only
 
-Deploy an OSD
--------------
+## Deploy an OSD
 
 There are four available `OSD_TYPE` values:
 
-* `<none>` - if no `OSD_TYPE` is set; one of `disk`, `activate` or `directory` will be used based on autodetection of the current OSD bootstrap state
-* `activate` - the daemon expects to be passed a block device of a `ceph-disk`-prepared disk (via the `OSD_DEVICE` environment variable); no bootstrapping will be performed
-* `directory` - the daemon expects to find the OSD filesystem(s) already mounted in `/var/lib/ceph/osd/`
-* `disk` - the daemon expects to be passed a block device via the `OSD_DEVICE` environment variable
-* `prepare` - the daemon expects to be passed a block device and run `ceph-disk` prepare to bootstra the disk (via the `OSD_DEVICE` environment variable)
+- `<none>` - if no `OSD_TYPE` is set; one of `disk`, `activate` or `directory` will be used based on autodetection of the current OSD bootstrap state
+- `activate` - the daemon expects to be passed a block device of a `ceph-disk`-prepared disk (via the `OSD_DEVICE` environment variable); no bootstrapping will be performed
+- `directory` - the daemon expects to find the OSD filesystem(s) already mounted in `/var/lib/ceph/osd/`
+- `disk` - the daemon expects to be passed a block device via the `OSD_DEVICE` environment variable
+- `prepare` - the daemon expects to be passed a block device and run `ceph-disk` prepare to bootstra the disk (via the `OSD_DEVICE` environment variable)
 
 Options for OSDs (TODO: consolidate these options between the types):
-* `JOURNAL_DIR` - if provided, new OSDs will be bootstrapped to use the specified directory as a common journal area.  This is usually used to store the journals for more than one OSD on a common, separate disk.  This currently only applies to the `directory` OSD type.
-* `JOURNAL` - if provided, the new OSD will be bootstrapped to use the specified journal file (if you do not wish to use the default).  This is currently only supported by the `directory` OSD type
-* `OSD_DEVICE` - mandatory for `activate` and `disk` OSD types; this specifies which block device to use as the OSD
-* `OSD_JOURNAL` - optional override of the OSD journal file. this only applies to the `activate` and `disk` OSD types
 
-### Without OSD_TYPE ###
+- `JOURNAL_DIR` - if provided, new OSDs will be bootstrapped to use the specified directory as a common journal area. This is usually used to store the journals for more than one OSD on a common, separate disk. This currently only applies to the `directory` OSD type.
+- `JOURNAL` - if provided, the new OSD will be bootstrapped to use the specified journal file (if you do not wish to use the default). This is currently only supported by the `directory` OSD type
+- `OSD_DEVICE` - mandatory for `activate` and `disk` OSD types; this specifies which block device to use as the OSD
+- `OSD_JOURNAL` - optional override of the OSD journal file. this only applies to the `activate` and `disk` OSD types
+
+### Without OSD_TYPE
 
 If the operator does not specify an `OSD_TYPE` autodetection happens:
+
 - `disk` is used if no bootstrapped OSD is found. `OSD_FORCE_ZAP=1` must be set at this point.
 - `activate` is used if a bootstrapped OSD is found and `OSD_DEVICE` is also provided.
 - `directory` is used if a bootstrapped OSD is found and no `OSD_DEVICE` is provided.
 
 Without KV backend:
+
 ```
 $ sudo docker run -d --net=host \
 --pid=host \
@@ -169,6 +145,7 @@ ceph/daemon osd
 ```
 
 With KV backend:
+
 ```
 $ sudo docker run -d --net=host \
 --privileged=true \
@@ -181,7 +158,7 @@ $ sudo docker run -d --net=host \
 ceph/daemon osd
 ```
 
-### Ceph disk ###
+### Ceph disk
 
 Without KV backend:
 
@@ -273,19 +250,15 @@ ceph/daemon osd
 
 List of available options:
 
-* `OSD_DEVICE` is the OSD device
-* `OSD_JOURNAL` is the journal for a given OSD
-* `HOSTNAME` is used to place the OSD in the CRUSH map
+- `OSD_DEVICE` is the OSD device
+- `OSD_JOURNAL` is the journal for a given OSD
+- `HOSTNAME` is used to place the OSD in the CRUSH map
 
 If you do not want to use `--privileged=true`, please fall back on the second example.
 
+### Ceph disk activate
 
-### Ceph disk activate ###
-
-This function is balance between ceph-disk and osd directory where the operator can use ceph-disk outside of the container (directly on the host) to prepare the devices.
-Devices will be prepared with `ceph-disk prepare`, then they will get activated inside the container.
-A priviledged container is still required as ceph-disk needs to access /dev/.
-So this has minimum value compare to the ceph-disk but might fit some use cases where the operators want to prepare their devices outside of a container.
+This function is balance between ceph-disk and osd directory where the operator can use ceph-disk outside of the container (directly on the host) to prepare the devices. Devices will be prepared with `ceph-disk prepare`, then they will get activated inside the container. A priviledged container is still required as ceph-disk needs to access /dev/. So this has minimum value compare to the ceph-disk but might fit some use cases where the operators want to prepare their devices outside of a container.
 
 ```
 $ sudo docker run -d --net=host \
@@ -299,88 +272,78 @@ $ sudo docker run -d --net=host \
 ceph/daemon osd
 ```
 
+### Ceph OSD directory
 
-### Ceph OSD directory ###
+There are a number of environment variables which are used to configure the execution of the OSD:
 
-There are a number of environment variables which are used to configure
-the execution of the OSD:
+- `CLUSTER` is the name of the ceph cluster (defaults to `ceph`)
 
-*  `CLUSTER` is the name of the ceph cluster (defaults to `ceph`)
+If the OSD is not already created (key, configuration, OSD data), the following environment variables will control its creation:
 
-If the OSD is not already created (key, configuration, OSD data), the
-following environment variables will control its creation:
+- `WEIGHT` is the of the OSD when it is added to the CRUSH map (default is `1.0`)
+- `JOURNAL` is the location of the journal (default is the `journal` file inside the OSD data directory)
+- `HOSTNAME` is the name of the host; it is used as a flag when adding the OSD to the CRUSH map
 
-* `WEIGHT` is the of the OSD when it is added to the CRUSH map (default is `1.0`)
-* `JOURNAL` is the location of the journal (default is the `journal` file inside the OSD data directory)
-* `HOSTNAME` is the name of the host; it is used as a flag when adding the OSD to the CRUSH map
-
-The old option `OSD_ID` is now unused.  Instead, the script will scan for each directory in `/var/lib/ceph/osd` of the form `<cluster>_<osd_id>`.
+The old option `OSD_ID` is now unused. Instead, the script will scan for each directory in `/var/lib/ceph/osd` of the form `<cluster>_<osd_id>`.
 
 To create your OSDs simply run the following command:
 
 `docker exec <mon-container-id> ceph osd create`.
 
-Note that we now default to dropping root privileges, so it is important to set the proper ownership for your OSD directories.  The Ceph OSD runs as UID:64045, GID:64045, so:
+Note that we now default to dropping root privileges, so it is important to set the proper ownership for your OSD directories. The Ceph OSD runs as UID:64045, GID:64045, so:
 
 `chown -R 64045:64045 /var/lib/ceph/osd/`
 
+#### Multiple OSDs
 
-#### Multiple OSDs ####
-
-There is a problem when attempting run run multiple OSD containers on a single docker host.  See issue #19.
+There is a problem when attempting run run multiple OSD containers on a single docker host. See issue #19.
 
 There are two workarounds, at present:
-* Run each OSD with the `--pid=host` option
-* Run multiple OSDs within the same container
+
+- Run each OSD with the `--pid=host` option
+- Run multiple OSDs within the same container
 
 To run multiple OSDs within the same container, simply bind-mount each OSD datastore directory:
-* `docker run -v /osds/1:/var/lib/ceph/osd/ceph-1 -v /osds/2:/var/lib/ceph/osd/ceph-2`
 
+- `docker run -v /osds/1:/var/lib/ceph/osd/ceph-1 -v /osds/2:/var/lib/ceph/osd/ceph-2`
 
-### Ceph OSD directory single ###
+### Ceph OSD directory single
 
-Ceph OSD directory single has a similar design to Ceph OSD directory since they both aim to run OSD processes from an already bootstrapped directory.
-So we assume the OSD directory has been populated already.
-The major different is that Ceph OSD directory single has a much simpler implementation since it only runs a single OSD process per container.
-It doesn't do anything with the journal as it assumes journal's symlink was provided during the initialization sequence of the OSD.
+Ceph OSD directory single has a similar design to Ceph OSD directory since they both aim to run OSD processes from an already bootstrapped directory. So we assume the OSD directory has been populated already. The major different is that Ceph OSD directory single has a much simpler implementation since it only runs a single OSD process per container. It doesn't do anything with the journal as it assumes journal's symlink was provided during the initialization sequence of the OSD.
 
-This scenario goes through the OSD directory (`/var/lib/ceph/osd`) and looks for OSDs that don't have a lock held by any other OSD.
-If no lock is found, the OSD process starts.
-If all the OSDs are already running, we gently exit 0 and explain that all the OSDs are already running.
+This scenario goes through the OSD directory (`/var/lib/ceph/osd`) and looks for OSDs that don't have a lock held by any other OSD. If no lock is found, the OSD process starts. If all the OSDs are already running, we gently exit 0 and explain that all the OSDs are already running.
 
-**Important note**: if you are aiming at running multiple OSD containers on a same machine (things that you will likely do with Ceph anyway), you must enable `--pid=host`.
-However if you are running Docker 1.12 (based on https://github.com/docker/docker/pull/22481), you can just share the same PID namespace for the OSD containers only using: `--pid=container:<id>`.
+**Important note**: if you are aiming at running multiple OSD containers on a same machine (things that you will likely do with Ceph anyway), you must enable `--pid=host`. However if you are running Docker 1.12 (based on <https://github.com/docker/docker/pull/22481>), you can just share the same PID namespace for the OSD containers only using: `--pid=container:<id>`.
 
-#### BTRFS and journal ####
+#### BTRFS and journal
 
-If your OSD is BTRFS and you want to use PARALLEL journal mode, you will need to run this container with `--privileged` set to true.  Otherwise, `ceph-osd` will have insufficient permissions and it will revert to the slower WRITEAHEAD mode.
+If your OSD is BTRFS and you want to use PARALLEL journal mode, you will need to run this container with `--privileged` set to true. Otherwise, `ceph-osd` will have insufficient permissions and it will revert to the slower WRITEAHEAD mode.
 
+#### Note
 
-#### Note ####
+Re: [<https://github.com/Ulexus/docker-ceph/issues/5>]
 
-Re: [https://github.com/Ulexus/docker-ceph/issues/5]
-
-A user has reported a consterning (and difficult to diagnose) problem wherein the OSD crashes frequently due to Docker running out of sufficient open file handles.  This is understandable, as the OSDs use a great many ports during periods of high traffic.  It is, therefore, recommended that you increase the number of open file handles available to Docker.
+A user has reported a consterning (and difficult to diagnose) problem wherein the OSD crashes frequently due to Docker running out of sufficient open file handles. This is understandable, as the OSDs use a great many ports during periods of high traffic. It is, therefore, recommended that you increase the number of open file handles available to Docker.
 
 On CoreOS (and probably other systemd-based systems), you can do this by creating the a file named `/etc/systemd/system/docker.service.d/limits.conf` with content something like:
 
-      [Service]
-      LimitNOFILE=4096
+```
+[Service]
+LimitNOFILE=4096
+```
 
+## Deploy a MDS
 
-Deploy a MDS
-------------
-
-By default, the MDS does _NOT_ create a ceph filesystem.  If you wish to have this MDS create a ceph filesystem (it will only do this if the specified `CEPHFS_NAME` does not already exist), you _must_ set, at a minimum, `CEPHFS_CREATE=1`.  It is strongly recommended that you read the rest of this section, as well.
+By default, the MDS does _NOT_ create a ceph filesystem. If you wish to have this MDS create a ceph filesystem (it will only do this if the specified `CEPHFS_NAME` does not already exist), you _must_ set, at a minimum, `CEPHFS_CREATE=1`. It is strongly recommended that you read the rest of this section, as well.
 
 For most people, the defaults for the following optional environment variables are fine, but if you wish to customize the data and metadata pools in which your CephFS is stored, you may override the following as you wish:
 
-  * `CEPHFS_CREATE`: Whether to create the ceph filesystem (0 = no / 1 = yes), if it doesn't exist.  Defaults to 0 (no)
-  * `CEPHFS_NAME`: The name of the new ceph filesystem and the basis on which the later variables are created.  Defaults to `cephfs`
-  * `CEPHFS_DATA_POOL`:  The name of the data pool for the ceph filesystem.  If it does not exist, it will be created.  Defaults to `${CEPHFS_NAME}_data`
-  * `CEPHFS_DATA_POOL_PG`:  The number of placement groups for the data pool.  Defaults to `8`
-  * `CEPHFS_METADATA_POOL`:  The name of the metadata pool for the ceph filesystem.  If it does not exist, it will be created.  Defaults to `${CEPHFS_NAME}_metadata`
-  * `CEPHFS_METADATA_POOL_PG`:  The number of placement groups for the metadata pool.  Defaults to `8`
+- `CEPHFS_CREATE`: Whether to create the ceph filesystem (0 = no / 1 = yes), if it doesn't exist. Defaults to 0 (no)
+- `CEPHFS_NAME`: The name of the new ceph filesystem and the basis on which the later variables are created. Defaults to `cephfs`
+- `CEPHFS_DATA_POOL`: The name of the data pool for the ceph filesystem. If it does not exist, it will be created. Defaults to `${CEPHFS_NAME}_data`
+- `CEPHFS_DATA_POOL_PG`: The number of placement groups for the data pool. Defaults to `8`
+- `CEPHFS_METADATA_POOL`: The name of the metadata pool for the ceph filesystem. If it does not exist, it will be created. Defaults to `${CEPHFS_NAME}_metadata`
+- `CEPHFS_METADATA_POOL_PG`: The number of placement groups for the metadata pool. Defaults to `8`
 
 Without KV backend, run:
 
@@ -404,18 +367,11 @@ ceph/daemon mds
 
 List of available options:
 
-* `MDS_NAME` is the name the MDS server (DEFAULT: mds-$(hostname)).
-One thing to note is that metadata servers are not machine-restricted.
-They are not bound by their data directories and can move around the cluster.
-As a result, you can run more than one MDS on a single machine.
-If you plan to do so, you better set this variable and do something like: `mds-$(hostname)-a`, `mds-$(hostname)-b`etc...
+- `MDS_NAME` is the name the MDS server (DEFAULT: mds-$(hostname)). One thing to note is that metadata servers are not machine-restricted. They are not bound by their data directories and can move around the cluster. As a result, you can run more than one MDS on a single machine. If you plan to do so, you better set this variable and do something like: `mds-$(hostname)-a`, `mds-$(hostname)-b`etc...
 
+## Deploy a Rados Gateway
 
-Deploy a Rados Gateway
-----------------------
-
-For the Rados Gateway, we deploy it with `civetweb` enabled by default.
-However it is possible to use different CGI frontends by simply giving remote address and port.
+For the Rados Gateway, we deploy it with `civetweb` enabled by default. However it is possible to use different CGI frontends by simply giving remote address and port.
 
 Without kv backend, run:
 
@@ -437,27 +393,26 @@ ceph/daemon rgw
 
 List of available options:
 
-* `RGW_CIVETWEB_PORT` is the port to which civetweb is listening on (DEFAULT: 8080)
-* `RGW_NAME`: default to hostname
-* `RGW_ZONEGROUP`: zonegroup to use (DEFAULT: empty)
-* `RGW_ZONE`: zone to use (DEFAULT: empty)
+- `RGW_CIVETWEB_PORT` is the port to which civetweb is listening on (DEFAULT: 8080)
+- `RGW_NAME`: default to hostname
+- `RGW_ZONEGROUP`: zonegroup to use (DEFAULT: empty)
+- `RGW_ZONE`: zone to use (DEFAULT: empty)
 
 Administration via [radosgw-admin](http://docs.ceph.com/docs/infernalis/man/8/radosgw-admin/) from the Docker host if the `RGW_NAME` variable hasn't been supplied:
 
 `docker exec <containerId> radosgw-admin -n client.rgw.$(hostname) -k /var/lib/ceph/radosgw/$(hostname)/keyring <commands>`
 
-If otherwise, `$(hostname)`  has to be replaced by the value of `RGW_NAME`.
+If otherwise, `$(hostname)` has to be replaced by the value of `RGW_NAME`.
 
 To enable an external CGI interface instead of civetweb set:
 
-* `RGW_REMOTE_CGI=1`
-* `RGW_REMOTE_CGI_HOST=192.168.0.1`
-* `RGW_REMOTE_CGI_PORT=9000`
+- `RGW_REMOTE_CGI=1`
+- `RGW_REMOTE_CGI_HOST=192.168.0.1`
+- `RGW_REMOTE_CGI_PORT=9000`
 
 And run the container like this `docker run -d -v /etc/ceph:/etc/ceph -v /var/lib/ceph/:/var/lib/ceph -e CEPH_DAEMON=RGW -e RGW_NAME=myrgw -p 9000:9000 -e RGW_REMOTE_CGI=1 -e RGW_REMOTE_CGI_HOST=192.168.0.1 -e RGW_REMOTE_CGI_PORT=9000 ceph/daemon`
 
-Deploy a REST API
------------------
+## Deploy a REST API
 
 This is pretty straighforward. The `--net=host` is not mandatory, if you don't use it do not forget to expose the `RESTAPI_PORT`.
 
@@ -468,8 +423,7 @@ $ sudo docker run -d --net=host \
 ceph/daemon restapi
 ```
 
-Deploy a RBD mirror
------------------
+## Deploy a RBD mirror
 
 This is pretty straighforward. The `--net=host` is not mandatory, with KV we do:
 
@@ -489,9 +443,8 @@ ceph/daemon rbd_mirror
 
 List of available options:
 
-* `RESTAPI_IP` is the IP address to listen on (DEFAULT: 0.0.0.0)
-* `RESTAPI_PORT` is the listening port of the REST API (DEFAULT: 5000)
-* `RESTAPI_BASE_URL` is the base URL of the API (DEFAULT: /api/v0.1)
-* `RESTAPI_LOG_LEVEL` is the log level of the API (DEFAULT: warning)
-* `RESTAPI_LOG_FILE` is the location of the log file (DEFAULT: /var/log/ceph/ceph-restapi.log)
- 
+- `RESTAPI_IP` is the IP address to listen on (DEFAULT: 0.0.0.0)
+- `RESTAPI_PORT` is the listening port of the REST API (DEFAULT: 5000)
+- `RESTAPI_BASE_URL` is the base URL of the API (DEFAULT: /api/v0.1)
+- `RESTAPI_LOG_LEVEL` is the log level of the API (DEFAULT: warning)
+- `RESTAPI_LOG_FILE` is the location of the log file (DEFAULT: /var/log/ceph/ceph-restapi.log)

--- a/ceph-releases/jewel/ubuntu/14.04/demo/README.md
+++ b/ceph-releases/jewel/ubuntu/14.04/demo/README.md
@@ -27,5 +27,5 @@ Commonly, you will want to bind-mount your host's `/etc/ceph` into the container
 If you get user_xattr error, try to remount your docker partition:
 
 ```
-$ sudo mount -o remount,user_xattr,rw $(df -P /var/lib/docker |tail -1 |tr -s ' ' |cut -d' ' -f6)
+sudo mount -o remount,user_xattr,rw $(df -P /var/lib/docker |tail -1 |tr -s ' ' |cut -d' ' -f6)
 ```

--- a/ceph-releases/jewel/ubuntu/14.04/demo/README.md
+++ b/ceph-releases/jewel/ubuntu/14.04/demo/README.md
@@ -1,41 +1,31 @@
-Demo container
-==============
+# Demo container
 
 This Dockerfile may be used to bootstrap a Ceph cluster with all the Ceph daemons running.
 
 **/!\ THIS CONTAINER IS NOT RECOMMENDED FOR PRODUCTION USAGE /!\**
 
-The main purpose of this container is to quickly get a Ceph cluster up and running by reducing all the setup steps.
-The container provides all the Ceph daemons, so you can rapidly start playing with Ceph.
+The main purpose of this container is to quickly get a Ceph cluster up and running by reducing all the setup steps. The container provides all the Ceph daemons, so you can rapidly start playing with Ceph.
 
-
-Usage
------
+## Usage
 
 The environment variables `MON_NAME` and `MON_IP` are required:
 
-*  `MON_NAME` is the name of the monitor (DEFAULT: hostname)
-*  `MON_IP` is the IP address of the monitor (public)
-*  `RGW_NAME` is the name of rados gateway instance (DEFAULT: hostname)
-*  `RGW_CIVETWEB_PORT` is the port of the rados gateway (DEFAULT: 80)
-*  `CLUSTER` is the name of the cluster (DEFAULT: ceph)
-*  `CEPH_PUBLIC_NETWORK` is the network where the OSD should communicate
-*  `CEPH_DEMO_UID`, `CEPH_DEMO_ACCESS_KEY`, `CEPH_DEMO_SECRET_KEY`, and `CEPH_DEMO_BUCKET` can be used to auto-provision an account.
+- `MON_NAME` is the name of the monitor (DEFAULT: hostname)
+- `MON_IP` is the IP address of the monitor (public)
+- `RGW_NAME` is the name of rados gateway instance (DEFAULT: hostname)
+- `RGW_CIVETWEB_PORT` is the port of the rados gateway (DEFAULT: 80)
+- `CLUSTER` is the name of the cluster (DEFAULT: ceph)
+- `CEPH_PUBLIC_NETWORK` is the network where the OSD should communicate
+- `CEPH_DEMO_UID`, `CEPH_DEMO_ACCESS_KEY`, `CEPH_DEMO_SECRET_KEY`, and `CEPH_DEMO_BUCKET` can be used to auto-provision an account.
 
-Commonly, you will want to bind-mount your host's `/etc/ceph` into the container.
-For example:
+Commonly, you will want to bind-mount your host's `/etc/ceph` into the container. For example:
 
 `docker run -d --net=host -v /etc/ceph:/etc/ceph -e MON_IP=192.168.0.20 -e CEPH_PUBLIC_NETWORK=192.168.0.0/24 ceph/demo`
 
-
-Tip
----
+## Tip
 
 If you get user_xattr error, try to remount your docker partition:
+
 ```
 $ sudo mount -o remount,user_xattr,rw $(df -P /var/lib/docker |tail -1 |tr -s ' ' |cut -d' ' -f6)
 ```
- 
- 
- 
- 

--- a/ceph-releases/jewel/ubuntu/16.04/base/README.md
+++ b/ceph-releases/jewel/ubuntu/16.04/base/README.md
@@ -9,5 +9,5 @@ Ceph base image (ubuntu 16.04 with the latest Ceph release installed).
 ## Usage (example)
 
 ```bash
-$ docker run -i -t ceph/base
+docker run -i -t ceph/base
 ```

--- a/ceph-releases/jewel/ubuntu/16.04/base/README.md
+++ b/ceph-releases/jewel/ubuntu/16.04/base/README.md
@@ -4,12 +4,10 @@ Ceph base image (ubuntu 16.04 with the latest Ceph release installed).
 
 ## Docker Hub/Registry location
 
-https://registry.hub.docker.com/u/ceph/base/
+<https://registry.hub.docker.com/u/ceph/base/>
 
 ## Usage (example)
 
 ```bash
 $ docker run -i -t ceph/base
 ```
-
- 

--- a/config/README.md
+++ b/config/README.md
@@ -2,21 +2,17 @@
 
 Given that the `ceph/daemon` image has the same capabilities and is more featureful we would recommend to use it as a replacement.
 
-ceph-config
-===========
+# ceph-config
 
-This Dockerfile may be used to bootstrap a cluster or add the cluster configuration
-to a new host. It uses etcd to store the cluster config. It is especially suitable
-to setup ceph on CoreOS.
+This Dockerfile may be used to bootstrap a cluster or add the cluster configuration to a new host. It uses etcd to store the cluster config. It is especially suitable to setup ceph on CoreOS.
 
 The following strategy is applied:
 
-  * An `/etc/ceph/ceph.conf` is found, do nothing.
-  * If a cluster configuration is available, it will be written to `/etc/ceph`
-  * If no cluster configuration is available, it will be bootstrapped. A lock mechanism 
-    is used to allow concurrent deployment of multiple hosts.
+- An `/etc/ceph/ceph.conf` is found, do nothing.
+- If a cluster configuration is available, it will be written to `/etc/ceph`
+- If no cluster configuration is available, it will be bootstrapped. A lock mechanism is used to allow concurrent deployment of multiple hosts.
 
-## Usage 
+## Usage
 
 To bootstrap a new cluster run:
 
@@ -24,28 +20,27 @@ To bootstrap a new cluster run:
 
 This will generate:
 
-  *  `ceph.conf` 
-  *  `ceph.client.admin.keyring` 
-  *  `ceph.mon.keyring` 
-  *  `monmap` 
+- `ceph.conf`
+- `ceph.client.admin.keyring`
+- `ceph.mon.keyring`
+- `monmap`
 
-Except the `monmap` the config will be stored in etcd under `/ceph-config/${CLUSTER}`. 
+Except the `monmap` the config will be stored in etcd under `/ceph-config/${CLUSTER}`.
 
-In case a configuration for the cluster is found, the configuration will be pulled
-from etcd and written to `/etc/ceph`.
+In case a configuration for the cluster is found, the configuration will be pulled from etcd and written to `/etc/ceph`.
 
-Multiple concurrent invocations will block until the first host finished to generate 
-the configuration.
+Multiple concurrent invocations will block until the first host finished to generate the configuration.
 
 ## Configuration
 
 The following environment variables can be used to configure the bootstrapping:
 
-  * `CONFIG_ROOT` is the location in etcd for the ceph configuration (defaults to: "/ceph") 
-  * `CLUSTER` is the name of the ceph cluster (defaults to: "ceph") 
-  * `CLUSTER_PATH` is the location in etcd for the ceph configuration (defaults to: "`${CONFIG_ROOT}/${CLUSTER}/config`") 
+- `CONFIG_ROOT` is the location in etcd for the ceph configuration (defaults to: "/ceph")
+- `CLUSTER` is the name of the ceph cluster (defaults to: "ceph")
+- `CLUSTER_PATH` is the location in etcd for the ceph configuration (defaults to: "`${CONFIG_ROOT}/${CLUSTER}/config`")
 
 Mandatory Configuration:
-  * `MON_NAME` is the name of the monitor. Usually the short hostname
-  * `MON_IP` is the IP address of the monitor (public)
-  * `ETCDCTL_PEERS` is a comma seperated list of etcd peers (e.g. http://192.168.2.4:4001)
+
+- `MON_NAME` is the name of the monitor. Usually the short hostname
+- `MON_IP` is the IP address of the monitor (public)
+- `ETCDCTL_PEERS` is a comma seperated list of etcd peers (e.g. <http://192.168.2.4:4001>)

--- a/docker-registry/README.md
+++ b/docker-registry/README.md
@@ -1,5 +1,4 @@
-Docker-registry
-===============
+# Docker-registry
 
 ```
 docker run -d \
@@ -15,11 +14,14 @@ docker run -d \
          ceph/docker-registry
 ```
 
-In the example boto.s3.connection.OrdinaryCallingFormat  makes API calls in the format:
+In the example boto.s3.connection.OrdinaryCallingFormat makes API calls in the format:
+
 ```
 http://HOST:PORT/BUCKET/OBJECT
 ```
+
 if AWS_CALLING_FORMAT is empty, it calls like:
+
 ```
 http://BUCKET.HOST:PORT/OBJECT
 ```

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,3 @@
-Description
-===========
+# Description
 
-This directory contains example scripts and helpers for different base
-operating systems.  
-
+This directory contains example scripts and helpers for different base operating systems.

--- a/examples/coreos/rbdmap/README.md
+++ b/examples/coreos/rbdmap/README.md
@@ -1,33 +1,34 @@
-Ceph RBDMAP
-===========
+# Ceph RBDMAP
 
 Allows mounting ceph rbd block devices under a CoreOS host for bind-mounting to containers.
 
 ## Installing
+
 - Copy rbdmap into /opt/sbin
 - Copy ceph-rbdnamer to /opt/bin
 - Copy 50-rbd.rules to /etc/udev/rules.d
 
 ## Usage
+
 1. Add rbd device to /etc/ceph/rbdmap
 
-e.g.
+  e.g.
 
-```
+  ```
   #poolname/imagename id=client,keyring=ceph.client.admin.keyring
   rbd/mysql id=admin,keyring=/etc/ceph/ceph.client.admin.keyring
-```
+  ```
 
 2. Add mount directory to /etc/fstab
 
-e.g.
+  e.g.
 
-```
+  ```
   /dev/rbd/poolname/imagename mountpoint fstype mount-options 0 0
   /dev/rbd/rbd/mariadb1	/data/mariadb1 ext4	noatime,_netdev	0 0
-```
+  ```
 
-Note: ensure the _netdev option is specified in the mount options.
+Note: ensure the `_netdev` option is specified in the mount options.
 
 ```
 _netdev

--- a/examples/coreos/tools/README.md
+++ b/examples/coreos/tools/README.md
@@ -4,23 +4,29 @@ These are wrapper files for ceph CLI tools to make working with ceph a little ea
 
 ## Installation
 
+Copy the tools files wherever you would like them. e.g. /opt/bin
 
-Copy the tools files wherever you would like them.  e.g. /opt/bin
+Typically the easiest way to install these is using the docker container. This method is especially handy under CoreOS.
 
-Typically the easiest way to install these is using the docker container.  This method is especially handy under CoreOS.
+To load the CLI tools to `/opt/bin` using docker, run the following command on the host:
 
-To load the CLI tools to `/opt/bin` using docker, run the following command on the host:  
-`/usr/bin/docker run --rm -v /opt/bin:/opt/bin ceph/install-utils`
+```
+/usr/bin/docker run --rm -v /opt/bin:/opt/bin ceph/install-utils`
+```
 
-To install to an alternate directory on the host using docker:  
-`/usr/bin/docker run --rm -v /path/for/install:/opt/bin ceph/install-utils`
+To install to an alternate directory on the host using docker:
 
+```
+/usr/bin/docker run --rm -v /path/for/install:/opt/bin ceph/install-utils`
+```
 
 Then use the CLI tools as you normally would.
 
-`ceph status`  
-`ceph-disk prepare`  
-`rados lspools`  
-`rbd ls`  
+```
+ceph status
+ceph-disk prepare
+rados lspools
+rbd ls
+```
 
-__Note:__ If the directory where you have loaded the files is not in PATH, you may need to add the directory or call using the full path to the wrapper (i.e. `/opt/bin/rbd ls`)
+**Note:** If the directory where you have loaded the files is not in PATH, you may need to add the directory or call using the full path to the wrapper (i.e. `/opt/bin/rbd ls`)

--- a/examples/coreos/units-etcd/README.md
+++ b/examples/coreos/units-etcd/README.md
@@ -1,16 +1,15 @@
-Deploy Ceph in Containers using Fleet with Etcd Support Example
-===============================================================
+# Deploy Ceph in Containers using Fleet with Etcd Support Example
 
-In this example, the configs (/etc/ceph/*) are created when the first Ceph monitor boots up and stored in Etcd cluster. When new node joins the Ceph cluster, the configs are pulled automatically from Etcd servers. So manual distribution of the config files can be avoided. In order to examine the generated config file, you will need to login to the running container using `docker exec -it CONTAINER bash`.
+In this example, the configs (`/etc/ceph/*`) are created when the first Ceph monitor boots up and stored in Etcd cluster. When new node joins the Ceph cluster, the configs are pulled automatically from Etcd servers. So manual distribution of the config files can be avoided. In order to examine the generated config file, you will need to login to the running container using `docker exec -it CONTAINER bash`.
 
 Those units assume an Etcd proxy/server is running on localhost. If not, please change KV_IP to the Etcd cluster and use KV_PORT for non-default Etcd port.
 
-It is also possible using Consul, but such a deployment is not tested yet. 
+It is also possible using Consul, but such a deployment is not tested yet.
 
-Deploy Units with Fleet
------------------------
+## Deploy Units with Fleet
 
 # Monitors
+
 Monitors have to be deployed first, before any other components.
 
 ```bash
@@ -27,7 +26,7 @@ fleetctl start ceph-osd@2
 ...
 ```
 
-# MDS 
+# MDS
 
 ```bash
 fleetctl start ceph-mds@1
@@ -35,7 +34,7 @@ fleetctl start ceph-mds@2
 ...
 ```
 
-# RGW 
+# RGW
 
 ```bash
 fleetctl start ceph-rgw@1

--- a/examples/kubernetes-coreos/README.md
+++ b/examples/kubernetes-coreos/README.md
@@ -1,24 +1,42 @@
-#  Ceph on CoreOS for Kubernetes
+# Ceph on CoreOS for Kubernetes
 
-This project enables running Ceph systems on Kubernetes on CoreOS and accessing Ceph resources via Kubernetes.  Installation can occur
-in several ways:
-- manually execute the image built by the included Dockerfile:  sudo /usr/bin/docker run --rm -v /opt/bin:/opt/bin coffeepac/ceph-Instal
-- modify 'install-job.yaml' to have at least one job per node in the kubernetes cluster.  This is only a best effort as Kubernetes
-  may schedule several of the pods for a single high performing node
-    kubectl create -f install-job.yaml
-      this currently pulls the latest tag which will sleep for 30d after the install is complete.  Should have a separate tag for the job
-- install the daemon-set.  this will install the required ceph utilities once on each node and then sleep for 30 days.  Its not ideal but
-  it will also install the ceph components to any future node.
-    kubectl create -f install-ds.yaml
-      this assumes a 'ceph' namespace exists.  If not you'll have to create one:
-      kubectl create namespace ceph
+This project enables running Ceph systems on Kubernetes on CoreOS and accessing Ceph resources via Kubernetes. Installation can occur in several ways:
+
+- Manually execute the image built by the included Dockerfile:
+
+  ```
+  sudo /usr/bin/docker run --rm -v /opt/bin:/opt/bin coffeepac/ceph-Instal
+  ```
+
+- Modify `install-job.yaml` to have at least one job per node in the kubernetes cluster. This is only a best effort as Kubernetes may schedule several of the pods for a single high performing node
+
+  ```
+  kubectl create -f install-job.yaml
+  ```
+
+  This currently pulls the latest tag which will sleep for 30d after the install is complete. Should have a separate tag for the job
+
+- Install the daemon-set. this will install the required ceph utilities once on each node and then sleep for 30 days. Its not ideal but it will also install the ceph components to any future node.
+
+  ```
+  kubectl create -f install-ds.yaml
+  ```
+
+  This assumes a 'ceph' namespace exists. If not you'll have to create one:
+
+  ```
+  kubectl create namespace ceph
+  ```
 
   Once the tools are installed you can follow the kubernetes example.
 
-#  Additional Kubenetes configuration
+## Additional Kubenetes configuration
 
 There are two additional pieces of configuration that have to happen:
-- the kubelet and apiserver need to be run with the flag 'allow-privileged'
-- the kubelet's need to have the following added to the Unit file:
-  Environment=PATH=/opt/bin/:/usr/bin/:/usr/sbin:$PATH
 
+- The kubelet and apiserver need to be run with the flag `allow-privileged`
+- The kubelet's need to have the following added to the Unit file:
+
+  ```
+  Environment=PATH=/opt/bin/:/usr/bin/:/usr/sbin:$PATH
+  ```

--- a/examples/kubernetes/README.md
+++ b/examples/kubernetes/README.md
@@ -1,12 +1,12 @@
-Ceph on Kubernetes
-=====
+# Ceph on Kubernetes
+
 This Guide will take you through the process of deploying a Ceph cluster on to a Kubernetes cluster.
 
-# Client Requirements
+## Client Requirements
 
-In addition to kubectl, Sigil is required for template handling and must be installed in your system PATH. Instructions can be found here: [https://github.com/gliderlabs/sigil](https://github.com/gliderlabs/sigil)
+In addition to kubectl, Sigil is required for template handling and must be installed in your system PATH. Instructions can be found here: <https://github.com/gliderlabs/sigil>
 
-# Cluster Requirements
+## Cluster Requirements
 
 At a High level:
 
@@ -58,7 +58,7 @@ This will not work on:
 
 - Debian 8.5
 
-# Quickstart
+## Quickstart
 
 If you're feeling confident:
 
@@ -72,11 +72,11 @@ This will most likely not work on your setup, see the rest of the guide if you e
 
 We will be working on making this setup more agnostic, especially in regards to the network IP ranges.
 
-# Tutorial
+## Tutorial
 
 ### Override the default network settings
 
-By default, 10.244.0.0/16 is used for the `cluster_network` and `public_network` in ceph.conf. To change these defaults, set the following environment variables according to your network requirements. These IPs should be set according to the range of your Pod IPs in your kubernetes cluster:
+By default, `10.244.0.0/16` is used for the `cluster_network` and `public_network` in ceph.conf. To change these defaults, set the following environment variables according to your network requirements. These IPs should be set according to the range of your Pod IPs in your kubernetes cluster:
 
 ```
 export osd_cluster_network=192.168.0.0/16

--- a/rados/README.md
+++ b/rados/README.md
@@ -1,5 +1,4 @@
-rados
-=====
+# rados
 
 A convenience container to execute ceph rados for object manipulation.
 
@@ -7,4 +6,6 @@ Make sure to pass your /etc/ceph path as a volume/bind-mount.
 
 Example:
 
-`docker run -v /etc/ceph:/etc/ceph ceph/rados lspools`
+```
+docker run -v /etc/ceph:/etc/ceph ceph/rados lspools
+```

--- a/rbd-lock/README.md
+++ b/rbd-lock/README.md
@@ -1,21 +1,21 @@
-rbd-lock
-========
+# rbd-lock
 
-A convenience container to acquire a lock on an RBD image (or fail)
-and (optionally) set an etcd key with that lockid.
+A convenience container to acquire a lock on an RBD image (or fail) and (optionally) set an etcd key with that lockid.
 
 Make sure to pass your /etc/ceph path as a volume/bind-mount.
 
 It uses the following environment variables, if present:
- - `IMAGENAME`: this should be of the form `poolName/imageName`, and you may override this by passing the image name as the first argument
- - `LOCKNAME`: this is an arbitrary text name for the lock, and you may override this by passing the lock name as the second argument.  The `LOCKNAME` will default to the `HOSTNAME` of the machine.
- - `ETCD_LOCKID_KEY`: this is the key name which will be set with the lock id acquired from Ceph after a successful lock.
- - `ETCDCTL_PEERS` is a comma seperated list of etcd peers (e.g. http://192.168.2.4:4001)
- - `etcdctl` is used to set the key, so any environment variable which acts upon etdctl will be honored within the execution.
 
-Note:  A lock is acquired if and only if the return value is 0.  If the lock id was obtained, it will be returned as the output.
+- `IMAGENAME`: this should be of the form `poolName/imageName`, and you may override this by passing the image name as the first argument
+- `LOCKNAME`: this is an arbitrary text name for the lock, and you may override this by passing the lock name as the second argument. The `LOCKNAME` will default to the `HOSTNAME` of the machine.
+- `ETCD_LOCKID_KEY`: this is the key name which will be set with the lock id acquired from Ceph after a successful lock.
+- `ETCDCTL_PEERS` is a comma seperated list of etcd peers (e.g. `http://192.168.2.4:4001`)
+- `etcdctl` is used to set the key, so any environment variable which acts upon etdctl will be honored within the execution.
+
+Note: A lock is acquired if and only if the return value is 0. If the lock id was obtained, it will be returned as the output.
 
 Example:
 
-`docker run --rm -v /etc/ceph:/etc/ceph ceph/rbd-lock myPool/myImage myLockName`
-
+```
+docker run --rm -v /etc/ceph:/etc/ceph ceph/rbd-lock myPool/myImage myLockName
+```

--- a/rbd-unlock/README.md
+++ b/rbd-unlock/README.md
@@ -1,19 +1,20 @@
-rbd-unlock
-==========
+# rbd-unlock
 
 A convenience container to release a lock on an RBD image
 
 Make sure to pass your /etc/ceph path as a volume/bind-mount.
 
 It uses the following environment variables, if present:
- - `IMAGENAME`: this should be of the form `poolName/imageName`, and you may override this by passing the image name as the first argument
- - `LOCKNAME`: this is name of the lock, and you may override this by passing the lock name as the second argument.  The `LOCKNAME` will default to the `HOSTNAME` of the machine.
- - `LOCKID`: this is the id of the lock, and you may override this by passing the lock id as the third argument.
- - `ETCD_LOCKID_KEY`: this is the key name from where the `LOCKID` should be read (thus obviating and overriding `LOCKID`)
- - `ETCDCTL_PEERS` is a comma seperated list of etcd peers (e.g. http://192.168.2.4:4001)
- - `etcdctl` is used to get the key, so any environment variable which acts upon etdctl will be honored within the execution.
+
+- `IMAGENAME`: this should be of the form `poolName/imageName`, and you may override this by passing the image name as the first argument
+- `LOCKNAME`: this is name of the lock, and you may override this by passing the lock name as the second argument. The `LOCKNAME` will default to the `HOSTNAME` of the machine.
+- `LOCKID`: this is the id of the lock, and you may override this by passing the lock id as the third argument.
+- `ETCD_LOCKID_KEY`: this is the key name from where the `LOCKID` should be read (thus obviating and overriding `LOCKID`)
+- `ETCDCTL_PEERS` is a comma seperated list of etcd peers (e.g. <http://192.168.2.4:4001>)
+- `etcdctl` is used to get the key, so any environment variable which acts upon etdctl will be honored within the execution.
 
 Example:
 
-`docker run --rm -v /etc/ceph:/etc/ceph ceph/rbd-unlock myPool/myImage myLockName lockId`
-
+```
+docker run --rm -v /etc/ceph:/etc/ceph ceph/rbd-unlock myPool/myImage myLockName lockId
+```

--- a/rbd-volume/README.md
+++ b/rbd-volume/README.md
@@ -1,24 +1,29 @@
-# `rbd-volume` - *NON-FUNCTIONAL*
+# `rbd-volume` - _NON-FUNCTIONAL_
 
-This Docker container will mount the requested `RBD` image to a volume.  You can then
-use link to that volume from other containers with the `--volumes-from` Docker `run` option.
+This Docker container will mount the requested `RBD` image to a volume. You can then use link to that volume from other containers with the `--volumes-from` Docker `run` option.
 
 ## Environment variables:
-   * `RBD_IMAGE`: name of the image (defaults to `image0`)
-   * `RBD_POOL`: name of the pool in which the image resides (defaults to `rbd`)
-   * `RBD_OPTS`: rbd map options (defaults to `rw`)
-   * `RBD_FS`: filesystem of the RBD image (defaults to `xfs`)
-      * NOTE:  this container does NOT create the filesystem
-   * `RBD_TARGET`: the target mountpoint inside the container (defaults to `/mnt/rbd`)
+
+- `RBD_IMAGE`: name of the image (defaults to `image0`)
+- `RBD_POOL`: name of the pool in which the image resides (defaults to `rbd`)
+- `RBD_OPTS`: rbd map options (defaults to `rw`)
+- `RBD_FS`: filesystem of the RBD image (defaults to `xfs`)
+
+  - NOTE: this container does NOT create the filesystem
+
+- `RBD_TARGET`: the target mountpoint inside the container (defaults to `/mnt/rbd`)
 
 ## Features
-   * May mount to different targets (allowing multiple instances)
-   * Go-based maintenance daemon
-      * Keeps container running
-      * Unmounts on exit signal
-   * May mount to host filesystem mountpoint (`-v /host/path/mountpoint:/mnt/rbd`)
+
+- May mount to different targets (allowing multiple instances)
+- Go-based maintenance daemon
+
+  - Keeps container running
+  - Unmounts on exit signal
+
+- May mount to host filesystem mountpoint (`-v /host/path/mountpoint:/mnt/rbd`)
 
 ## Example usage
 
-   * `docker run --name myData -e RBD_IMAGE=myData -e RBD_POOL=myPool ceph/rbd-volume`
-   * `docker run --volumes-from myData myOrg/myApp`
+- `docker run --name myData -e RBD_IMAGE=myData -e RBD_POOL=myPool ceph/rbd-volume`
+- `docker run --volumes-from myData myOrg/myApp`

--- a/rbd/README.md
+++ b/rbd/README.md
@@ -1,5 +1,4 @@
-rbd
-===
+# rbd
 
 A convenience container to execute ceph rbd for block device manipulation
 
@@ -7,4 +6,6 @@ Make sure to pass your /etc/ceph path as a volume/bind-mount.
 
 Example:
 
-`docker run -v /etc/ceph:/etc/ceph ceph/rbd -p vms ls`
+```
+docker run -v /etc/ceph:/etc/ceph ceph/rbd -p vms ls
+```


### PR DESCRIPTION
I ran [tidy-markdown](https://github.com/slang800/tidy-markdown) over all the markdown files & then did some manual cleanup in cases of odd formatting. This makes the documentation formatting more consistent, removes trailing whitespace, and applies code formatting to more identifiers