### PR TITLE
populate_kv: 'cat file | grep x' is 'grep x file'

### DIFF
--- a/ceph-releases/kraken/ubuntu/16.04/daemon/populate_kv.sh
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/populate_kv.sh
@@ -21,7 +21,7 @@ function populate_kv {
             DEFAULTS_PATH="/ceph.defaults"
           fi
           # read defaults file, grab line with key<space>value without comment #
-          cat "$DEFAULTS_PATH" | grep '^.* .*' | grep -v '#' | while read line; do
+          grep '^.* .*' "$DEFAULTS_PATH" | grep -v '#' | while read line; do
             kv `echo $line`
           done
           ;;


### PR DESCRIPTION
cat | grep is just grep. So let's remove a useless command here