### PR TITLE
Removing runit

### DIFF
--- a/ceph-releases/jewel/centos/7/base/Dockerfile
+++ b/ceph-releases/jewel/centos/7/base/Dockerfile
@@ -15,10 +15,6 @@ ENV KUBECTL_VERSION v1.2.4
 # Install prerequisites
 RUN yum install -y unzip
 
-# Install Runit
-RUN curl -s https://packagecloud.io/install/repositories/imeyer/runit/script.rpm.sh | bash
-RUN yum install -y runit-2.1.1-7.el7.centos.x86_64
-
 # Install Ceph
 RUN rpm --import 'https://download.ceph.com/keys/release.asc'
 RUN rpm -Uvh http://download.ceph.com/rpm-${CEPH_VERSION}/el7/noarch/ceph-release-1-1.el7.noarch.rpm
@@ -44,7 +40,9 @@ RUN chmod +x /usr/local/bin/kubectl
 ADD https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 /usr/local/bin/jq
 RUN chmod +x /usr/local/bin/jq
 
+# Download forego
+ADD https://bin.equinox.io/c/ekMN3bCZFUn/forego-stable-linux-amd64.tgz /forego.tgz
+RUN cd /usr/local/bin && tar xfz /forego.zip && chmod +x /usr/local/bin/forego && rm /forego.zip
 
 ADD entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
-

--- a/ceph-releases/jewel/centos/7/base/Dockerfile
+++ b/ceph-releases/jewel/centos/7/base/Dockerfile
@@ -42,7 +42,7 @@ RUN chmod +x /usr/local/bin/jq
 
 # Download forego
 ADD https://bin.equinox.io/c/ekMN3bCZFUn/forego-stable-linux-amd64.tgz /forego.tgz
-RUN cd /usr/local/bin && tar xfz /forego.zip && chmod +x /usr/local/bin/forego && rm /forego.zip
+RUN cd /usr/local/bin && tar xfz /forego.tgz && chmod +x /usr/local/bin/forego && rm /forego.tgz
 
 ADD entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/ceph-releases/jewel/centos/7/daemon/Dockerfile
+++ b/ceph-releases/jewel/centos/7/daemon/Dockerfile
@@ -10,13 +10,6 @@ MAINTAINER Sébastien Han "seb@redhat.com"
 # Add bootstrap script, ceph defaults key/values for KV store
 ADD entrypoint.sh config.*.sh check_zombie_mons.py remove-mon.sh ceph.defaults / 
 
-ADD my_init/my_init /sbin/my_init
-ADD 2.sh /etc/runit/2
-
-RUN chmod +x /sbin/my_init && \
-    mkdir -p /etc/container_environment && \
-    chmod +x /etc/runit/2
-
 # Add templates for confd
 ADD ./confd/templates/* /etc/confd/templates/
 ADD ./confd/conf.d/* /etc/confd/conf.d/

--- a/ceph-releases/jewel/fedora/24/base/Dockerfile
+++ b/ceph-releases/jewel/fedora/24/base/Dockerfile
@@ -17,6 +17,9 @@ ADD https://github.com/AcalephStorage/kviator/releases/download/v${KVIATOR_VERSI
 # Download confd
 ADD https://github.com/kelseyhightower/confd/releases/download/v${CONFD_VERSION}/confd-${CONFD_VERSION}-linux-amd64 /usr/local/bin/confd
 
+# Download forego
+ADD https://bin.equinox.io/c/ekMN3bCZFUn/forego-stable-linux-amd64.tgz /forego.tgz
+
 # install prerequisites
 RUN dnf install -y ceph ceph-radosgw rbd-mirror nfs-ganesha-rgw nfs-ganesha-vfs sharutils systemd-udev wget unzip && \
     dnf clean all && \
@@ -29,17 +32,14 @@ RUN dnf install -y ceph ceph-radosgw rbd-mirror nfs-ganesha-rgw nfs-ganesha-vfs 
     cd /usr/local/bin && unzip /kviator.zip && chmod +x /usr/local/bin/kviator && rm /kviator.zip && \
 \
 # Install confd
-    chmod +x /usr/local/bin/confd && mkdir -p /etc/confd/conf.d && mkdir -p /etc/confd/templates
+    chmod +x /usr/local/bin/confd && mkdir -p /etc/confd/conf.d && mkdir -p /etc/confd/templates && \
+\
+# Install forego
+    cd /usr/local/bin && tar xfz /forego.zip && chmod +x /usr/local/bin/forego && rm /forego.zip
 
 # Install kubectl
 ADD https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl /usr/local/bin/kubectl
 RUN chmod +x /usr/local/bin/kubectl
-
-# Install runit
-RUN dnf install -y gcc glibc-static
-RUN cd / && mkdir -p /package && wget -q -O- "http://smarden.org/runit/runit-2.1.2.tar.gz" |tar xfz - -C/package/ && cd /package/admin/runit-2.1.2/ && ./package/install
-RUN mkdir -p /etc/service && chmod +x /etc/service/
-RUN dnf remove -y gcc glibc-static
 
 ADD https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 /usr/local/bin/jq
 RUN chmod +x /usr/local/bin/jq

--- a/ceph-releases/jewel/fedora/24/base/Dockerfile
+++ b/ceph-releases/jewel/fedora/24/base/Dockerfile
@@ -35,7 +35,7 @@ RUN dnf install -y ceph ceph-radosgw rbd-mirror nfs-ganesha-rgw nfs-ganesha-vfs 
     chmod +x /usr/local/bin/confd && mkdir -p /etc/confd/conf.d && mkdir -p /etc/confd/templates && \
 \
 # Install forego
-    cd /usr/local/bin && tar xfz /forego.zip && chmod +x /usr/local/bin/forego && rm /forego.zip
+    cd /usr/local/bin && tar xfz /forego.tgz && chmod +x /usr/local/bin/forego && rm /forego.tgz
 
 # Install kubectl
 ADD https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl /usr/local/bin/kubectl

--- a/ceph-releases/jewel/fedora/24/daemon/Dockerfile
+++ b/ceph-releases/jewel/fedora/24/daemon/Dockerfile
@@ -7,16 +7,9 @@
 FROM ceph/base:tag-build-master-jewel-fedora-24
 MAINTAINER Sébastien Han "seb@redhat.com"
 
-ADD my_init/my_init /sbin/my_init
-ADD 2.sh /etc/runit/2
-
 # Add templates for confd
 ADD ./confd/templates/* /etc/confd/templates/
 ADD ./confd/conf.d/* /etc/confd/conf.d/
-
-RUN chmod +x /sbin/my_init && \
-    mkdir -p /etc/container_environment && \
-    chmod +x /etc/runit/2
 
 # Add bootstrap script, ceph defaults key/values for KV store
 ADD entrypoint.sh config.*.sh ceph.defaults check_zombie_mons.py remove-mon.sh /

--- a/ceph-releases/jewel/ubuntu/14.04/base/Dockerfile
+++ b/ceph-releases/jewel/ubuntu/14.04/base/Dockerfile
@@ -18,8 +18,11 @@ ADD https://github.com/AcalephStorage/kviator/releases/download/v${KVIATOR_VERSI
 # Download confd
 ADD https://github.com/kelseyhightower/confd/releases/download/v${CONFD_VERSION}/confd-${CONFD_VERSION}-linux-amd64 /usr/local/bin/confd
 
+# Download forego
+ADD https://bin.equinox.io/c/ekMN3bCZFUn/forego-stable-linux-amd64.tgz /forego.tgz
+
 # install prerequisites
-RUN DEBIAN_FRONTEND=noninteractive apt-get update &&  apt-get install -y wget unzip uuid-runtime python-setuptools udev runit sharutils && \
+RUN DEBIAN_FRONTEND=noninteractive apt-get update &&  apt-get install -y wget unzip uuid-runtime python-setuptools udev sharutils && \
 \
 # install ceph and ganesha
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3FE869A9 && \
@@ -38,7 +41,10 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update &&  apt-get install -y wget un
     cd /usr/local/bin && unzip /kviator.zip && chmod +x /usr/local/bin/kviator && rm /kviator.zip && \
 \
 # Install confd
-    chmod +x /usr/local/bin/confd && mkdir -p /etc/confd/conf.d && mkdir -p /etc/confd/templates
+    chmod +x /usr/local/bin/confd && mkdir -p /etc/confd/conf.d && mkdir -p /etc/confd/templates && \
+\
+# Install forego
+    cd /usr/local/bin && tar xfz /forego.zip && chmod +x /usr/local/bin/forego && rm /forego.zip
 
 # Install kubectl
 ADD https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl /usr/local/bin/kubectl

--- a/ceph-releases/jewel/ubuntu/14.04/base/Dockerfile
+++ b/ceph-releases/jewel/ubuntu/14.04/base/Dockerfile
@@ -44,7 +44,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update &&  apt-get install -y wget un
     chmod +x /usr/local/bin/confd && mkdir -p /etc/confd/conf.d && mkdir -p /etc/confd/templates && \
 \
 # Install forego
-    cd /usr/local/bin && tar xfz /forego.zip && chmod +x /usr/local/bin/forego && rm /forego.zip
+    cd /usr/local/bin && tar xfz /forego.tgz && chmod +x /usr/local/bin/forego && rm /forego.tgz
 
 # Install kubectl
 ADD https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl /usr/local/bin/kubectl

--- a/ceph-releases/jewel/ubuntu/14.04/daemon/Dockerfile
+++ b/ceph-releases/jewel/ubuntu/14.04/daemon/Dockerfile
@@ -7,16 +7,9 @@
 FROM ceph/base:tag-build-master-jewel-ubuntu-14.04
 MAINTAINER Sébastien Han "seb@redhat.com"
 
-ADD my_init/my_init /sbin/my_init
-ADD 2.sh /etc/runit/2
-
 # Add templates for confd
 ADD ./confd/templates/* /etc/confd/templates/
 ADD ./confd/conf.d/* /etc/confd/conf.d/
-
-RUN chmod +x /sbin/my_init && \
-    mkdir -p /etc/container_environment && \
-    chmod +x /etc/runit/2
 
 # Add bootstrap script, ceph defaults key/values for KV store
 ADD entrypoint.sh config.*.sh ceph.defaults check_zombie_mons.py remove-mon.sh /

--- a/ceph-releases/jewel/ubuntu/14.04/daemon/entrypoint.sh
+++ b/ceph-releases/jewel/ubuntu/14.04/daemon/entrypoint.sh
@@ -40,8 +40,8 @@ set -e
 : ${GANESHA_EPOCH:=""} # For restarting
 
 if [ ! -z "${KV_CA_CERT}" ]; then
-	KV_TLS="--ca-cert=${KV_CA_CERT} --client-cert=${KV_CLIENT_CERT} --client-key=${KV_CLIENT_KEY}"
-	CONFD_KV_TLS="-scheme=https -client-ca-keys=${KV_CA_CERT} -client-cert=${KV_CLIENT_CERT} -client-key=${KV_CLIENT_KEY}"
+  KV_TLS="--ca-cert=${KV_CA_CERT} --client-cert=${KV_CLIENT_CERT} --client-key=${KV_CLIENT_KEY}"
+  CONFD_KV_TLS="-scheme=https -client-ca-keys=${KV_CA_CERT} -client-cert=${KV_CLIENT_CERT} -client-key=${KV_CLIENT_KEY}"
 fi
 
 CEPH_OPTS="--cluster ${CLUSTER}"
@@ -162,12 +162,12 @@ esac
 # CONFIG #
 ##########
 function kv {
-	# Note the 'cas' command puts a value in the KV store if it is empty
-	KEY="$1"
-	shift
-	VALUE="$*"
-	echo "adding key ${KEY} with value ${VALUE} to KV store"
-	kviator --kvstore=${KV_TYPE} --client=${KV_IP}:${KV_PORT} ${KV_TLS} cas ${CLUSTER_PATH}"${KEY}" "${VALUE}" || echo "value is already set"
+  # Note the 'cas' command puts a value in the KV store if it is empty
+  KEY="$1"
+  shift
+  VALUE="$*"
+  echo "adding key ${KEY} with value ${VALUE} to KV store"
+  kviator --kvstore=${KV_TYPE} --client=${KV_IP}:${KV_PORT} ${KV_TLS} cas ${CLUSTER_PATH}"${KEY}" "${VALUE}" || echo "value is already set"
 }
 
 function populate_kv {
@@ -388,9 +388,9 @@ function osd_directory {
     echo "created folder /var/lib/ceph/osd/${CLUSTER}-${OSD_ID}"
   fi
 
-	# Create the directory and an empty Procfile
-	mkdir -p /etc/forego/${CLUSTER}
-	echo "" > /etc/forego/${CLUSTER}/Procfile
+  # Create the directory and an empty Procfile
+  mkdir -p /etc/forego/${CLUSTER}
+  echo "" > /etc/forego/${CLUSTER}/Procfile
 
   for OSD_ID in $(ls /var/lib/ceph/osd |  awk 'BEGIN { FS = "-" } ; { print $2 }'); do
     if [ -n "${JOURNAL_DIR}" ]; then
@@ -593,9 +593,9 @@ function osd_disks {
   # make sure ceph owns the directory
   chown ceph. /var/lib/ceph/osd
 
-	# Create the directory and an empty Procfile
-	mkdir -p /etc/forego/${CLUSTER}
-	echo "" > /etc/forego/${CLUSTER}/Procfile
+  # Create the directory and an empty Procfile
+  mkdir -p /etc/forego/${CLUSTER}
+  echo "" > /etc/forego/${CLUSTER}/Procfile
 
   # check if anything is there, if not create an osd with directory
   if [[ -z "$(find /var/lib/ceph/osd -prune -empty)" ]]; then
@@ -613,11 +613,11 @@ function osd_disks {
         exit 1
       fi
 
-			echo "${CLUSTER}-${OSD_ID}: /usr/bin/ceph-osd ${CEPH_OPTS} -f -d -i ${OSD_ID} --setuser ceph --setgroup disk" | tee -a /etc/forego/${CLUSTER}/Procfile
+      echo "${CLUSTER}-${OSD_ID}: /usr/bin/ceph-osd ${CEPH_OPTS} -f -d -i ${OSD_ID} --setuser ceph --setgroup disk" | tee -a /etc/forego/${CLUSTER}/Procfile
 
     done
 
-		exec /usr/local/bin/forego start -f /etc/forego/${CLUSTER}/Procfile
+    exec /usr/local/bin/forego start -f /etc/forego/${CLUSTER}/Procfile
   else
     for i in ${OSD_DISKS}; do
       OSD_ID=$(echo ${i}|sed 's/\(.*\):\(.*\)/\1/')
@@ -651,13 +651,13 @@ function osd_disks {
           while [ -e /proc/${OSD_PID} ]; do sleep 1;done
       fi
 
-			echo "${CLUSTER}-${OSD_ID}: /usr/bin/ceph-osd ${CEPH_OPTS} -f -d -i ${OSD_ID} --setuser ceph --setgroup disk" | tee -a /etc/forego/${CLUSTER}/Procfile
+      echo "${CLUSTER}-${OSD_ID}: /usr/bin/ceph-osd ${CEPH_OPTS} -f -d -i ${OSD_ID} --setuser ceph --setgroup disk" | tee -a /etc/forego/${CLUSTER}/Procfile
 
 
     done
 
 
-		exec /usr/local/bin/forego start -f /etc/forego/${CLUSTER}/Procfile
+    exec /usr/local/bin/forego start -f /etc/forego/${CLUSTER}/Procfile
   fi
 }
 

--- a/ceph-releases/jewel/ubuntu/16.04/base/Dockerfile
+++ b/ceph-releases/jewel/ubuntu/16.04/base/Dockerfile
@@ -18,6 +18,10 @@ ADD https://github.com/AcalephStorage/kviator/releases/download/v${KVIATOR_VERSI
 # Download confd
 ADD https://github.com/kelseyhightower/confd/releases/download/v${CONFD_VERSION}/confd-${CONFD_VERSION}-linux-amd64 /usr/local/bin/confd
 
+# Download forego
+ADD https://bin.equinox.io/c/ekMN3bCZFUn/forego-stable-linux-amd64.tgz /forego.tgz
+
+
 # install prerequisites
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y wget unzip uuid-runtime python-setuptools udev runit sharutils python3 && \
 \
@@ -38,7 +42,10 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y wget unz
     cd /usr/local/bin && unzip /kviator.zip && chmod +x /usr/local/bin/kviator && rm /kviator.zip && \
 \
 # Install confd
-    chmod +x /usr/local/bin/confd && mkdir -p /etc/confd/conf.d && mkdir -p /etc/confd/templates
+    chmod +x /usr/local/bin/confd && mkdir -p /etc/confd/conf.d && mkdir -p /etc/confd/templates && \
+\
+# Install forego
+    cd /usr/local/bin && tar xfz /forego.zip && chmod +x /usr/local/bin/forego && rm /forego.zip
 
 # Install kubectl
 ADD https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl /usr/local/bin/kubectl
@@ -46,7 +53,6 @@ RUN chmod +x /usr/local/bin/kubectl
 
 ADD https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 /usr/local/bin/jq
 RUN chmod +x /usr/local/bin/jq
-
 
 ADD entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/ceph-releases/jewel/ubuntu/16.04/base/Dockerfile
+++ b/ceph-releases/jewel/ubuntu/16.04/base/Dockerfile
@@ -45,7 +45,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y wget unz
     chmod +x /usr/local/bin/confd && mkdir -p /etc/confd/conf.d && mkdir -p /etc/confd/templates && \
 \
 # Install forego
-    cd /usr/local/bin && tar xfz /forego.zip && chmod +x /usr/local/bin/forego && rm /forego.zip
+    cd /usr/local/bin && tar xfz /forego.tgz && chmod +x /usr/local/bin/forego && rm /forego.tgz
 
 # Install kubectl
 ADD https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl /usr/local/bin/kubectl

--- a/ceph-releases/jewel/ubuntu/16.04/daemon/Dockerfile
+++ b/ceph-releases/jewel/ubuntu/16.04/daemon/Dockerfile
@@ -10,16 +10,9 @@ MAINTAINER Sébastien Han "seb@redhat.com"
 # Add bootstrap script, ceph defaults key/values for KV store
 ADD entrypoint.sh config.*.sh ceph.defaults check_zombie_mons.py remove-mon.sh /
 
-ADD my_init/my_init /sbin/my_init
-ADD 2.sh /etc/runit/2
-
 # Add templates for confd
 ADD ./confd/templates/* /etc/confd/templates/
 ADD ./confd/conf.d/* /etc/confd/conf.d/
-
-RUN chmod +x /sbin/my_init && \
-    mkdir -p /etc/container_environment && \
-    chmod +x /etc/runit/2
 
 # Add volumes for Ceph config and data
 VOLUME ["/etc/ceph","/var/lib/ceph", "/etc/ganesha"]


### PR DESCRIPTION
It seems we've had a few issues with runit recently and thought I'd start a discussion (with code) for switching it out for something else.

We've used forego (a go based foreman replacement) in other projects so decided to test it out an alternative for launching multiple processes in ceph-docker. It's currently untested but thought I'd put it out there first before spending more time getting it ready.

The main change is that forego will run the processes specified in a 'Procfile' which is generated slightly differently to the runit. Overall there are slightly fewer dependencies with a single binary that will work across all base OSes. Logs are still sent to stdout/err with each line prefixed with the process name (cluster name and osd ID).

Thoughts? Not a visible change but may simplify things slightly