### PR TITLE
zap_device: 'Payload offset' unit is sector size

### DIFF
--- a/ceph-releases/kraken/ubuntu/16.04/daemon/zap_device.sh
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/zap_device.sh
@@ -34,8 +34,13 @@ function zap_device {
       # erase all keyslots (remove encryption key)
       cryptsetup --verbose --batch-mode erase /dev/disk/by-partuuid/$dm_uuid
       payload_offset=$(cryptsetup luksDump /dev/disk/by-partuuid/$dm_uuid | awk '/Payload offset:/ { print $3 }')
+      phys_sector_size=$(blockdev --getpbsz /dev/disk/by-partuuid/$dm_uuid)
+      if ! is_integer "$phys_sector_size"; then
+        # If the sector size isn't a number, let's default to 512
+        phys_sector_size=512
+      fi
       # remove LUKS header
-      dd if=/dev/zero of=/dev/disk/by-partuuid/$dm_uuid bs=512 count=$payload_offset oflag=direct
+      dd if=/dev/zero of=/dev/disk/by-partuuid/$dm_uuid bs=$phys_sector_size count=$payload_offset oflag=direct
     done
   fi
 

--- a/ceph-releases/kraken/ubuntu/16.04/daemon/zap_device.sh
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/zap_device.sh
@@ -29,18 +29,20 @@ function zap_device {
   ceph_dm=$(blkid -t TYPE="crypto_LUKS" ${OSD_DEVICE}* -o value -s PARTUUID || true)
   if [[ -n $ceph_dm ]]; then
     for dm_uuid in $ceph_dm; do
+      dm_path="/dev/disk/by-partuuid/$dm_uuid"
       dmsetup --verbose --force wipe_table $dm_uuid || true
       dmsetup --verbose --force remove $dm_uuid || true
+
       # erase all keyslots (remove encryption key)
-      cryptsetup --verbose --batch-mode erase /dev/disk/by-partuuid/$dm_uuid
-      payload_offset=$(cryptsetup luksDump /dev/disk/by-partuuid/$dm_uuid | awk '/Payload offset:/ { print $3 }')
-      phys_sector_size=$(blockdev --getpbsz /dev/disk/by-partuuid/$dm_uuid)
+      cryptsetup --verbose --batch-mode erase $dm_path
+      payload_offset=$(cryptsetup luksDump $dm_path | awk '/Payload offset:/ { print $3 }')
+      phys_sector_size=$(blockdev --getpbsz $dm_path)
       if ! is_integer "$phys_sector_size"; then
         # If the sector size isn't a number, let's default to 512
         phys_sector_size=512
       fi
       # remove LUKS header
-      dd if=/dev/zero of=/dev/disk/by-partuuid/$dm_uuid bs=$phys_sector_size count=$payload_offset oflag=direct
+      dd if=/dev/zero of=$dm_path bs=$phys_sector_size count=$payload_offset oflag=direct
     done
   fi
 


### PR DESCRIPTION
'Payload Offset' field from crypsetup return a number of physical sectors.

The actual code is considering the sector size to be 512 when devices can report a different value like 4096.

This patch is about reading the physical block device size by using blockdev, and use it on the 'dd' command line to specify the proper 'bs' field.
If we fail at detecting that value, then we default to 512 which is the legacy value for sectors.