### PR TITLE
cleanup: Avoid inverted logic

### DIFF
--- a/ceph-releases/kraken/ubuntu/16.04/daemon/config.kv.sh
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/config.kv.sh
@@ -6,7 +6,7 @@ sed -r "s/@CLUSTER@/${CLUSTER:-ceph}/g" \
 
 # make sure etcd uses http or https as a prefix
 if [[ "$KV_TYPE" == "etcd" ]]; then
-  if [ ! -z "${KV_CA_CERT}" ]; then
+  if [ -n "${KV_CA_CERT}" ]; then
   	CONFD_NODE_SCHEMA="https://"
   else
     CONFD_NODE_SCHEMA="http://"

--- a/ceph-releases/kraken/ubuntu/16.04/daemon/config.static.sh
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/config.static.sh
@@ -23,7 +23,7 @@ osd journal size = ${OSD_JOURNAL_SIZE}
 ENDHERE
 
     if command -v ip; then
-      if [[ ! -z "$(ip -6 -o a | grep scope.global | awk '/eth/ { sub ("/..", "", $4); print $4 }' | head -n1)" ]]; then
+      if [[ -n "$(ip -6 -o a | grep scope.global | awk '/eth/ { sub ("/..", "", $4); print $4 }' | head -n1)" ]]; then
         echo "ms_bind_ipv6 = true" >> /etc/ceph/${CLUSTER}.conf
         sed -i '/mon host/d' /etc/ceph/${CLUSTER}.conf
         echo "mon host = ${MON_IP}" >> /etc/ceph/${CLUSTER}.conf

--- a/ceph-releases/kraken/ubuntu/16.04/daemon/entrypoint.sh
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/entrypoint.sh
@@ -110,7 +110,7 @@ case "$CEPH_DAEMON" in
     watch_mon_health
     ;;
   *)
-  if [ ! -n "$CEPH_DAEMON" ]; then
+  if [ -z "$CEPH_DAEMON" ]; then
     log "ERROR- One of CEPH_DAEMON or a daemon parameter must be defined as the name "
     log "of the daemon you want to deploy."
     log "Valid values for CEPH_DAEMON are MON, OSD, OSD_DIRECTORY, OSD_CEPH_DISK, OSD_CEPH_DISK_PREPARE, OSD_CEPH_DISK_ACTIVATE, OSD_CEPH_ACTIVATE_JOURNAL, MDS, RGW, RGW_USER, RESTAPI, ZAP_DEVICE, RBD_MIRROR, NFS"

--- a/ceph-releases/kraken/ubuntu/16.04/daemon/start_mon.sh
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/start_mon.sh
@@ -3,12 +3,12 @@ set -e
 
 function start_mon {
   if [[ ${NETWORK_AUTO_DETECT} -eq 0 ]]; then
-      if [[ ! -n "$CEPH_PUBLIC_NETWORK" ]]; then
+      if [[ -z "$CEPH_PUBLIC_NETWORK" ]]; then
         log "ERROR- CEPH_PUBLIC_NETWORK must be defined as the name of the network for the OSDs"
         exit 1
       fi
 
-      if [[ ! -n "$MON_IP" ]]; then
+      if [[ -z "$MON_IP" ]]; then
         log "ERROR- MON_IP must be defined as the IP address of the monitor"
         exit 1
       fi

--- a/ceph-releases/kraken/ubuntu/16.04/daemon/variables_entrypoint.sh
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/variables_entrypoint.sh
@@ -39,7 +39,7 @@
 : ${GANESHA_OPTIONS:=""}
 : ${GANESHA_EPOCH:=""} # For restarting
 
-if [ ! -z "${KV_CA_CERT}" ]; then
+if [ -n "${KV_CA_CERT}" ]; then
   KV_TLS="--ca-cert=${KV_CA_CERT} --client-cert=${KV_CLIENT_CERT} --client-key=${KV_CLIENT_KEY}"
   CONFD_KV_TLS="-scheme=https -client-ca-keys=${KV_CA_CERT} -client-cert=${KV_CLIENT_CERT} -client-key=${KV_CLIENT_KEY}"
 fi

--- a/ceph-releases/kraken/ubuntu/16.04/daemon/zap_device.sh
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/zap_device.sh
@@ -27,7 +27,7 @@ function zap_device {
 
   # look for Ceph encrypted partitions
   ceph_dm=$(blkid -t TYPE="crypto_LUKS" ${OSD_DEVICE}* -o value -s PARTUUID || true)
-  if [[ ! -z $ceph_dm ]]; then
+  if [[ -n $ceph_dm ]]; then
     for dm_uuid in $ceph_dm; do
       dmsetup --verbose --force wipe_table $dm_uuid || true
       dmsetup --verbose --force remove $dm_uuid || true


### PR DESCRIPTION
In the whole code base, we have a several inverted logic.

Using the "! -z" syntax is just a "-n" test.

This simple patch is just about using the direct way of testing instead of using the inverted logic.
This makes the code more straigh-forward to read.