### PR TITLE
ceph.conf tests

### DIFF
--- a/tests/base/test_ceph_conf.py
+++ b/tests/base/test_ceph_conf.py
@@ -5,4 +5,8 @@ class TestAllContainers(object):
     def test_ceph_fsid_exists(self, mon_containers, client):
         result = client.run(mon_containers, 'grep fsid /etc/ceph/ceph.conf').split()
         assert len(result) == 3
-        assert result[-1] != '='
+
+    def test_initial_members_is_defined(self, mon_containers, client):
+        result = client.run(mon_containers, 'grep "mon initial members" /etc/ceph/ceph.conf').split()
+        host_id = mon_containers['Id'][:12]
+        assert result[-1] == host_id

--- a/tests/base/test_ceph_conf.py
+++ b/tests/base/test_ceph_conf.py
@@ -1,0 +1,8 @@
+
+
+class TestAllContainers(object):
+
+    def test_ceph_fsid_exists(self, mon_containers, client):
+        result = client.run(mon_containers, 'grep fsid /etc/ceph/ceph.conf').split()
+        assert len(result) == 3
+        assert result[-1] != '='

--- a/tests/base/test_ceph_conf.py
+++ b/tests/base/test_ceph_conf.py
@@ -10,3 +10,15 @@ class TestAllContainers(object):
         result = client.run(mon_containers, 'grep "mon initial members" /etc/ceph/ceph.conf').split()
         host_id = mon_containers['Id'][:12]
         assert result[-1] == host_id
+
+    def test_cluster_is_required(self, mon_containers, client):
+        result = client.run(mon_containers, 'grep "auth cluster required" /etc/ceph/ceph.conf')
+        assert result == 'auth cluster required = cephx\n'
+
+    def test_service_is_required(self, mon_containers, client):
+        result = client.run(mon_containers, 'grep "auth service required" /etc/ceph/ceph.conf')
+        assert result == 'auth service required = cephx\n'
+
+    def test_client_is_required(self, mon_containers, client):
+        result = client.run(mon_containers, 'grep "auth client required" /etc/ceph/ceph.conf')
+        assert result == 'auth client required = cephx\n'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ import pytest
 
 def pytest_runtest_logreport(report):
     if report.failed:
-        try;
+        try:
             client = docker.Client('unix://var/run/docker.sock', version="auto")
         except DockerException as e:
             raise pytest.UsageError(


### PR DESCRIPTION
Adds a bunch of tests for `ceph.conf`, cleans up `conftest.py` that had some duplication, and adds a new helper for calling `execute` that should make it simpler to run commands on the containers