### PR TITLE
daemon: source ceph env files

### DIFF
--- a/ceph-releases/kraken/ubuntu/16.04/daemon/common_functions.sh
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/common_functions.sh
@@ -174,3 +174,24 @@ function to_lowercase {
 function comma_to_space {
   echo "${@//,/ }"
 }
+
+# Get based distro by discovering the package manager
+function get_package_manager {
+  if is_available rpm; then
+    OS_VENDOR=redhat
+  elif is_available dpkg; then
+    OS_VENDOR=ubuntu
+  fi
+}
+
+# Determine if current distribution is an Ubuntu-based distribution
+function is_ubuntu {
+  get_package_manager
+  [[ "$OS_VENDOR" == "ubuntu" ]]
+}
+
+# Determine if current distribution is a RedHat-based distribution
+function is_redhat {
+  get_package_manager
+  [[ "$OS_VENDOR" == "redhat" ]]
+}

--- a/ceph-releases/kraken/ubuntu/16.04/daemon/start_osd.sh
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/start_osd.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 set -e
 
+if is_redhat; then
+  source /etc/sysconfig/ceph
+elif is_ubuntu; then
+  source /etc/default/ceph
+fi
+
 function start_osd {
   get_config
   check_config


### PR DESCRIPTION
As described in https://github.com/ceph/ceph-docker/issues/572, we
currently don't source `/etc/sysconfig/ceph` on RedHat based systems and
`/etc/default/ceph` on Ubuntu based systems.
This is important we source this file so we can enable
TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES.

This commits adds some functions to determine on which OS the container
image is running. Then during the OSD execution sources the right file.

Fixes: https://github.com/ceph/ceph-docker/issues/572

Signed-off-by: Sébastien Han <seb@redhat.com>