### PR TITLE
Add MON_DATA_DIR var to allow data to be saved in a set directory

### DIFF
--- a/ceph-releases/kraken/ubuntu/16.04/daemon/start_mon.sh
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/start_mon.sh
@@ -45,7 +45,7 @@ function start_mon {
   fi
 
   # If we don't have a monitor keyring, this is a new monitor
-  if [ ! -e /var/lib/ceph/mon/${CLUSTER}-${MON_NAME}/keyring ]; then
+  if [ ! -e "$MON_DATA_DIR/keyring" ]; then
 
     get_mon_config
     create_socket_dir
@@ -69,11 +69,11 @@ function start_mon {
     chown ceph. /tmp/${CLUSTER}.mon.keyring
 
     # Make the monitor directory
-    mkdir -p /var/lib/ceph/mon/${CLUSTER}-${MON_NAME}
-    chown ceph. /var/lib/ceph/mon/${CLUSTER}-${MON_NAME}
+    mkdir -p "$MON_DATA_DIR"
+    chown ceph. "$MON_DATA_DIR"
 
     # Prepare the monitor daemon's directory with the map and keyring
-    ceph-mon --setuser ceph --setgroup ceph --mkfs -i ${MON_NAME} --monmap /etc/ceph/monmap-${CLUSTER} --keyring /tmp/${CLUSTER}.mon.keyring --mon-data /var/lib/ceph/mon/${CLUSTER}-${MON_NAME}
+    ceph-mon --setuser ceph --setgroup ceph --mkfs -i ${MON_NAME} --monmap /etc/ceph/monmap-${CLUSTER} --keyring /tmp/${CLUSTER}.mon.keyring --mon-data "$MON_DATA_DIR"
 
     # Clean up the temporary key
     rm /tmp/${CLUSTER}.mon.keyring

--- a/ceph-releases/kraken/ubuntu/16.04/daemon/variables_entrypoint.sh
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/variables_entrypoint.sh
@@ -4,6 +4,7 @@
 : ${CEPH_GET_ADMIN_KEY:=0}
 : ${HOSTNAME:=$(hostname -s)}
 : ${MON_NAME:=${HOSTNAME}}
+: ${MON_DATA_DIR:=/var/lib/ceph/mon/${CLUSTER}-${MON_NAME}}
 : ${NETWORK_AUTO_DETECT:=0}
 : ${MDS_NAME:=mds-${HOSTNAME}}
 : ${OSD_FORCE_ZAP:=0}

--- a/ceph-releases/kraken/ubuntu/16.04/demo/entrypoint.sh
+++ b/ceph-releases/kraken/ubuntu/16.04/demo/entrypoint.sh
@@ -4,6 +4,7 @@ set -e
 : ${CLUSTER:=ceph}
 : ${RGW_NAME:=$(hostname -s)}
 : ${MON_NAME:=$(hostname -s)}
+: ${MON_DATA_DIR:=/var/lib/ceph/mon/${CLUSTER}-${MON_NAME}}
 : ${RGW_CIVETWEB_PORT:=80}
 : ${NETWORK_AUTO_DETECT:=0}
 : ${RESTAPI_IP:=0.0.0.0}
@@ -117,7 +118,7 @@ ENDHERE
   fi
 
   # If we don't have a monitor keyring, this is a new monitor
-  if [ ! -e /var/lib/ceph/mon/${CLUSTER}-${MON_NAME}/keyring ]; then
+  if [ ! -e "$MON_DATA_DIR/keyring" ]; then
 
     if [ ! -e /etc/ceph/${CLUSTER}.client.admin.keyring ]; then
       log "ERROR- /etc/ceph/${CLUSTER}.client.admin.keyring must exist; get it from your existing mon"
@@ -139,7 +140,7 @@ ENDHERE
     ceph-authtool /tmp/${CLUSTER}.mon.keyring --import-keyring /etc/ceph/${CLUSTER}.mon.keyring
 
     # Make the monitor directory
-    mkdir -p /var/lib/ceph/mon/${CLUSTER}-${MON_NAME}
+    mkdir -p "$MON_DATA_DIR"
 
     # Make user 'ceph' the owner of all the tree
     chown ceph. /var/lib/ceph/bootstrap-{osd,mds,rgw}
@@ -147,7 +148,7 @@ ENDHERE
     # Prepare the monitor daemon's directory with the map and keyring
     chown -R ceph. /var/lib/ceph/mon
     ceph-mon ${CEPH_OPTS} --mkfs -i ${MON_NAME} --monmap /etc/ceph/monmap-${CLUSTER} --keyring /tmp/${CLUSTER}.mon.keyring
-    ceph-mon ${CEPH_OPTS} --setuser ceph --setgroup ceph --mkfs -i ${MON_NAME} --monmap /etc/ceph/monmap-${CLUSTER} --keyring /tmp/${CLUSTER}.mon.keyring --mon-data /var/lib/ceph/mon/${CLUSTER}-${MON_NAME}
+    ceph-mon ${CEPH_OPTS} --setuser ceph --setgroup ceph --mkfs -i ${MON_NAME} --monmap /etc/ceph/monmap-${CLUSTER} --keyring /tmp/${CLUSTER}.mon.keyring --mon-data "$MON_DATA_DIR"
 
     # Clean up the temporary key
     rm /tmp/${CLUSTER}.mon.keyring


### PR DESCRIPTION
This fixes issues when all Ceph Mon Pods are deleted and recreated. As they don't come up with the old data and are missing their original data.

Closes https://github.com/ceph/ceph-docker/issues/485