### PR TITLE
workflow changes for kraken

### DIFF
--- a/ceph-docker-workflow.sh
+++ b/ceph-docker-workflow.sh
@@ -87,7 +87,7 @@ function copy_files {
 
 function commit_new_changes {
   echo_info "CREATING COMMIT"
-  git add base daemon demo
+  git add base daemon demo || true
   git commit -s -m "Building $BRANCH_NAME"
 }
 

--- a/generate-dev-env.sh
+++ b/generate-dev-env.sh
@@ -40,7 +40,7 @@ function copy_files {
     mkdir -p $file_dir
     ln $orig_file $file_dir/
   done
-  echo ${dir} > base/SOURCE_TREE
+  echo ${dir} | tee base/SOURCE_TREE &> /dev/null || true
   echo ${dir} > daemon/SOURCE_TREE
   echo ${dir} > demo/SOURCE_TREE
 }
@@ -63,7 +63,7 @@ goto_basedir
 test_args $@
 
 case "$1" in
-  hammer|infernalis|jewel)
+  hammer|infernalis|jewel|kraken)
     case "$2" in
       centos|ubuntu|fedora|opensuse)
           test_combination $@

--- a/travis-builds/build_imgs.sh
+++ b/travis-builds/build_imgs.sh
@@ -7,36 +7,37 @@ set -xe
 # using "head" as a temporary solution
 function copy_dirs {
   # if base, daemon and demo exit we are testing a pushed branch and not a PR
-  if [[ ! -d daemon && ! -d base && ! -d demo ]]; then
+  if [[ (! -d daemon || ! -d base) && ! -d demo ]]; then
     dir_to_test=$(git diff --name-only HEAD~1 | tr " " "\n" | awk -F '/' '/ceph-releases/ {print $1,"/",$2,"/",$3,"/",$4}' | tr -d " " | sort -u | uniq)
     if [[ "$(echo $dir_to_test | tr " " "\n" | wc -l)" -ne 1 ]]; then
-      if [[ "$(echo $dir_to_test | tr " " "\n" | grep "jewel/ubuntu/14.04")" ]]; then
-        dir_to_test=$(git diff --name-only HEAD~1 | tr " " "\n" | awk -F '/' '/ceph-releases/ {print $1,"/",$2,"/",$3,"/",$4}' | tr -d " " | sort -u | uniq | grep "jewel/ubuntu/14.04")
+      if [[ "$(echo $dir_to_test | tr " " "\n" | grep "kraken/ubuntu/16.04")" ]]; then
+        dir_to_test=$(git diff --name-only HEAD~1 | tr " " "\n" | awk -F '/' '/ceph-releases/ {print $1,"/",$2,"/",$3,"/",$4}' | tr -d " " | sort -u | uniq | grep "kraken/ubuntu/16.04")
       else
         dir_to_test=$(git diff --name-only HEAD~1 | tr " " "\n" | awk -F '/' '/ceph-releases/ {print $1,"/",$2,"/",$3,"/",$4}' | tr -d " " | sort -u | uniq | head -1)
       fi
     fi
     if [[ ! -z "$dir_to_test" ]]; then
       mkdir -p {base,daemon,demo}
-      cp -Lrv $dir_to_test/base/* base
+      cp -Lrv $dir_to_test/base/* base || true
       cp -Lrv $dir_to_test/daemon/* daemon
       cp -Lrv $dir_to_test/demo/* demo
     else
       echo "looks like your commit did not bring any changes"
-      echo "building jewel ubuntu 14.04 anyway"
-      mkdir -p {base,daemon,demo}
-      cp -Lrv ceph-releases/jewel/ubuntu/14.04/base/* base
-      cp -Lrv ceph-releases/jewel/ubuntu/14.04/daemon/* daemon
-      cp -Lrv ceph-releases/jewel/ubuntu/14.04/demo/* demo
+      echo "building Kraken on Ubuntu 16.04"
+      mkdir -p {daemon,demo}
+      cp -Lrv ceph-releases/kraken/ubuntu/16.04/daemon/* daemon
+      cp -Lrv ceph-releases/kraken/ubuntu/16.04/demo/* demo
     fi
   fi
 }
 
 function build_base_img {
-  pushd base
-  docker build -t base .
-  rm -rf base
-  popd
+  if [[ -d base ]]; then
+    pushd base
+    docker build -t base .
+    rm -rf base
+    popd
+  fi
 }
 
 function build_daemon_img {


### PR DESCRIPTION
Now that kraken is out the workflow and the ci build need some refactor.
The main difference is that kraken doesn't have a base image anymore. We
also prioritize kraken in the build process if nothing is found.

Signed-off-by: Sébastien Han <seb@redhat.com>