### PR TITLE
add a "SUCCESS" marking string

### DIFF
--- a/ceph-releases/hammer/ubuntu/14.04/daemon/entrypoint.sh
+++ b/ceph-releases/hammer/ubuntu/14.04/daemon/entrypoint.sh
@@ -131,6 +131,8 @@ function start_mon {
     rm /tmp/${CLUSTER}.mon.keyring
   fi
 
+  echo "SUCCESS"
+
   # start MON
   exec /usr/bin/ceph-mon ${CEPH_OPTS} -d -i ${MON_NAME} --public-addr "${MON_IP}:6789"
 }
@@ -232,6 +234,8 @@ EOF
     chmod +x /etc/service/${CLUSTER}-${OSD_ID}/run
   done
 
+echo "SUCCESS"
+
 exec /sbin/my_init
 }
 
@@ -275,6 +279,8 @@ function osd_disk {
   OSD_WEIGHT=$(df -P -k /var/lib/ceph/osd/${CLUSTER}-$OSD_ID/ | tail -1 | awk '{ d= $2/1073741824 ; r = sprintf("%.2f", d); print r }')
   ceph ${CEPH_OPTS} --name=osd.${OSD_ID} --keyring=/var/lib/ceph/osd/${CLUSTER}-${OSD_ID}/keyring osd crush create-or-move -- ${OSD_ID} ${OSD_WEIGHT} ${CRUSH_LOCATION}
 
+  echo "SUCCESS"
+
   exec /usr/bin/ceph-osd ${CEPH_OPTS} -f -d -i ${OSD_ID}
 }
 
@@ -294,6 +300,8 @@ function osd_activate {
   OSD_ID=$(cat /var/lib/ceph/osd/$(ls -ltr /var/lib/ceph/osd/ | tail -n1 | awk -v pattern="$CLUSTER" '$0 ~ pattern {print $9}')/whoami)
   OSD_WEIGHT=$(df -P -k /var/lib/ceph/osd/${CLUSTER}-$OSD_ID/ | tail -1 | awk '{ d= $2/1073741824 ; r = sprintf("%.2f", d); print r }')
   ceph ${CEPH_OPTS} --name=osd.${OSD_ID} --keyring=/var/lib/ceph/osd/${CLUSTER}-${OSD_ID}/keyring osd crush create-or-move -- ${OSD_ID} ${OSD_WEIGHT} ${CRUSH_LOCATION}
+
+  echo "SUCCESS"
 
   exec /usr/bin/ceph-osd ${CEPH_OPTS} -f -d -i ${OSD_ID}
 }
@@ -353,6 +361,8 @@ function start_mds {
     fi
   fi
 
+  echo "SUCCESS"
+
   # NOTE: prefixing this with exec causes it to die (commit suicide)
   /usr/bin/ceph-mds ${CEPH_OPTS} -d -i ${MDS_NAME}
 }
@@ -387,6 +397,8 @@ function start_rgw {
     ceph ${CEPH_OPTS} --name client.bootstrap-rgw --keyring /var/lib/ceph/bootstrap-rgw/${CLUSTER}.keyring auth get-or-create client.rgw.${RGW_NAME} osd 'allow rwx' mon 'allow rw' -o /var/lib/ceph/radosgw/${RGW_NAME}/keyring
   fi
 
+  echo "SUCCESS"
+
   if [ "$RGW_REMOTE_CGI" -eq 1 ]; then
     /usr/bin/radosgw -d ${CEPH_OPTS} -n client.rgw.${RGW_NAME} -k /var/lib/ceph/radosgw/$RGW_NAME/keyring --rgw-socket-path="" --rgw-frontends="fastcgi socket_port=$RGW_REMOTE_CGI_PORT socket_host=$RGW_REMOTE_CGI_HOST"
   else
@@ -418,6 +430,8 @@ function start_restapi {
   log file = ${RESTAPI_LOG_FILE}
 ENDHERE
   fi
+
+  echo "SUCCESS"
 
   # start ceph-rest-api
   exec /usr/bin/ceph-rest-api ${CEPH_OPTS} -n client.admin

--- a/ceph-releases/hammer/ubuntu/14.04/demo/entrypoint.sh
+++ b/ceph-releases/hammer/ubuntu/14.04/demo/entrypoint.sh
@@ -197,4 +197,5 @@ bootstrap_osd
 bootstrap_mds
 bootstrap_rgw
 bootstrap_rest_api
+echo "SUCCESS"
 exec ceph ${CEPH_OPTS} -w

--- a/ceph-releases/infernalis/ubuntu/14.04/daemon/entrypoint.sh
+++ b/ceph-releases/infernalis/ubuntu/14.04/daemon/entrypoint.sh
@@ -145,6 +145,8 @@ function start_mon {
     rm /tmp/${CLUSTER}.mon.keyring
   fi
 
+  echo "SUCCESS"
+
   # start MON
   exec /usr/bin/ceph-mon ${CEPH_OPTS} -d -i ${MON_NAME} --public-addr "${MON_IP}:6789" --setuser ceph --setgroup ceph
 }
@@ -248,6 +250,8 @@ exec ceph-osd ${CEPH_OPTS} -f -d -i ${OSD_ID} --osd-journal ${OSD_J} -k /var/lib
 EOF
     chmod +x /etc/service/${CLUSTER}-${OSD_ID}/run
   done
+
+echo "SUCCESS"
 
 exec /sbin/my_init
 }
@@ -379,6 +383,8 @@ function start_mds {
     fi
   fi
 
+  echo "SUCCESS"
+
   # NOTE: prefixing this with exec causes it to die (commit suicide)
   /usr/bin/ceph-mds ${CEPH_OPTS} -d -i ${MDS_NAME} --setuser ceph --setgroup ceph
 }
@@ -417,6 +423,8 @@ function start_rgw {
     create_socket_dir
   fi
 
+  echo "SUCCESS"
+
   if [ "$RGW_REMOTE_CGI" -eq 1 ]; then
     /usr/bin/radosgw -d ${CEPH_OPTS} -n client.rgw.${RGW_NAME} -k /var/lib/ceph/radosgw/$RGW_NAME/keyring --rgw-socket-path="" --rgw-frontends="fastcgi socket_port=$RGW_REMOTE_CGI_PORT socket_host=$RGW_REMOTE_CGI_HOST" --setuser ceph --setgroup ceph
   else
@@ -448,6 +456,8 @@ function start_restapi {
   log file = ${RESTAPI_LOG_FILE}
 ENDHERE
   fi
+
+  echo "SUCCESS"
 
   # start ceph-rest-api
   exec /usr/bin/ceph-rest-api ${CEPH_OPTS} -n client.admin

--- a/ceph-releases/infernalis/ubuntu/14.04/demo/entrypoint.sh
+++ b/ceph-releases/infernalis/ubuntu/14.04/demo/entrypoint.sh
@@ -212,4 +212,5 @@ bootstrap_osd
 bootstrap_mds
 bootstrap_rgw
 bootstrap_rest_api
+echo "SUCCESS"
 exec ceph ${CEPH_OPTS} -w

--- a/ceph-releases/jewel/redhat/7.2/entrypoint.sh
+++ b/ceph-releases/jewel/redhat/7.2/entrypoint.sh
@@ -269,6 +269,7 @@ function start_mon {
     rm /tmp/${CLUSTER}.mon.keyring
   fi
 
+  echo "SUCCESS"
   # start MON
   exec /usr/bin/ceph-mon ${CEPH_OPTS} -d -i ${MON_NAME} --public-addr "${MON_IP}:6789" --setuser ceph --setgroup ceph
 }
@@ -383,6 +384,7 @@ function osd_directory {
       ceph ${CEPH_OPTS} --name=osd.${OSD_ID} --keyring=/var/lib/ceph/osd/${CLUSTER}-${OSD_ID}/keyring osd crush create-or-move -- ${OSD_ID} ${OSD_WEIGHT} ${CRUSH_LOCATION}
     fi
 
+    echo "SUCCESS"
     echo "store-daemon: starting daemon on ${HOSTNAME}..."
     exec ceph-osd ${CEPH_OPTS} -f -d -i ${OSD_ID} --osd-journal ${OSD_J} -k /var/lib/ceph/osd/${CLUSTER}-${OSD_ID}/keyring
 
@@ -477,6 +479,7 @@ function osd_activate {
       echo "OSD (PID ${OSD_PID}) is running, waiting till it exits"
       while [ -e /proc/${OSD_PID} ]; do sleep 1;done
   else
+      echo "SUCCESS"
       exec /usr/bin/ceph-osd ${CEPH_OPTS} -f -d -i ${OSD_ID} --setuser ceph --setgroup disk
   fi
 }
@@ -511,6 +514,7 @@ function osd_activate_journal {
       echo "OSD (PID ${OSD_PID}) is running, waiting till it exits"
       while [ -e /proc/${OSD_PID} ]; do sleep 1;done
   else
+      echo "SUCCESS"
       exec /usr/bin/ceph-osd ${CEPH_OPTS} -f -d -i ${OSD_ID} --setuser ceph --setgroup disk
   fi
 }
@@ -575,6 +579,7 @@ function start_mds {
     fi
   fi
 
+  echo "SUCCESS"
   # NOTE: prefixing this with exec causes it to die (commit suicide)
   /usr/bin/ceph-mds ${CEPH_OPTS} -d -i ${MDS_NAME} --setuser ceph --setgroup ceph
 }
@@ -613,6 +618,7 @@ function start_rgw {
     chmod 0600 /var/lib/ceph/radosgw/${RGW_NAME}/keyring
   fi
 
+  echo "SUCCESS"
   if [ "$RGW_REMOTE_CGI" -eq 1 ]; then
     /usr/bin/radosgw -d ${CEPH_OPTS} -n client.rgw.${RGW_NAME} -k /var/lib/ceph/radosgw/$RGW_NAME/keyring --rgw-socket-path="" --rgw-zonegroup="$RGW_ZONEGROUP" --rgw-zone="$RGW_ZONE" --rgw-frontends="fastcgi socket_port=$RGW_REMOTE_CGI_PORT socket_host=$RGW_REMOTE_CGI_HOST" --setuser ceph --setgroup ceph
   else
@@ -663,6 +669,7 @@ function start_restapi {
 ENDHERE
   fi
 
+  echo "SUCCESS"
   # start ceph-rest-api
   exec /usr/bin/ceph-rest-api ${CEPH_OPTS} -n client.admin
 
@@ -691,6 +698,8 @@ function start_nfs {
   # Init RPC
   start_rpc
 
+  echo "SUCCESS"
+
   # start nfs
   exec /usr/bin/ganesha.nfsd -F ${GANESHA_OPTIONS} ${GANESHA_EPOCH}
 
@@ -709,6 +718,8 @@ function start_rbd_mirror {
   # ensure we have the admin key
   get_admin_key
   check_admin_key
+
+  echo "SUCCESS"
 
   # start rbd-mirror
   exec /usr/bin/rbd-mirror ${CEPH_OPTS} -d --setuser ceph --setgroup ceph

--- a/ceph-releases/jewel/ubuntu/14.04/daemon/entrypoint.sh
+++ b/ceph-releases/jewel/ubuntu/14.04/daemon/entrypoint.sh
@@ -274,6 +274,8 @@ function start_mon {
     rm /tmp/${CLUSTER}.mon.keyring
   fi
 
+  echo "SUCCESS"
+
   # start MON
   exec /usr/bin/ceph-mon ${CEPH_OPTS} -d -i ${MON_NAME} --public-addr "${MON_IP}:6789" --setuser ceph --setgroup ceph
 }
@@ -345,6 +347,7 @@ function osd_directory_single {
       # many thanks to Julien Danjou for the python piece
       if python -c "import sys, fcntl, struct; l = fcntl.fcntl(open('/var/lib/ceph/osd/${CLUSTER}-${OSD_ID}/fsid', 'a'), fcntl.F_GETLK, struct.pack('hhllhh', fcntl.F_WRLCK, 0, 0, 0, 0, 0)); l_type, l_whence, l_start, l_len, l_pid, l_sysid = struct.unpack('hhllhh', l); sys.exit(0 if l_type == fcntl.F_UNLCK else 1)"; then
         echo "Looks like OSD: ${OSD_ID} is not started, starting it..."
+        echo "SUCCESS"
         exec ceph-osd ${CEPH_OPTS} -f -d -i ${OSD_ID} -k /var/lib/ceph/osd/${CLUSTER}-${OSD_ID}/keyring
         break
       fi
@@ -353,6 +356,7 @@ function osd_directory_single {
 
   echo "Looks like all the OSDs are already running, doing nothing"
   echo "Exiting the container"
+  echo "SUCCESS"
   exit 0
 }
 
@@ -438,6 +442,8 @@ function osd_directory {
 echo "${CLUSTER}-${OSD_ID}: /usr/bin/ceph-osd ${CEPH_OPTS} -f -d -i ${OSD_ID} --osd-journal ${OSD_J} -k /var/lib/ceph/osd/${CLUSTER}-${OSD_ID}/keyring" | tee -a /etc/forego/${CLUSTER}/Procfile
 
   done
+
+echo "SUCCESS"
 
 exec /usr/local/bin/forego start -f /etc/forego/${CLUSTER}/Procfile
 }
@@ -558,6 +564,7 @@ function osd_activate {
       echo "OSD (PID ${OSD_PID}) is running, waiting till it exits"
       while [ -e /proc/${OSD_PID} ]; do sleep 1;done
   else
+      echo "SUCCESS"
       exec /usr/bin/ceph-osd ${CEPH_OPTS} -f -d -i ${OSD_ID} --setuser ceph --setgroup disk
   fi
 }
@@ -656,6 +663,7 @@ function osd_disks {
 
     done
 
+    echo "SUCCESS"
 
     exec /usr/local/bin/forego start -f /etc/forego/${CLUSTER}/Procfile
   fi
@@ -691,6 +699,7 @@ function osd_activate_journal {
       echo "OSD (PID ${OSD_PID}) is running, waiting till it exits"
       while [ -e /proc/${OSD_PID} ]; do sleep 1;done
   else
+      echo "SUCCESS"
       exec /usr/bin/ceph-osd ${CEPH_OPTS} -f -d -i ${OSD_ID} --setuser ceph --setgroup disk
   fi
 }
@@ -755,6 +764,7 @@ function start_mds {
     fi
   fi
 
+  echo "SUCCESS"
   # NOTE: prefixing this with exec causes it to die (commit suicide)
   /usr/bin/ceph-mds ${CEPH_OPTS} -d -i ${MDS_NAME} --setuser ceph --setgroup ceph
 }
@@ -792,6 +802,8 @@ function start_rgw {
     chown ceph. /var/lib/ceph/radosgw/${RGW_NAME}/keyring
     chmod 0600 /var/lib/ceph/radosgw/${RGW_NAME}/keyring
   fi
+
+  echo "SUCCESS"
 
   if [ "$RGW_REMOTE_CGI" -eq 1 ]; then
     /usr/bin/radosgw -d ${CEPH_OPTS} -n client.rgw.${RGW_NAME} -k /var/lib/ceph/radosgw/$RGW_NAME/keyring --rgw-socket-path="" --rgw-zonegroup="$RGW_ZONEGROUP" --rgw-zone="$RGW_ZONE" --rgw-frontends="fastcgi socket_port=$RGW_REMOTE_CGI_PORT socket_host=$RGW_REMOTE_CGI_HOST" --setuser ceph --setgroup ceph
@@ -843,6 +855,8 @@ function start_restapi {
 ENDHERE
   fi
 
+  echo "SUCCESS"
+
   # start ceph-rest-api
   exec /usr/bin/ceph-rest-api ${CEPH_OPTS} -n client.admin
 
@@ -862,6 +876,7 @@ function start_rbd_mirror {
   get_admin_key
   check_admin_key
 
+  echo "SUCCESS"
   # start rbd-mirror
   exec /usr/bin/rbd-mirror ${CEPH_OPTS} -d --setuser ceph --setgroup ceph
 
@@ -887,6 +902,7 @@ function start_nfs {
   # Init RPC
   start_rpc
 
+  echo "SUCCESS"
   # start ganesha
   exec /usr/bin/ganesha.nfsd -F ${GANESHA_OPTIONS} ${GANESHA_EPOCH}
 

--- a/ceph-releases/jewel/ubuntu/14.04/demo/entrypoint.sh
+++ b/ceph-releases/jewel/ubuntu/14.04/demo/entrypoint.sh
@@ -276,5 +276,5 @@ bootstrap_rgw
 bootstrap_demo_user
 bootstrap_rest_api
 bootstrap_nfs
-
+echo "SUCCESS"
 exec ceph ${CEPH_OPTS} -w


### PR DESCRIPTION
So that scripts can tell when an entrypoint is done right before the `exec` calls.

Fixes issue #399 