### PR TITLE
Timeout loop to detect IP addresses of ceph-mons

### DIFF
--- a/ceph-releases/jewel/ubuntu/14.04/daemon/config.k8s.sh
+++ b/ceph-releases/jewel/ubuntu/14.04/daemon/config.k8s.sh
@@ -10,8 +10,19 @@ function get_mon_config {
   # Get FSID from ceph.conf
   FSID=$(ceph-conf --lookup fsid -c /etc/ceph/ceph.conf)
 
-  # Get the ceph mon pods (name and IP) from the Kubernetes API. Formatted as a set of monmap params
-  MONMAP_ADD=$(kubectl get pods --namespace=${CLUSTER} -l daemon=mon -o template --template="{{range .items}}{{if .status.podIP}}--add {{.metadata.name}} {{.status.podIP}} {{end}} {{end}}")
+  timeout=10
+  MONMAP_ADD=""
+
+  while [[ -z "${MONMAP_ADD// }" && "${timeout}" -gt 0 ]]; do
+    # Get the ceph mon pods (name and IP) from the Kubernetes API. Formatted as a set of monmap params
+    MONMAP_ADD=$(kubectl get pods --namespace=${CLUSTER} -l daemon=mon -o template --template="{{range .items}}{{if .status.podIP}}--add {{.metadata.name}} {{.status.podIP}} {{end}} {{end}}")
+    (( timeout-- ))
+    sleep 1
+  done
+
+  if [[ -z "${MONMAP_ADD// }" ]]; then
+      exit 1
+  fi
 
   # Create a monmap with the Pod Names and IP
   monmaptool --create ${MONMAP_ADD} --fsid ${FSID} /etc/ceph/monmap-${CLUSTER}


### PR DESCRIPTION
Race condition at times prevents the proper detection of ceph-mon pod IP
addresses resulting in the creation of an invalid monmap. This change
implements a 10 second retry loop to attempt to grab the ceph-mon pod IP
addresses before giving up and exiting. If we exit, we allow kubernetes to
restart the pod.

Signed-off-by: Ivan Font <ifont@redhat.com>