### PR TITLE
upgrade examples/kubernetes/generator/ceph-key.py to python 3

### DIFF
--- a/examples/kubernetes/generator/README.md
+++ b/examples/kubernetes/generator/README.md
@@ -1,48 +1,60 @@
-Ceph Kubernetes Secret Generation
-=================================
+# Ceph Kubernetes Secret Generation
 
 This script will generate ceph keyrings and configs as Kubernetes secrets.
 
-Sigil is required for template handling and must be installed in system PATH. Instructions can be found here: https://github.com/gliderlabs/sigil
+Sigil is required for template handling and must be installed in system PATH. Instructions can be found here: <https://github.com/gliderlabs/sigil>
 
 The following functions are provided:
 
 ## Generate raw FSID (can be used for other functions)
 
-`./generate_secrets.sh fsid`
+```bash
+./generate_secrets.sh fsid
+```
 
 ## Generate raw ceph.conf (For verification)
 
-`./generate_secrets.sh ceph-conf-raw <fsid> "overridekey=value"`
+```bash
+./generate_secrets.sh ceph-conf-raw <fsid> "overridekey=value"
+```
 
 Take a look at `ceph/ceph.conf.tmpl` for the default values
 
 ## Generate encoded ceph.conf secret
 
-`./generate_secrets.sh ceph-conf <fsid> "overridekey=value"`
+```bash
+./generate_secrets.sh ceph-conf <fsid> "overridekey=value"
+```
 
 ## Generate encoded admin keyring secret
 
-`./generate_secrets.sh admin-keyring`
+```bash
+./generate_secrets.sh admin-keyring
+```
 
 ## Generate encoded mon keyring secret
 
-`./generate_secrets.sh mon-keyring`
+```bash
+./generate_secrets.sh mon-keyring
+```
 
 ## Generate a combined secret
 
 Contains ceph.conf, admin keyring and mon keyring. Useful for generating the `/etc/ceph` directory
 
-`./generate_secrets.sh combined-conf`
+```bash
+./generate_secrets.sh combined-conf
+```
 
 ## Generate encoded boostrap keyring secret
 
-`./generate_secrets.sh bootstrap-keyring <osd|mds|rgw>`
-
-Kubernetes workflow
-===================
-
+```bash
+./generate_secrets.sh bootstrap-keyring <osd|mds|rgw>
 ```
+
+# Kubernetes workflow
+
+```bash
 ./generator/generate_secrets.sh all `./generate_secrets.sh fsid`
 
 kubectl create secret generic ceph-conf-combined --from-file=ceph.conf --from-file=ceph.client.admin.keyring --from-file=ceph.mon.keyring --namespace=ceph
@@ -51,4 +63,3 @@ kubectl create secret generic ceph-bootstrap-mds-keyring --from-file=ceph.keyrin
 kubectl create secret generic ceph-bootstrap-osd-keyring --from-file=ceph.keyring=ceph.osd.keyring --namespace=ceph
 kubectl create secret generic ceph-client-key --from-file=ceph-client-key --namespace=ceph
 ```
-

--- a/examples/kubernetes/generator/ceph-key.py
+++ b/examples/kubernetes/generator/ceph-key.py
@@ -1,7 +1,5 @@
-import errno
-import logging
+#!/bin/python
 import os
-import uuid
 import struct
 import time
 import base64
@@ -14,4 +12,4 @@ header = struct.pack(
     0,                 # le32 created: nanoseconds,
     len(key),          # le16: len(key)
 )
-print base64.b64encode(header + key)
+print(base64.b64encode(header + key).decode('ascii'))


### PR DESCRIPTION
Noticed this when the script broke on my arch-linux box. Python3 is pretty much the de-facto version of Python nowadays, right?

Also I found some dead imports and a markdown file in the generator folder that I missed in #385.