### PR TITLE
ensure packages are installed after "yum install"

### DIFF
--- a/ceph-releases/hammer/centos/7/base/Dockerfile
+++ b/ceph-releases/hammer/centos/7/base/Dockerfile
@@ -20,7 +20,8 @@ RUN yum install -y runit-2.1.1-7.el7.centos.x86_64
 RUN rpm --import 'https://download.ceph.com/keys/release.asc'
 RUN rpm -Uvh https://download.ceph.com/rpm-${CEPH_VERSION}/el7/noarch/ceph-release-1-1.el7.noarch.rpm
 RUN yum install -y epel-release && yum clean all
-RUN yum install -y ceph ceph-radosgw sharutils && yum clean all
+ARG PACKAGES="ceph ceph-radosgw sharutils"
+RUN yum install -y $PACKAGES && rpm -q $PACKAGES && yum clean all
 ENV KVIATOR_VERSION 0.0.7
 ENV CONFD_VERSION 0.10.0
 

--- a/ceph-releases/jewel/centos/7/base/Dockerfile
+++ b/ceph-releases/jewel/centos/7/base/Dockerfile
@@ -19,7 +19,8 @@ RUN yum install -y unzip
 RUN rpm --import 'https://download.ceph.com/keys/release.asc'
 RUN rpm -Uvh http://download.ceph.com/rpm-${CEPH_VERSION}/el7/noarch/ceph-release-1-1.el7.noarch.rpm
 RUN yum install -y epel-release && yum clean all
-RUN yum install -y ceph ceph-radosgw rbd-mirror sharutils python34 nfs-ganesha-rgw nfs-ganesha-vfs nfs-ganesha-ceph && yum clean all
+ARG PACKAGES="ceph ceph-radosgw rbd-mirror sharutils python34"
+RUN yum install -y $PACKAGES && rpm -q $PACKAGES && yum clean all
 
 # Install etcdctl
 RUN curl -L --remote-name https://github.com/coreos/etcd/releases/download/${ETCDCTL_VERSION}/etcd-${ETCDCTL_VERSION}-${ETCDCTL_ARCH}.tar.gz && tar xfz etcd-${ETCDCTL_VERSION}-${ETCDCTL_ARCH}.tar.gz -C /tmp/ etcd-${ETCDCTL_VERSION}-${ETCDCTL_ARCH}/etcdctl

--- a/ceph-releases/jewel/ubuntu/14.04/base/Dockerfile
+++ b/ceph-releases/jewel/ubuntu/14.04/base/Dockerfile
@@ -21,15 +21,17 @@ ADD https://github.com/kelseyhightower/confd/releases/download/v${CONFD_VERSION}
 # Download forego
 ADD https://bin.equinox.io/c/ekMN3bCZFUn/forego-stable-linux-amd64.tgz /forego.tgz
 
+# Packages list
+ARG PACKAGES="ceph radosgw rbd-mirror"
+
 # install prerequisites
 RUN DEBIAN_FRONTEND=noninteractive apt-get update &&  apt-get install -y wget unzip uuid-runtime python-setuptools udev sharutils && \
 \
 # install ceph and ganesha
-    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3FE869A9 && \
-    echo "deb http://ppa.launchpad.net/gluster/libntirpc/ubuntu trusty main" | tee /etc/apt/sources.list.d/libntirpc.list && \
     wget -q -O- 'https://download.ceph.com/keys/release.asc' | apt-key add - && \
     echo "deb http://download.ceph.com/debian-$CEPH_VERSION/ trusty main" | tee /etc/apt/sources.list.d/ceph-$CEPH_VERSION.list && \
-    apt-get update && apt-get install -y --force-yes ceph radosgw rbd-mirror && \
+    apt-get update && apt-get install -y --force-yes $PACKAGES && \
+    dpkg -s $PACKAGES && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
 \
 # Install etcdctl

--- a/ceph-releases/kraken/centos/7/daemon/Dockerfile
+++ b/ceph-releases/kraken/centos/7/daemon/Dockerfile
@@ -15,7 +15,8 @@ RUN yum install -y unzip
 RUN rpm --import 'https://download.ceph.com/keys/release.asc'
 RUN rpm -Uvh http://download.ceph.com/rpm-${CEPH_VERSION}/el7/noarch/ceph-release-1-1.el7.noarch.rpm
 RUN yum install -y epel-release && yum clean all
-RUN yum install -y ceph-mon ceph-osd ceph-mds ceph-mgr ceph-base ceph-common ceph-radosgw rbd-mirror nfs-ganesha-rgw nfs-ganesha-vfs nfs-ganesha-ceph device-mapper sharutils etcd kubernetes-client && yum clean all
+ARG PACKAGES="ceph-mon ceph-osd ceph-mds ceph-mgr ceph-base ceph-common ceph-radosgw rbd-mirror device-mapper sharutils etcd kubernetes-client"
+RUN yum install -y $PACKAGES && rpm -q $PACKAGES && yum clean all
 
 # Install confd
 ADD https://github.com/kelseyhightower/confd/releases/download/v${CONFD_VERSION}/confd-${CONFD_VERSION}-linux-amd64 /usr/local/bin/confd

--- a/ceph-releases/kraken/ubuntu/16.04/daemon/Dockerfile
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/Dockerfile
@@ -15,15 +15,17 @@ ADD https://github.com/kelseyhightower/confd/releases/download/v${CONFD_VERSION}
 # Download forego
 ADD https://bin.equinox.io/c/ekMN3bCZFUn/forego-stable-linux-amd64.tgz /forego.tgz
 
+# Packages list
+ARG PACKAGES="ceph-mon ceph-osd ceph-mds ceph-mgr ceph-base ceph-common radosgw rbd-mirror sharutils etcd"
+
 # install prerequisites
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y wget unzip uuid-runtime python-setuptools udev dmsetup && \
 \
 # Install ceph, ganesha and etcd
-    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3FE869A9 && \
-    echo "deb http://ppa.launchpad.net/gluster/libntirpc/ubuntu xenial main" | tee /etc/apt/sources.list.d/libntirpc.list && \
     wget -q -O- 'https://download.ceph.com/keys/release.asc' | apt-key add - && \
     echo "deb http://download.ceph.com/debian-$CEPH_VERSION/ xenial main" | tee /etc/apt/sources.list.d/ceph-$CEPH_VERSION.list && \
-    apt-get update && apt-get install -y --force-yes ceph-mon ceph-osd ceph-mds ceph-mgr ceph-base ceph-common radosgw rbd-mirror sharutils etcd && \
+    apt-get update && apt-get install -y --force-yes $PACKAGES && \
+    dpkg -s $PACKAGES && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
 \
 # Install confd


### PR DESCRIPTION
When "yum install <list-of-packages>" fails to install package(s) in the list, it will simply print a warning, eg, "No package ceph-radosgw available". It still exits with a "0" exit code in this case, leading Docker to continue on with the build process as if nothing is wrong.

This can happen if one of the packages is accidentally unavailable in our Yum repositories.

If we fail to install a package in this list, we need the build process to fail immediately so we know the container will not be usable.

Rather than only relying on "yum install"'s exit code, use rpm to double-check that the packages were indeed installed locally.