### PR TITLE
daemon: kv store for mds add admin key function

### DIFF
--- a/ceph-releases/kraken/ubuntu/16.04/daemon/config.kv.etcd.sh
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/config.kv.etcd.sh
@@ -97,3 +97,8 @@ function get_config {
     etcdctl $ETCDCTL_OPT ${KV_TLS} set ${CLUSTER_PATH}/bootstrap${bootstrap}Keyring < /var/lib/ceph/bootstrap-$(to_lowercase $bootstrap)/${CLUSTER}.keyring
   done
 }
+
+function get_admin_key {
+  log "Retrieving Admin key."
+  etcdctl $ETCDCTL_OPT ${KV_TLS} get ${CLUSTER_PATH}/adminKeyring > /etc/ceph/${CLUSTER}.client.admin.keyring
+}


### PR DESCRIPTION
In order to create the Ceph filesystem we need the admin keyring. The kv
etcd scenario was missing this function.

Signed-off-by: Sébastien Han <seb@redhat.com>