### PR TITLE
fixes get osd_id from directory name

### DIFF
--- a/ceph-releases/hammer/centos/7/daemon/check_zombie_mons.py
+++ b/ceph-releases/hammer/centos/7/daemon/check_zombie_mons.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 import re
+import os
 import subprocess
 import json
 MON_REGEX = r"^\d: ([0-9\.]*):\d+/\d* mon.([^ ]*)$"
@@ -7,13 +8,13 @@ MON_REGEX = r"^\d: ([0-9\.]*):\d+/\d* mon.([^ ]*)$"
 
 #kubctl_command = 'kubectl get pods --namespace=${CLUSTER} -l daemon=mon -o template --template="{ {{range .items}} \\"{{.metadata.name}}\\": \\"{{.status.podIP}}\\" ,   {{end}} }"'
 kubectl_command = 'kubectl get pods --namespace=${CLUSTER} -l daemon=mon -o template --template="{ {{range  \$i, \$v  := .items}} {{ if \$i}} , {{ end }} \\"{{\$v.metadata.name}}\\": \\"{{\$v.status.podIP}}\\" {{end}} }"'
-monmap_command = "ceph mon getmap > /tmp/monmap && monmaptool -f /tmp/monmap --print"
+monmap_command = "ceph --cluster=${CLUSTER} mon getmap > /tmp/monmap && monmaptool -f /tmp/monmap --print"
 
 
 
 def extract_mons_from_monmap():
-    monmap =  subprocess.check_output(monmap_command, shell=True)
-    mons = { }
+    monmap = subprocess.check_output(monmap_command, shell=True)
+    mons = {}
     for line in monmap.split("\n"):
         m = re.match(MON_REGEX, line)
         if m is not None:
@@ -33,16 +34,15 @@ print "expected mons:", expected_mons
 for mon in current_mons:
     removed_mon = False
     if not mon in expected_mons:
-        print "print removing zombie mon ", mon
-        subprocess.call(["ceph", "mon", "remove", mon])
+        print "removing zombie mon ", mon
+        subprocess.call(["ceph", "--cluster", os.environ["CLUSTER"], "mon", "remove", mon])
         removed_mon = True
     elif current_mons[mon] != expected_mons[mon]: # check if for some reason the ip of the mon changed
         print "ip change dedected for pod ", mon
-        subprocess.call(["kubectl", "--namespace=ceph", "delete", "pod", mon])
+        subprocess.call(["kubectl", "--namespace", os.environ["CLUSTER"], "delete", "pod", mon])
         removed_mon = True
         print "deleted mon %s via the kubernetes api" % mon
 
 
 if not removed_mon:
     print "no zombie mons found ..."
-

--- a/ceph-releases/hammer/ubuntu/14.04/daemon/entrypoint.sh
+++ b/ceph-releases/hammer/ubuntu/14.04/daemon/entrypoint.sh
@@ -190,7 +190,7 @@ function osd_directory {
     exit 1
   fi
 
-  for OSD_ID in $(ls /var/lib/ceph/osd |  awk 'BEGIN { FS = "-" } ; { print $2 }'); do
+  for OSD_ID in $(ls /var/lib/ceph/osd | sed 's/.*-//'); do
     if [ -n "${JOURNAL_DIR}" ]; then
        OSD_J="${JOURNAL_DIR}/journal.${OSD_ID}"
     else

--- a/ceph-releases/infernalis/ubuntu/14.04/daemon/check_zombie_mons.py
+++ b/ceph-releases/infernalis/ubuntu/14.04/daemon/check_zombie_mons.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 import re
+import os
 import subprocess
 import json
 MON_REGEX = r"^\d: ([0-9\.]*):\d+/\d* mon.([^ ]*)$"
@@ -7,13 +8,13 @@ MON_REGEX = r"^\d: ([0-9\.]*):\d+/\d* mon.([^ ]*)$"
 
 #kubctl_command = 'kubectl get pods --namespace=${CLUSTER} -l daemon=mon -o template --template="{ {{range .items}} \\"{{.metadata.name}}\\": \\"{{.status.podIP}}\\" ,   {{end}} }"'
 kubectl_command = 'kubectl get pods --namespace=${CLUSTER} -l daemon=mon -o template --template="{ {{range  \$i, \$v  := .items}} {{ if \$i}} , {{ end }} \\"{{\$v.metadata.name}}\\": \\"{{\$v.status.podIP}}\\" {{end}} }"'
-monmap_command = "ceph mon getmap > /tmp/monmap && monmaptool -f /tmp/monmap --print"
+monmap_command = "ceph --cluster=${CLUSTER} mon getmap > /tmp/monmap && monmaptool -f /tmp/monmap --print"
 
 
 
 def extract_mons_from_monmap():
-    monmap =  subprocess.check_output(monmap_command, shell=True)
-    mons = { }
+    monmap = subprocess.check_output(monmap_command, shell=True)
+    mons = {}
     for line in monmap.split("\n"):
         m = re.match(MON_REGEX, line)
         if m is not None:
@@ -33,16 +34,15 @@ print "expected mons:", expected_mons
 for mon in current_mons:
     removed_mon = False
     if not mon in expected_mons:
-        print "print removing zombie mon ", mon
-        subprocess.call(["ceph", "mon", "remove", mon])
+        print "removing zombie mon ", mon
+        subprocess.call(["ceph", "--cluster", os.environ["CLUSTER"], "mon", "remove", mon])
         removed_mon = True
     elif current_mons[mon] != expected_mons[mon]: # check if for some reason the ip of the mon changed
         print "ip change dedected for pod ", mon
-        subprocess.call(["kubectl", "--namespace=ceph", "delete", "pod", mon])
+        subprocess.call(["kubectl", "--namespace", os.environ["CLUSTER"], "delete", "pod", mon])
         removed_mon = True
         print "deleted mon %s via the kubernetes api" % mon
 
 
 if not removed_mon:
     print "no zombie mons found ..."
-

--- a/ceph-releases/infernalis/ubuntu/14.04/daemon/entrypoint.sh
+++ b/ceph-releases/infernalis/ubuntu/14.04/daemon/entrypoint.sh
@@ -469,7 +469,6 @@ ENDHERE
 ###################
 
 function watch_mon_health {
-echo "checking for zombie mons"
 
 while [ true ]
 do

--- a/ceph-releases/infernalis/ubuntu/14.04/daemon/entrypoint.sh
+++ b/ceph-releases/infernalis/ubuntu/14.04/daemon/entrypoint.sh
@@ -204,7 +204,7 @@ function osd_directory {
     exit 1
   fi
 
-  for OSD_ID in $(ls /var/lib/ceph/osd |  awk 'BEGIN { FS = "-" } ; { print $2 }'); do
+  for OSD_ID in $(ls /var/lib/ceph/osd | sed 's/.*-//'); do
     if [ -n "${JOURNAL_DIR}" ]; then
        OSD_J="${JOURNAL_DIR}/journal.${OSD_ID}"
     else

--- a/ceph-releases/jewel/ubuntu/14.04/daemon/check_zombie_mons.py
+++ b/ceph-releases/jewel/ubuntu/14.04/daemon/check_zombie_mons.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 import re
+import os
 import subprocess
 import json
 MON_REGEX = r"^\d: ([0-9\.]*):\d+/\d* mon.([^ ]*)$"
@@ -7,13 +8,13 @@ MON_REGEX = r"^\d: ([0-9\.]*):\d+/\d* mon.([^ ]*)$"
 
 #kubctl_command = 'kubectl get pods --namespace=${CLUSTER} -l daemon=mon -o template --template="{ {{range .items}} \\"{{.metadata.name}}\\": \\"{{.status.podIP}}\\" ,   {{end}} }"'
 kubectl_command = 'kubectl get pods --namespace=${CLUSTER} -l daemon=mon -o template --template="{ {{range  \$i, \$v  := .items}} {{ if \$i}} , {{ end }} \\"{{\$v.metadata.name}}\\": \\"{{\$v.status.podIP}}\\" {{end}} }"'
-monmap_command = "ceph mon getmap > /tmp/monmap && monmaptool -f /tmp/monmap --print"
+monmap_command = "ceph --cluster=${CLUSTER} mon getmap > /tmp/monmap && monmaptool -f /tmp/monmap --print"
 
 
 
 def extract_mons_from_monmap():
-    monmap =  subprocess.check_output(monmap_command, shell=True)
-    mons = { }
+    monmap = subprocess.check_output(monmap_command, shell=True)
+    mons = {}
     for line in monmap.split("\n"):
         m = re.match(MON_REGEX, line)
         if m is not None:
@@ -33,16 +34,15 @@ print "expected mons:", expected_mons
 for mon in current_mons:
     removed_mon = False
     if not mon in expected_mons:
-        print "print removing zombie mon ", mon
-        subprocess.call(["ceph", "mon", "remove", mon])
+        print "removing zombie mon ", mon
+        subprocess.call(["ceph", "--cluster", os.environ["CLUSTER"], "mon", "remove", mon])
         removed_mon = True
     elif current_mons[mon] != expected_mons[mon]: # check if for some reason the ip of the mon changed
         print "ip change dedected for pod ", mon
-        subprocess.call(["kubectl", "--namespace=ceph", "delete", "pod", mon])
+        subprocess.call(["kubectl", "--namespace", os.environ["CLUSTER"], "delete", "pod", mon])
         removed_mon = True
         print "deleted mon %s via the kubernetes api" % mon
 
 
 if not removed_mon:
     print "no zombie mons found ..."
-

--- a/ceph-releases/jewel/ubuntu/14.04/daemon/entrypoint.sh
+++ b/ceph-releases/jewel/ubuntu/14.04/daemon/entrypoint.sh
@@ -987,7 +987,6 @@ function zap_device {
 ####################
 
 function watch_mon_health {
-  log "checking for zombie mons"
 
   while [ true ]
   do

--- a/ceph-releases/jewel/ubuntu/14.04/daemon/entrypoint.sh
+++ b/ceph-releases/jewel/ubuntu/14.04/daemon/entrypoint.sh
@@ -350,7 +350,7 @@ function osd_directory_single {
   chown -R ceph. /var/lib/ceph/osd
 
   # pick one osd and make sure no lock is held
-  for OSD_ID in $(ls /var/lib/ceph/osd |  awk 'BEGIN { FS = "-" } ; { print $2 }'); do
+  for OSD_ID in $(ls /var/lib/ceph/osd | sed 's/.*-//'); do
     if [[ -n "$(find /var/lib/ceph/osd/${CLUSTER}-${OSD_ID} -prune -empty)" ]]; then
       log "Looks like OSD: ${OSD_ID} has not been bootstrapped yet, doing nothing, moving on to the next discoverable OSD"
     else
@@ -407,7 +407,7 @@ function osd_directory {
   mkdir -p /etc/forego/${CLUSTER}
   echo "" > /etc/forego/${CLUSTER}/Procfile
 
-  for OSD_ID in $(ls /var/lib/ceph/osd |  awk 'BEGIN { FS = "-" } ; { print $2 }'); do
+  for OSD_ID in $(ls /var/lib/ceph/osd | sed 's/.*-//'); do
     if [ -n "${JOURNAL_DIR}" ]; then
        OSD_J="${JOURNAL_DIR}/journal.${OSD_ID}"
        chown -R ceph. ${JOURNAL_DIR}
@@ -636,7 +636,7 @@ function osd_disks {
   # check if anything is there, if not create an osd with directory
   if [[ -z "$(find /var/lib/ceph/osd -prune -empty)" ]]; then
     log "Mount existing and prepared OSD disks for ceph-cluster ${CLUSTER}"
-    for OSD_ID in $(ls /var/lib/ceph/osd |  awk 'BEGIN { FS = "-" } ; { print $2 }'); do
+    for OSD_ID in $(ls /var/lib/ceph/osd | sed 's/.*-//'); do
       OSD_DEV=$(get_osd_dev ${OSD_ID})
       if [[ -z ${OSD_DEV} ]]; then
         log "No device mapping for ${CLUSTER}-${OSD_ID} for ceph-cluster ${CLUSTER}"

--- a/ceph-releases/kraken/ubuntu/16.04/daemon/osd_scenarios/osd_directory.sh
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/osd_scenarios/osd_directory.sh
@@ -36,7 +36,7 @@ function osd_directory {
   mkdir -p /etc/forego/${CLUSTER}
   echo "" > /etc/forego/${CLUSTER}/Procfile
 
-  for OSD_ID in $(ls /var/lib/ceph/osd | awk 'BEGIN { FS = "-" } ; { print $2 }'); do
+  for OSD_ID in $(ls /var/lib/ceph/osd | sed 's/.*-//'); do
     OSD_PATH=$(get_OSD_path $OSD_ID)
     OSD_KEYRING="$OSD_PATH/keyring"
 

--- a/ceph-releases/kraken/ubuntu/16.04/daemon/osd_scenarios/osd_directory_single.sh
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/osd_scenarios/osd_directory_single.sh
@@ -9,7 +9,7 @@ function osd_directory_single {
   fi
 
   # pick one osd and make sure no lock is held
-  for OSD_ID in $(ls /var/lib/ceph/osd |  awk 'BEGIN { FS = "-" } ; { print $2 }'); do
+  for OSD_ID in $(ls /var/lib/ceph/osd | sed 's/.*-//'); do
     OSD_PATH=$(get_OSD_path $OSD_ID)
     OSD_KEYRING="$OSD_PATH/keyring"
 

--- a/ceph-releases/kraken/ubuntu/16.04/daemon/osd_scenarios/osd_disks.sh
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/osd_scenarios/osd_disks.sh
@@ -20,7 +20,7 @@ function osd_disks {
   # check if anything is there, if not create an osd with directory
   if [[ -z "$(find /var/lib/ceph/osd -prune -empty)" ]]; then
     log "Mount existing and prepared OSD disks for ceph-cluster ${CLUSTER}"
-    for OSD_ID in $(ls /var/lib/ceph/osd |  awk 'BEGIN { FS = "-" } ; { print $2 }'); do
+    for OSD_ID in $(ls /var/lib/ceph/osd | sed 's/.*-//'); do
       OSD_PATH=$(get_OSD_path $OSD_ID)
       OSD_KEYRING="$OSD_PATH/keyring"
       OSD_DEV=$(get_osd_dev ${OSD_ID})

--- a/ceph-releases/kraken/ubuntu/16.04/daemon/watch_mon_health.sh
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/watch_mon_health.sh
@@ -2,7 +2,6 @@
 set -e
 
 function watch_mon_health {
-  log "checking for zombie mons"
 
   while [ true ]
   do


### PR DESCRIPTION
get the OSD_ID from directory name after the last "-"

for example:
kube-system-3 -> OSD_ID = "3"

instead of OSD_ID="system" with the current command
fixes #579