### PR TITLE
test: travis cluster name on error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,4 +30,4 @@ after_failure:
   - docker ps
   - docker ps -a
   - docker logs ceph-demo
-  - docker exec ceph-demo ceph -s
+  - docker exec ceph-demo ceph --cluster test -s


### PR DESCRIPTION
We deploy the ceph-demo container on Travis using 'test' as a cluster
name. On error when only call 'ceph -s' which assumes a cluster named
'ceph'. This commits resolves this.

Signed-off-by: Sébastien Han <seb@redhat.com>