### PR TITLE
Don't validate yml files for creating the cluster

### DIFF
--- a/examples/kubernetes/create_ceph_cluster.sh
+++ b/examples/kubernetes/create_ceph_cluster.sh
@@ -9,4 +9,4 @@ kubectl create \
 -f ceph-mon-v1-dp.yaml \
 -f ceph-mon-check-v1-dp.yaml \
 -f ceph-osd-v1-ds.yaml \
---namespace=ceph
+--namespace=ceph --validate=false


### PR DESCRIPTION
Executing the yml files in a kubernetes cluster with version 1.5.x raises invalid attributes for the yml file. This can be fixed adding the --validate=false on the kubectl call. 

