### PR TITLE
cleanup: bash eq compare means integer not text

### DIFF
--- a/ceph-releases/kraken/ubuntu/16.04/daemon/osd_scenarios/osd_disks.sh
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/osd_scenarios/osd_disks.sh
@@ -44,7 +44,7 @@ function osd_disks {
     OSD_DEV="/dev/$(echo ${OSD_DISK}|sed 's/\(.*\):\(.*\)/\2/')"
 
     if [[ "$(parted --script ${OSD_DEV} print | egrep '^ 1.*ceph data')" ]]; then
-      if [[ ${OSD_FORCE_ZAP} -eq "1" ]]; then
+      if [[ ${OSD_FORCE_ZAP} -eq 1 ]]; then
         ceph-disk -v zap ${OSD_DEV}
       else
         log "ERROR- It looks like the device ($OSD_DEV) is an OSD, set OSD_FORCE_ZAP=1 to use this device anyway and zap its content"

--- a/ceph-releases/kraken/ubuntu/16.04/daemon/start_mds.sh
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/start_mds.sh
@@ -40,7 +40,7 @@ function start_mds {
     get_admin_key
     check_admin_key
 
-    if [[ "$(ceph fs ls | grep -c name:.${CEPHFS_NAME},)" -eq "0" ]]; then
+    if [[ "$(ceph fs ls | grep -c name:.${CEPHFS_NAME},)" -eq 0 ]]; then
        # Make sure the specified data pool exists
        if ! ceph ${CEPH_OPTS} osd pool stats ${CEPHFS_DATA_POOL} > /dev/null 2>&1; then
           ceph ${CEPH_OPTS} osd pool create ${CEPHFS_DATA_POOL} ${CEPHFS_DATA_POOL_PG}

--- a/ceph-releases/kraken/ubuntu/16.04/daemon/start_osd.sh
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/start_osd.sh
@@ -5,7 +5,7 @@ function start_osd {
   get_config
   check_config
 
-  if [ ${CEPH_GET_ADMIN_KEY} -eq "1" ]; then
+  if [ ${CEPH_GET_ADMIN_KEY} -eq 1 ]; then
     get_admin_key
     check_admin_key
   fi

--- a/ceph-releases/kraken/ubuntu/16.04/daemon/start_rgw.sh
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/start_rgw.sh
@@ -5,7 +5,7 @@ function start_rgw {
   get_config
   check_config
 
-  if [ ${CEPH_GET_ADMIN_KEY} -eq "1" ]; then
+  if [ ${CEPH_GET_ADMIN_KEY} -eq 1 ]; then
     get_admin_key
     check_admin_key
   fi


### PR DESCRIPTION
When doing a test -eq, having quotes around the right value is clearly misleading as we do compare integers not text.

This patch is just about removing the quotes around the right member.