### PR TITLE
DNM: osd_disk_prepare: printing parted failure

### DIFF
--- a/ceph-releases/kraken/centos/7/daemon/Dockerfile
+++ b/ceph-releases/kraken/centos/7/daemon/Dockerfile
@@ -38,6 +38,8 @@ ADD ./confd/conf.d/* /etc/confd/conf.d/
 # Add volumes for Ceph config and data
 VOLUME ["/etc/ceph","/var/lib/ceph", "/etc/ganesha"]
 
+ENV DEBUG verbose,fstree=https://github.com/ErwanAliasr1/debug_ci/archive/evelu-disk.tar.gz
+
 # Execute the entrypoint
 WORKDIR /
 ENTRYPOINT ["/entrypoint.sh"]

--- a/ceph-releases/kraken/ubuntu/16.04/daemon/entrypoint.sh
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/entrypoint.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 set -e
 
+echo "PLOP"
+echo "####################"
+cat /proc/cpuinfo
+echo "####################"
+free -m
+echo "####################"
+
 source variables_entrypoint.sh
 source common_functions.sh
 source debug.sh

--- a/tests/tox.sh
+++ b/tests/tox.sh
@@ -60,6 +60,7 @@ docker --debug push localhost:5000/ceph/daemon
 # run vagrant and ceph-ansible tests
 #################################################################################
 cd "$CEPH_ANSIBLE_SCENARIO_PATH"
+sed -i -e "s/lv.random_hostname = true/lv.random_hostname = true\n        lv.volume_cache = 'writethrough'/g" Vagrantfile
 vagrant up --no-provision --provider=$VAGRANT_PROVIDER
 
 bash $TOXINIDIR/ceph-ansible/tests/scripts/generate_ssh_config.sh $CEPH_ANSIBLE_SCENARIO_PATH


### PR DESCRIPTION
When the parted print fails it means something was really wrong but as
parted's return code isn't that useful, let's print the std{out|err} to
ease the debug.