### PR TITLE
osd: add support for setting partition uuids

### DIFF
--- a/ceph-releases/kraken/centos/7/daemon/Dockerfile
+++ b/ceph-releases/kraken/centos/7/daemon/Dockerfile
@@ -19,7 +19,7 @@ RUN yum install -y unzip
 RUN rpm --import 'https://download.ceph.com/keys/release.asc'
 RUN rpm -Uvh http://download.ceph.com/rpm-${CEPH_VERSION}/el7/noarch/ceph-release-1-1.el7.noarch.rpm
 RUN yum install -y epel-release && yum clean all
-RUN yum install -y ceph ceph-radosgw rbd-mirror sharutils python34 nfs-ganesha-rgw nfs-ganesha-vfs nfs-ganesha-ceph && yum clean all
+RUN yum install -y ceph ceph-radosgw rbd-mirror sharutils python34 nfs-ganesha-rgw nfs-ganesha-vfs nfs-ganesha-ceph device-mapper && yum clean all
 
 # Install etcdctl
 RUN curl -L --remote-name https://github.com/coreos/etcd/releases/download/${ETCDCTL_VERSION}/etcd-${ETCDCTL_VERSION}-${ETCDCTL_ARCH}.tar.gz && tar xfz etcd-${ETCDCTL_VERSION}-${ETCDCTL_ARCH}.tar.gz -C /tmp/ etcd-${ETCDCTL_VERSION}-${ETCDCTL_ARCH}/etcdctl

--- a/ceph-releases/kraken/ubuntu/16.04/daemon/Dockerfile
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/Dockerfile
@@ -29,7 +29,7 @@ ADD https://bin.equinox.io/c/ekMN3bCZFUn/forego-stable-linux-amd64.tgz /forego.t
 
 
 # install prerequisites
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y wget unzip uuid-runtime python-setuptools udev runit sharutils python3 && \
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y wget unzip uuid-runtime python-setuptools udev runit sharutils python3 dmsetup && \
 \
 # install ceph and ganesha
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3FE869A9 && \

--- a/ceph-releases/kraken/ubuntu/16.04/daemon/osd_scenarios/osd_disk_activate.sh
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/osd_scenarios/osd_disk_activate.sh
@@ -16,7 +16,7 @@ function osd_activate {
     timeout 10 bash -c "while [ ! -e ${OSD_DEVICE} ]; do sleep 1; done"
     chown ceph. ${OSD_JOURNAL}
     if [[ ${OSD_DMCRYPT} -eq 1 ]]; then
-      ceph-disk -v --setuser ceph --setgroup disk --dmcrypt disk activate --no-start-daemon $(dev_part ${OSD_DEVICE} 1)
+      ceph-disk -v --setuser ceph --setgroup disk activate --dmcrypt --no-start-daemon $(dev_part ${OSD_DEVICE} 1)
     else
       ceph-disk -v --setuser ceph --setgroup disk activate --no-start-daemon $(dev_part ${OSD_DEVICE} 1)
     fi
@@ -25,7 +25,7 @@ function osd_activate {
     timeout 10 bash -c "while [ ! -e $(dev_part ${OSD_DEVICE} 1) ]; do sleep 1; done"
     chown ceph. $(dev_part ${OSD_DEVICE} 2)
     if [[ ${OSD_DMCRYPT} -eq 1 ]]; then
-      ceph-disk -v --setuser ceph --setgroup disk --dmcrypt activate --no-start-daemon $(dev_part ${OSD_DEVICE} 1)
+      ceph-disk -v --setuser ceph --setgroup disk activate --dmcrypt --no-start-daemon $(dev_part ${OSD_DEVICE} 1)
     else
       ceph-disk -v --setuser ceph --setgroup disk activate --no-start-daemon $(dev_part ${OSD_DEVICE} 1)
     fi

--- a/ceph-releases/kraken/ubuntu/16.04/daemon/osd_scenarios/osd_disk_activate.sh
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/osd_scenarios/osd_disk_activate.sh
@@ -16,20 +16,32 @@ function osd_activate {
     timeout 10 bash -c "while [ ! -e ${OSD_DEVICE} ]; do sleep 1; done"
     chown ceph. ${OSD_JOURNAL}
     if [[ ${OSD_DMCRYPT} -eq 1 ]]; then
+      echo "Mounting LOCKBOX directory"
+      # NOTE(leseb): adding || true so when this bug will be fixed the entrypoint will not fail
+      # Ceph bug tracker: http://tracker.ceph.com/issues/18945
+      mkdir -p /var/lib/ceph/osd-lockbox/$(blkid -o value -s PARTUUID ${OSD_DEVICE}1)
+      mount /dev/disk/by-partuuid/$(blkid -o value -s PARTUUID ${OSD_DEVICE}3) /var/lib/ceph/osd-lockbox/$(blkid -o value -s PARTUUID ${OSD_DEVICE}1) || true
       ceph-disk -v --setuser ceph --setgroup disk activate --dmcrypt --no-start-daemon $(dev_part ${OSD_DEVICE} 1)
+      OSD_ID=$(grep /dev/mapper/$(blkid -o value -s PARTUUID ${OSD_DEVICE}1) /proc/mounts | awk '{print $2}' | grep -oh '[0-9]*')
     else
       ceph-disk -v --setuser ceph --setgroup disk activate --no-start-daemon $(dev_part ${OSD_DEVICE} 1)
+      OSD_ID=$(grep "$(dev_part ${ACTUAL_OSD_DEVICE} 1)" /proc/mounts | awk '{print $2}' | grep -oh '[0-9]*')
     fi
-    OSD_ID=$(grep "$(dev_part ${ACTUAL_OSD_DEVICE} 1)" /proc/mounts | awk '{print $2}' | grep -oh '[0-9]*')
   else
     timeout 10 bash -c "while [ ! -e $(dev_part ${OSD_DEVICE} 1) ]; do sleep 1; done"
     chown ceph. $(dev_part ${OSD_DEVICE} 2)
     if [[ ${OSD_DMCRYPT} -eq 1 ]]; then
+      echo "Mounting LOCKBOX directory"
+      # NOTE(leseb): adding || true so when this bug will be fixed the entrypoint will not fail
+      # Ceph bug tracker: http://tracker.ceph.com/issues/18945
+      mkdir -p /var/lib/ceph/osd-lockbox/$(blkid -o value -s PARTUUID ${OSD_DEVICE}1)
+      mount /dev/disk/by-partuuid/$(blkid -o value -s PARTUUID ${OSD_DEVICE}3) /var/lib/ceph/osd-lockbox/$(blkid -o value -s PARTUUID ${OSD_DEVICE}1) || true
       ceph-disk -v --setuser ceph --setgroup disk activate --dmcrypt --no-start-daemon $(dev_part ${OSD_DEVICE} 1)
+      OSD_ID=$(grep /dev/mapper/$(blkid -o value -s PARTUUID ${OSD_DEVICE}1) /proc/mounts | awk '{print $2}' | grep -oh '[0-9]*')
     else
       ceph-disk -v --setuser ceph --setgroup disk activate --no-start-daemon $(dev_part ${OSD_DEVICE} 1)
+      OSD_ID=$(grep "$(dev_part ${ACTUAL_OSD_DEVICE} 1)" /proc/mounts | awk '{print $2}' | grep -oh '[0-9]*')
     fi
-    OSD_ID=$(grep "$(dev_part ${ACTUAL_OSD_DEVICE} 1)" /proc/mounts | awk '{print $2}' | grep -oh '[0-9]*')
   fi
   OSD_WEIGHT=$(df -P -k /var/lib/ceph/osd/${CLUSTER}-$OSD_ID/ | tail -1 | awk '{ d= $2/1073741824 ; r = sprintf("%.2f", d); print r }')
   ceph ${CEPH_OPTS} --name=osd.${OSD_ID} --keyring=/var/lib/ceph/osd/${CLUSTER}-${OSD_ID}/keyring osd crush create-or-move -- ${OSD_ID} ${OSD_WEIGHT} ${CRUSH_LOCATION}

--- a/ceph-releases/kraken/ubuntu/16.04/daemon/osd_scenarios/osd_disk_prepare.sh
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/osd_scenarios/osd_disk_prepare.sh
@@ -38,6 +38,10 @@ function osd_disk_prepare {
       # the admin key must be present on the node
       # in order to store the encrypted key in the monitor's k/v store
       ceph-disk -v prepare ${CEPH_OPTS} --journal-uuid ${OSD_JOURNAL_UUID} --lockbox-uuid ${OSD_LOCKBOX_UUID} --dmcrypt ${OSD_DEVICE} ${OSD_JOURNAL}
+      echo "Unmounting LOCKBOX directory"
+      # NOTE(leseb): adding || true so when this bug will be fixed the entrypoint will not fail
+      # Ceph bug tracker: http://tracker.ceph.com/issues/18944
+      umount /var/lib/ceph/osd-lockbox/$(blkid -o value -s PARTUUID ${OSD_DEVICE}1) || true
     else
       ceph-disk -v prepare ${CEPH_OPTS} --journal-uuid ${OSD_JOURNAL_UUID} ${OSD_DEVICE} ${OSD_JOURNAL}
     fi
@@ -51,6 +55,10 @@ function osd_disk_prepare {
       # the admin key must be present on the node
       # in order to store the encrypted key in the monitor's k/v store
       ceph-disk -v prepare ${CEPH_OPTS} --journal-uuid ${OSD_JOURNAL_UUID} --lockbox-uuid ${OSD_LOCKBOX_UUID} --dmcrypt ${OSD_DEVICE}
+      echo "Unmounting LOCKBOX directory"
+      # NOTE(leseb): adding || true so when this bug will be fixed the entrypoint will not fail
+      # Ceph bug tracker: http://tracker.ceph.com/issues/18944
+      umount /var/lib/ceph/osd-lockbox/$(blkid -o value -s PARTUUID ${OSD_DEVICE}1) || true
     else
       ceph-disk -v prepare ${CEPH_OPTS} --journal-uuid ${OSD_JOURNAL_UUID} ${OSD_DEVICE}
     fi

--- a/ceph-releases/kraken/ubuntu/16.04/daemon/osd_scenarios/osd_disk_prepare.sh
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/osd_scenarios/osd_disk_prepare.sh
@@ -37,9 +37,9 @@ function osd_disk_prepare {
       check_admin_key
       # the admin key must be present on the node
       # in order to store the encrypted key in the monitor's k/v store
-      ceph-disk -v prepare ${CEPH_OPTS} --dmcrypt ${OSD_DEVICE} ${OSD_JOURNAL}
+      ceph-disk -v prepare ${CEPH_OPTS} --journal-uuid ${OSD_JOURNAL_UUID} --lockbox-uuid ${OSD_LOCKBOX_UUID} --dmcrypt ${OSD_DEVICE} ${OSD_JOURNAL}
     else
-      ceph-disk -v prepare ${CEPH_OPTS} ${OSD_DEVICE} ${OSD_JOURNAL}
+      ceph-disk -v prepare ${CEPH_OPTS} --journal-uuid ${OSD_JOURNAL_UUID} ${OSD_DEVICE} ${OSD_JOURNAL}
     fi
     chown ceph. ${OSD_JOURNAL}
   else
@@ -50,9 +50,9 @@ function osd_disk_prepare {
       check_admin_key
       # the admin key must be present on the node
       # in order to store the encrypted key in the monitor's k/v store
-      ceph-disk -v prepare ${CEPH_OPTS} --dmcrypt ${OSD_DEVICE}
+      ceph-disk -v prepare ${CEPH_OPTS} --journal-uuid ${OSD_JOURNAL_UUID} --lockbox-uuid ${OSD_LOCKBOX_UUID} --dmcrypt ${OSD_DEVICE}
     else
-      ceph-disk -v prepare ${CEPH_OPTS} ${OSD_DEVICE}
+      ceph-disk -v prepare ${CEPH_OPTS} --journal-uuid ${OSD_JOURNAL_UUID} ${OSD_DEVICE}
     fi
     chown ceph. $(dev_part ${OSD_DEVICE} 2)
   fi

--- a/ceph-releases/kraken/ubuntu/16.04/daemon/variables_entrypoint.sh
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/variables_entrypoint.sh
@@ -10,6 +10,8 @@
 : ${OSD_JOURNAL_SIZE:=100}
 : ${OSD_BLUESTORE:=0}
 : ${OSD_DMCRYPT:=0}
+: ${OSD_JOURNAL_UUID:=$(uuidgen)}
+: ${OSD_LOCKBOX_UUID:=$(uuidgen)}
 : ${CRUSH_LOCATION:=root=default host=${HOSTNAME}}
 : ${CEPHFS_CREATE:=0}
 : ${CEPHFS_NAME:=cephfs}


### PR DESCRIPTION
We can now set a partition uuid for the journal and the lockbox (used
when dmcrypt is used).

Signed-off-by: Sébastien Han <seb@redhat.com>