### PR TITLE
daemon: resolve broken package dependancy

### DIFF
--- a/ceph-releases/jewel/ubuntu/14.04/base/Dockerfile
+++ b/ceph-releases/jewel/ubuntu/14.04/base/Dockerfile
@@ -26,11 +26,10 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update &&  apt-get install -y wget un
 \
 # install ceph and ganesha
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3FE869A9 && \
-    echo "deb http://ppa.launchpad.net/gluster/nfs-ganesha/ubuntu trusty main" | tee /etc/apt/sources.list.d/nfs-ganesha.list && \
     echo "deb http://ppa.launchpad.net/gluster/libntirpc/ubuntu trusty main" | tee /etc/apt/sources.list.d/libntirpc.list && \
     wget -q -O- 'https://download.ceph.com/keys/release.asc' | apt-key add - && \
     echo "deb http://download.ceph.com/debian-$CEPH_VERSION/ trusty main" | tee /etc/apt/sources.list.d/ceph-$CEPH_VERSION.list && \
-    apt-get update && apt-get install -y --force-yes ceph radosgw rbd-mirror nfs-ganesha nfs-ganesha-fsal && \
+    apt-get update && apt-get install -y --force-yes ceph radosgw rbd-mirror && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
 \
 # Install etcdctl

--- a/ceph-releases/jewel/ubuntu/14.04/daemon/entrypoint.sh
+++ b/ceph-releases/jewel/ubuntu/14.04/daemon/entrypoint.sh
@@ -1058,6 +1058,9 @@ case "$CEPH_DAEMON" in
     start_rbd_mirror
     ;;
   nfs)
+    echo "Temporarily disabled due to broken package dependencies with nfs-ganesha"
+    echo "For more info see: https://github.com/ceph/ceph-docker/pull/564"
+    exit 1
     start_nfs
     ;;
   zap_device)

--- a/ceph-releases/jewel/ubuntu/14.04/demo/entrypoint.sh
+++ b/ceph-releases/jewel/ubuntu/14.04/demo/entrypoint.sh
@@ -292,6 +292,8 @@ bootstrap_mds
 bootstrap_rgw
 bootstrap_demo_user
 bootstrap_rest_api
-bootstrap_nfs
+# bootstrap_nfs is temporarily disabled due to broken package dependencies with nfs-ganesha"
+# For more info see: https://github.com/ceph/ceph-docker/pull/564"
+#bootstrap_nfs
 log "SUCCESS"
 exec ceph ${CEPH_OPTS} -w

--- a/ceph-releases/jewel/ubuntu/16.04/base/Dockerfile
+++ b/ceph-releases/jewel/ubuntu/16.04/base/Dockerfile
@@ -27,11 +27,10 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y wget unz
 \
 # install ceph and ganesha
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3FE869A9 && \
-    echo "deb http://ppa.launchpad.net/gluster/nfs-ganesha/ubuntu xenial main" | tee /etc/apt/sources.list.d/nfs-ganesha.list && \
     echo "deb http://ppa.launchpad.net/gluster/libntirpc/ubuntu xenial main" | tee /etc/apt/sources.list.d/libntirpc.list && \
     wget -q -O- 'https://download.ceph.com/keys/release.asc' | apt-key add - && \
     echo "deb http://download.ceph.com/debian-$CEPH_VERSION/ xenial main" | tee /etc/apt/sources.list.d/ceph-$CEPH_VERSION.list && \
-    apt-get update && apt-get install -y --force-yes ceph radosgw rbd-mirror nfs-ganesha nfs-ganesha-fsal && \
+    apt-get update && apt-get install -y --force-yes ceph radosgw rbd-mirror && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
 \
 # Install etcdctl

--- a/ceph-releases/kraken/ubuntu/16.04/daemon/Dockerfile
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/Dockerfile
@@ -20,11 +20,10 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y wget unz
 \
 # Install ceph, ganesha and etcd
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3FE869A9 && \
-    echo "deb http://ppa.launchpad.net/gluster/nfs-ganesha/ubuntu xenial main" | tee /etc/apt/sources.list.d/nfs-ganesha.list && \
     echo "deb http://ppa.launchpad.net/gluster/libntirpc/ubuntu xenial main" | tee /etc/apt/sources.list.d/libntirpc.list && \
     wget -q -O- 'https://download.ceph.com/keys/release.asc' | apt-key add - && \
     echo "deb http://download.ceph.com/debian-$CEPH_VERSION/ xenial main" | tee /etc/apt/sources.list.d/ceph-$CEPH_VERSION.list && \
-    apt-get update && apt-get install -y --force-yes ceph-mon ceph-osd ceph-mds ceph-mgr ceph-base ceph-common radosgw rbd-mirror nfs-ganesha nfs-ganesha-fsal sharutils etcd && \
+    apt-get update && apt-get install -y --force-yes ceph-mon ceph-osd ceph-mds ceph-mgr ceph-base ceph-common radosgw rbd-mirror sharutils etcd && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
 \
 # Install confd

--- a/ceph-releases/kraken/ubuntu/16.04/daemon/entrypoint.sh
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/entrypoint.sh
@@ -112,6 +112,9 @@ case "$CEPH_DAEMON" in
     start_rbd_mirror
     ;;
   nfs)
+    echo "Temporarily disabled due to broken package dependencies with nfs-ganesha"
+    echo "For more info see: https://github.com/ceph/ceph-docker/pull/564"
+    exit 1
     source start_nfs.sh
     start_nfs
     ;;

--- a/ceph-releases/kraken/ubuntu/16.04/demo/Dockerfile
+++ b/ceph-releases/kraken/ubuntu/16.04/demo/Dockerfile
@@ -9,11 +9,10 @@ ENV CEPH_VERSION kraken
 # Install Ceph and prerequisites
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y wget unzip uuid-runtime python-setuptools udev sharutils python3 s3cmd && \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3FE869A9 && \
-    echo "deb http://ppa.launchpad.net/gluster/nfs-ganesha/ubuntu xenial main" | tee /etc/apt/sources.list.d/nfs-ganesha.list && \
     echo "deb http://ppa.launchpad.net/gluster/libntirpc/ubuntu xenial main" | tee /etc/apt/sources.list.d/libntirpc.list && \
     wget -q -O- 'https://download.ceph.com/keys/release.asc' | apt-key add - && \
     echo "deb http://download.ceph.com/debian-$CEPH_VERSION/ xenial main" | tee /etc/apt/sources.list.d/ceph-$CEPH_VERSION.list && \
-    apt-get update && apt-get install -y --force-yes ceph-mon ceph-osd ceph-mds ceph-mgr ceph-base ceph-common radosgw rbd-mirror nfs-ganesha nfs-ganesha-fsal && \
+    apt-get update && apt-get install -y --force-yes ceph-mon ceph-osd ceph-mds ceph-mgr ceph-base ceph-common radosgw rbd-mirror && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Add entrypoint

--- a/ceph-releases/kraken/ubuntu/16.04/demo/entrypoint.sh
+++ b/ceph-releases/kraken/ubuntu/16.04/demo/entrypoint.sh
@@ -334,7 +334,9 @@ bootstrap_mds
 bootstrap_rgw
 bootstrap_demo_user
 bootstrap_rest_api
-bootstrap_nfs
+# bootstrap_nfs is temporarily disabled due to broken package dependencies with nfs-ganesha"
+# For more info see: https://github.com/ceph/ceph-docker/pull/564"
+#bootstrap_nfs
 bootstrap_rbd_mirror
 bootstrap_mgr
 log "SUCCESS"


### PR DESCRIPTION
Error:  nfs-ganesha-fsal : Depends: glusterfs-common (>= 3.8.8) but it
is not going to be installed

Solution: temporary remove the package and re-introduce it once the
issue is resolved.

This is urgent as this breaks all the builds on Xenial.

Signed-off-by: Sébastien Han <seb@redhat.com>