### PR TITLE
daemon: clarify the get_admin_key function

### DIFF
--- a/ceph-releases/kraken/ubuntu/16.04/daemon/config.k8s.sh
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/config.k8s.sh
@@ -3,7 +3,7 @@ set -e
 
 function get_admin_key {
    # No-op for static
-   log "k8s: does not generate admin key. Use secrets instead."
+   log "k8s: does not generate the admin key. Use Kubernetes secrets instead."
 }
 
 function get_mon_config {

--- a/ceph-releases/kraken/ubuntu/16.04/daemon/config.kv.etcd.sh
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/config.kv.etcd.sh
@@ -112,6 +112,6 @@ function get_config {
 }
 
 function get_admin_key {
-  log "Retrieving Admin key."
+  log "Retrieving the admin key."
   etcdctl $ETCDCTL_OPT ${KV_TLS} get ${CLUSTER_PATH}/adminKeyring > /etc/ceph/${CLUSTER}.client.admin.keyring
 }

--- a/ceph-releases/kraken/ubuntu/16.04/daemon/config.static.sh
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/config.static.sh
@@ -3,7 +3,11 @@ set -e
 
 function get_admin_key {
    # No-op for static
-   log "static: does not generate admin key"
+   log "static: does not generate the admin key, so we can not get it."
+   log "static: make it available with the help of your configuration management system."
+   log "static: ceph-ansible is a good candidate to deploy a containerized version of Ceph."
+   log "static: ceph-ansible will help you fetching the keys and push them on the right nodes."
+   log "static: if you're interested, please visit: https://github.com/ceph/ceph-ansible"
 }
 
 function get_mon_config {


### PR DESCRIPTION
Depending on the method we use to deploy the admin key can not be
fetched so this commit clarifies the code printed during execution.

Signed-off-by: Sébastien Han <seb@redhat.com>