### PR TITLE
adding s3cfg for ubuntu 16.04 ceph/demo image

### DIFF
--- a/ceph-releases/jewel/ubuntu/16.04/demo/Dockerfile
+++ b/ceph-releases/jewel/ubuntu/16.04/demo/Dockerfile
@@ -9,6 +9,7 @@ MAINTAINER Sébastien Han "seb@redhat.com"
 
 # Add bootstrap script
 ADD entrypoint.sh /entrypoint.sh
+ADD s3cfg /root/.s3cfg
 
 # Add volumes for Ceph config and data
 VOLUME ["/etc/ceph","/var/lib/ceph"]

--- a/ceph-releases/jewel/ubuntu/16.04/demo/s3cfg
+++ b/ceph-releases/jewel/ubuntu/16.04/demo/s3cfg
@@ -1,0 +1,1 @@
+../../../ubuntu/14.04/demo/s3cfg


### PR DESCRIPTION
When enabling auto demo user creation with ceph/demo:tag-build-master-jewel-ubuntu-16.04, container fails to start because there is no s3cfg there.