### PR TITLE
start_rgw: Avoid duplicated code

### DIFF
--- a/ceph-releases/kraken/ubuntu/16.04/daemon/common_functions.sh
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/common_functions.sh
@@ -59,6 +59,9 @@ function create_mandatory_directories {
   # Create socket directory
   mkdir -p /var/run/ceph
 
+  # Creating rados directories
+  mkdir -p /var/lib/ceph/radosgw/${RGW_NAME}
+
   # Adjust the owner of all those directories
   chown -R ceph. /var/run/ceph/ /var/lib/ceph/*
 }

--- a/ceph-releases/kraken/ubuntu/16.04/daemon/start_rgw.sh
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/start_rgw.sh
@@ -13,9 +13,6 @@ function start_rgw {
   # Check to see if our RGW has been initialized
   if [ ! -e /var/lib/ceph/radosgw/${RGW_NAME}/keyring ]; then
 
-    mkdir -p /var/lib/ceph/radosgw/${RGW_NAME}
-    chown ceph. /var/lib/ceph/radosgw/${RGW_NAME}
-
     if [ ! -e /var/lib/ceph/bootstrap-rgw/${CLUSTER}.keyring ]; then
       log "ERROR- /var/lib/ceph/bootstrap-rgw/${CLUSTER}.keyring must exist. You can extract it from your current monitor by running 'ceph auth get client.bootstrap-rgw -o /var/lib/ceph/bootstrap-rgw/${CLUSTER}.keyring'"
       exit 1
@@ -47,7 +44,6 @@ function create_rgw_user {
     exit 1
   fi
 
-  mkdir -p "/var/lib/ceph/radosgw/${RGW_NAME}"
   mv /var/lib/ceph/radosgw/keyring /var/lib/ceph/radosgw/${RGW_NAME}/keyring
 
   USER_KEY=""


### PR DESCRIPTION
In this program, there is two occurences of duplicated code that over-complicate the reading.

This patch just take care of getting the conditional code being smaller
and then execute the command with arguments.

This patch is also adding an exec prior the final command as per docker rule.
The last process to be executed should be run in exec when using bash as init.