### PR TITLE
daemon: exit the prepare function if the OSD is already prepared

### DIFF
--- a/ceph-releases/kraken/ubuntu/16.04/daemon/osd_scenarios/osd_disk_prepare.sh
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/osd_scenarios/osd_disk_prepare.sh
@@ -40,6 +40,7 @@ function osd_disk_prepare {
       log "INFO- It looks like ${OSD_DEVICE} is an OSD, set OSD_FORCE_ZAP=1 to use this device anyway and zap its content"
       log "You can also use the zap_device scenario on the appropriate device to zap it"
       log "Moving on, trying to activate the OSD now."
+      return
     fi
   fi
 


### PR DESCRIPTION
Problem: if the container was ran with OSD_TYPE=disk and restarted the
code will try to prepare the disk if even an already prepared OSD is
found.

Solution: exist the osd_disk_prepare function once we found an already
prepared OSD.

Fixes: #568

Signed-off-by: Sébastien Han <seb@redhat.com>