### PR TITLE
opensuse: make zypper commands into a single RUN statement

### DIFF
--- a/ceph-releases/jewel/opensuse/Leap_42.2/base/Dockerfile
+++ b/ceph-releases/jewel/opensuse/Leap_42.2/base/Dockerfile
@@ -6,10 +6,9 @@ FROM opensuse:42.2
 MAINTAINER Ricardo Dias "rdias@suse.com"
 
 # Install Ceph
-RUN zypper -n ref
-RUN zypper -n install net-tools
-RUN zypper -n install "ceph<11" "ceph-radosgw<11" "rbd-mirror<11"
-
+RUN zypper -n ref && \
+    zypper -n install net-tools "ceph<11" "ceph-radosgw<11" "rbd-mirror<11" && \
+    zypper clean -a
 
 ADD entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
squashing multiple RUN statements onto one and reducing the image size
by cleaning up the zypper cache when we're done.

Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>