### PR TITLE
start_mon: Reworking network detection

### DIFF
--- a/ceph-releases/kraken/ubuntu/16.04/daemon/common_functions.sh
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/common_functions.sh
@@ -39,6 +39,11 @@ function prefix_length {
   done
 }
 
+# Test if a command line tool is available
+function is_available {
+  command -v $@ &>/dev/null
+}
+
 # create the mandatory directories
 function create_mandatory_directories {
   # Let's create the bootstrap directories

--- a/ceph-releases/kraken/ubuntu/16.04/daemon/start_mon.sh
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/start_mon.sh
@@ -145,5 +145,5 @@ function start_mon {
   log "SUCCESS"
 
   # start MON
-  exec /usr/bin/ceph-mon ${CEPH_OPTS} -d -i ${MON_NAME} --public-addr "${MON_IP}:6789" --setuser ceph --setgroup ceph --mon-data "$MON_DATA_DIR"
+  exec /usr/bin/ceph-mon ${CEPH_OPTS} -d -i ${MON_NAME} --setuser ceph --setgroup ceph --mon-data "$MON_DATA_DIR"
 }


### PR DESCRIPTION
The actual code is using a lot of regexp and a complex logic to define if we should use ipv4 or ipv6.

This patch try to simplify the read of the start_mon() function by:
- adding basic functions to extract ip or network information
- embedded the logic if 'ip' is missing directly in those functions
- improve the ipv6 support
- simplify the logic by making common calls between ipv4|6

First, the get_ip & get_network functions are created to externalize
the detection code from the main function. This way the logic is easier
to read.

This logic is simplified by unificating cases where NETWORK_AUTO_DETECT > 1 (aka 4 or 6).
We now have the same code base for both.

The newly created functions embedded the logic to detect the network configuration regarding if 'ip' is present or not.

For IPV6, some code is added to read ipv6_route or if_inet6 from /proc to extract the relevant information.
A flat_to_ipv6 function is added to transform ipv6 address in a short expression.

This patch embedded a fix for the NETWORK_AUTO_DETECT=6 case where the network was detecting by using an IPv4 regexp.