### PR TITLE
script: move misslinks script to root dir

### DIFF
--- a/misslinks.sh
+++ b/misslinks.sh
@@ -10,6 +10,9 @@ function all_distro_but_me {
   echo $1 | sed -e "s|$2||g"
 }
 
+# Go to ceph-releases directory
+pushd ceph-releases &>/dev/null
+
 # By default, we check all ceph releases
 all_releases=$(find . -maxdepth 1 -type d | grep -v "^.$")
 


### PR DESCRIPTION
The current location of the script breaks the ceph-workflow script as
the script is evaluated as a release. Moving the script to the git root
dir and pushd into ceph-releases before execution.

Signed-off-by: Sébastien Han <seb@redhat.com>