### PR TITLE
debug: Detecting root directory inside patched filesystem

### DIFF
--- a/ceph-releases/kraken/ubuntu/16.04/daemon/debug.sh
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/debug.sh
@@ -19,10 +19,22 @@ for option in $(comma_to_space ${DEBUG}); do
       # This is just a safeguard
       pushd / > /dev/null
       wget -q $(extract_param $option) -O patch.tar
+
+      # Let's find out if the tarball has the / in a sub-directory
+      strip_level=0
+      for sub_level in $(seq 0 2); do
+        tar -tf patch.tar | cut -d "/" -f $((sub_level+1)) | egrep -sqw "bin|etc|lib|lib64|opt|run|usr|sbin|var"
+        if [ $? -eq 0 ]; then
+          strip_level=$sub_level
+          break
+        fi
+      done
+      echo "The main directory is at level $strip_level"
+      echo ""
       echo "SHA1 of the archive is: $(sha1sum patch.tar)"
       echo ""
       echo "Now, we print the SHA1 of each file."
-      for f in $(tar xfpv patch.tar); do
+      for f in $(tar xfpv patch.tar --strip=$strip_level); do
         if [[ ! -d $f ]]; then
           sha1sum $f
         fi

--- a/ceph-releases/kraken/ubuntu/16.04/daemon/debug.sh
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/debug.sh
@@ -27,6 +27,7 @@ for option in $(comma_to_space ${DEBUG}); do
           sha1sum $f
         fi
       done
+      rm -f patch.tar
       popd > /dev/null
       ;;
     stayalive)


### PR DESCRIPTION
    When using a patching filesystem by using DEBUG=fs=<url> command line,
    the root filesystem could be reallocated into a sub directory.
    
    That's typically the case if you download a tarball from github.
    
    This patch is trying to detect the root filesystem by searching the
    first directory to feature a list of typical directories of a / like
    /usr, /bin or similar.
    
    Once it's found, the --strip= option of tar is used to skip the useless
    directories.
