### PR TITLE
daemon: add missing help message for ceph-mgr

### DIFF
--- a/ceph-releases/kraken/ubuntu/16.04/daemon/entrypoint.sh
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/entrypoint.sh
@@ -134,8 +134,8 @@ case "$CEPH_DAEMON" in
   if [ -z "$CEPH_DAEMON" ]; then
     log "ERROR- One of CEPH_DAEMON or a daemon parameter must be defined as the name "
     log "of the daemon you want to deploy."
-    log "Valid values for CEPH_DAEMON are MON, OSD, OSD_DIRECTORY, OSD_CEPH_DISK, OSD_CEPH_DISK_PREPARE, OSD_CEPH_DISK_ACTIVATE, OSD_CEPH_ACTIVATE_JOURNAL, MDS, RGW, RGW_USER, RESTAPI, ZAP_DEVICE, RBD_MIRROR, NFS"
-    log "Valid values for the daemon parameter are mon, osd, osd_directory, osd_ceph_disk, osd_ceph_disk_prepare, osd_ceph_disk_activate, osd_ceph_activate_journal, mds, rgw, rgw_user, restapi, zap_device, rbd_mirror, nfs"
+    log "Valid values for CEPH_DAEMON are MON, OSD, OSD_DIRECTORY, OSD_CEPH_DISK, OSD_CEPH_DISK_PREPARE, OSD_CEPH_DISK_ACTIVATE, OSD_CEPH_ACTIVATE_JOURNAL, MDS, RGW, RGW_USER, RESTAPI, ZAP_DEVICE, RBD_MIRROR, NFS, MGR"
+    log "Valid values for the daemon parameter are mon, osd, osd_directory, osd_ceph_disk, osd_ceph_disk_prepare, osd_ceph_disk_activate, osd_ceph_activate_journal, mds, rgw, rgw_user, restapi, zap_device, rbd_mirror, nfs, mgr"
     exit 1
   fi
   ;;


### PR DESCRIPTION
Prior to this patch is no valid CEPH_DAEMON was found no one would know
that the ceph-mgr can be activated. Using the mgr option as $1 when
doing your "docker run" or the variable CEPH_DAEMON=MGR you can enable
it.

Signed-off-by: Sébastien Han <seb@redhat.com>