### PR TITLE
Added MON variable for Kubernetes hostNetwork mode

### DIFF
--- a/ceph-releases/kraken/ubuntu/16.04/daemon/check_zombie_mons.py
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/check_zombie_mons.py
@@ -1,12 +1,16 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 import re
+import os
 import subprocess
 import json
 
-
 MON_REGEX = r"^\d: ([0-9\.]*):\d+/\d* mon.([^ ]*)$"
 # kubctl_command = 'kubectl get pods --namespace=${CLUSTER} -l daemon=mon -o template --template="{ {{range .items}} \\"{{.metadata.name}}\\": \\"{{.status.podIP}}\\" ,   {{end}} }"'
-kubectl_command = 'kubectl get pods --namespace=${CLUSTER} -l daemon=mon -o template --template="{ {{range  \$i, \$v  := .items}} {{ if \$i}} , {{ end }} \\"{{\$v.metadata.name}}\\": \\"{{\$v.status.podIP}}\\" {{end}} }"'
+if int(os.getenv('K8S_HOST_NETWORK', 0)) > 0:
+    kubectl_command = 'kubectl get pods --namespace=${CLUSTER} -l daemon=mon -o template --template="{ {{range  \$i, \$v  := .items}} {{ if \$i}} , {{ end }} \\"{{\$v.spec.nodeName}}\\": \\"{{\$v.status.podIP}}\\" {{end}} }"'
+else:
+    kubectl_command = 'kubectl get pods --namespace=${CLUSTER} -l daemon=mon -o template --template="{ {{range  \$i, \$v  := .items}} {{ if \$i}} , {{ end }} \\"{{\$v.metadata.name}}\\": \\"{{\$v.status.podIP}}\\" {{end}} }"'
+
 monmap_command = "ceph mon getmap > /tmp/monmap && monmaptool -f /tmp/monmap --print"
 
 

--- a/ceph-releases/kraken/ubuntu/16.04/daemon/config.k8s.sh
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/config.k8s.sh
@@ -15,7 +15,11 @@ function get_mon_config {
 
   while [[ -z "${MONMAP_ADD// }" && "${timeout}" -gt 0 ]]; do
     # Get the ceph mon pods (name and IP) from the Kubernetes API. Formatted as a set of monmap params
-    MONMAP_ADD=$(kubectl get pods --namespace=${CLUSTER} -l daemon=mon -o template --template="{{range .items}}{{if .status.podIP}}--add {{.metadata.name}} {{.status.podIP}} {{end}} {{end}}")
+    if [[ ${K8S_HOST_NETWORK} -eq 0 ]]; then
+        MONMAP_ADD=$(kubectl get pods --namespace=${CLUSTER} -l daemon=mon -o template --template="{{range .items}}{{if .status.podIP}}--add {{.metadata.name}} {{.status.podIP}} {{end}} {{end}}")
+    else
+        MONMAP_ADD=$(kubectl get pods --namespace=${CLUSTER} -l daemon=mon -o template --template="{{range .items}}{{if .status.podIP}}--add {{.spec.nodeName}} {{.status.podIP}} {{end}} {{end}}")
+    fi
     (( timeout-- ))
     sleep 1
   done

--- a/ceph-releases/kraken/ubuntu/16.04/daemon/start_mon.sh
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/start_mon.sh
@@ -88,7 +88,7 @@ function start_mon {
       CEPH_PUBLIC_NETWORK=$(get_network ${NIC_MORE_TRAFFIC} ${NETWORK_AUTO_DETECT})
       IP_VERSION=${NETWORK_AUTO_DETECT}
     else # Means -eq 1
-      MON_IP=$(get_ip ${NIC_MORE_TRAFFIC} 6)
+      MON_IP="[$(get_ip ${NIC_MORE_TRAFFIC} 6)]"
       CEPH_PUBLIC_NETWORK=$(get_network ${NIC_MORE_TRAFFIC} 6)
       IP_VERSION=6
       if [ -z "$MON_IP" ]; then
@@ -129,7 +129,7 @@ function start_mon {
     ceph-mon --setuser ceph --setgroup ceph -i ${MON_NAME} --inject-monmap $MONMAP --keyring $MON_KEYRING --mon-data "$MON_DATA_DIR"
     # Ignore when we timeout in most cases that means the cluster has no qorum or
     # no mons are up and running
-    timeout 7 ceph mon add ${MON_NAME} "${MON_IP}:6789" || true
+    timeout 7 ceph mon add "${MON_NAME}" "${MON_IP}:6789" || true
   fi
 
   log "SUCCESS"

--- a/ceph-releases/kraken/ubuntu/16.04/daemon/start_mon.sh
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/start_mon.sh
@@ -129,7 +129,7 @@ function start_mon {
     ceph-mon --setuser ceph --setgroup ceph -i ${MON_NAME} --inject-monmap $MONMAP --keyring $MON_KEYRING --mon-data "$MON_DATA_DIR"
     # Ignore when we timeout in most cases that means the cluster has no qorum or
     # no mons are up and running
-    timeout 7 ceph mon add "${MON_NAME}" "${MON_IP}:6789" || true
+    timeout 7 ceph ${CLI_OPTS} mon add "${MON_NAME}" "${MON_IP}:6789" || true
   fi
 
   log "SUCCESS"

--- a/ceph-releases/kraken/ubuntu/16.04/daemon/variables_entrypoint.sh
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/variables_entrypoint.sh
@@ -6,6 +6,7 @@
 : ${HOSTNAME:=$(hostname -s)}
 : ${MON_NAME:=${HOSTNAME}}
 : ${MON_DATA_DIR:=/var/lib/ceph/mon/${CLUSTER}-${MON_NAME}}
+: ${K8S_HOST_NETWORK:=0}
 : ${NETWORK_AUTO_DETECT:=0}
 : ${MDS_NAME:=mds-${HOSTNAME}}
 : ${OSD_FORCE_ZAP:=0}

--- a/ceph-releases/kraken/ubuntu/16.04/daemon/watch_mon_health.sh
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/watch_mon_health.sh
@@ -7,7 +7,7 @@ function watch_mon_health {
   while [ true ]
   do
     log "checking for zombie mons"
-    /check_zombie_mons.py || true;
+    /check_zombie_mons.py || true
     log "sleep 30 sec"
     sleep 30
   done

--- a/examples/kubernetes/generator/templates/ceph/admin.keyring.tmpl
+++ b/examples/kubernetes/generator/templates/ceph/admin.keyring.tmpl
@@ -1,6 +1,6 @@
 [client.admin]
   key = {{ $key }}
   auid = 0
-  caps mds = "allow"
+  caps mds = "allow *"
   caps mon = "allow *"
   caps osd = "allow *"


### PR DESCRIPTION
This will use the nodeNames instead of the pod names for the monmap

***

This allows users to use `hostNetwork: true` mode for Ceph mons in Kubernetes.