### PR TITLE
Fix CI errors caused by container status commands

### DIFF
--- a/travis-builds/purge_cluster.sh
+++ b/travis-builds/purge_cluster.sh
@@ -3,7 +3,12 @@
 
 # FUNCTIONS
 function purge_ceph {
-  docker stop $(docker ps -q)
+  container_count=$(docker ps -q | wc -l)
+
+  if [[ "${container_count}" -gt 0 ]]; then
+    docker stop $(docker ps -q) || echo failed to stop containers
+  fi
+
   rm -rf /var/lib/ceph/*
   rm -rf /etc/ceph
 }


### PR DESCRIPTION
The docker ps command was returning no containers that caused the docker
stop command to fail. That, combined with the set -e flag from the
caller was causing the purge_cluster.sh script to exit prematurely. This
prevented the purge_cluster.sh script from properly cleaning up previous
ceph configuration files.

Signed-off-by: Ivan Font <ifont@redhat.com>