### PR TITLE
Fixes weight calculations for bluestore OSD whereby weights are alway…

### DIFF
--- a/ceph-releases/kraken/ubuntu/16.04/daemon/osd_scenarios/osd_disk_activate.sh
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/osd_scenarios/osd_disk_activate.sh
@@ -43,7 +43,11 @@ function osd_activate {
   OSD_ID=$(grep "${MOUNTED_PART}" /proc/mounts | awk '{print $2}' | grep -oh '[0-9]*')
   OSD_PATH=$(get_osd_path $OSD_ID)
   OSD_KEYRING="$OSD_PATH/keyring"
-  OSD_WEIGHT=$(df -P -k $OSD_PATH | tail -1 | awk '{ d= $2/1073741824 ; r = sprintf("%.2f", d); print r }')
+  if [[ ${OSD_BLUESTORE} -eq 1 ]] && [ -e "${OSD_PATH}block" ]; then
+    OSD_WEIGHT=$(awk "BEGIN { d= $(blockdev --getsize64 ${OSD_PATH}block)/1099511627776 ; r = sprintf(\"%.2f\", d); print r }")
+  else
+    OSD_WEIGHT=$(df -P -k $OSD_PATH | tail -1 | awk '{ d= $2/1073741824 ; r = sprintf("%.2f", d); print r }')
+  fi
   ceph ${CLI_OPTS} --name=osd.${OSD_ID} --keyring=$OSD_KEYRING osd crush create-or-move -- ${OSD_ID} ${OSD_WEIGHT} ${CRUSH_LOCATION}
 
   log "SUCCESS"

--- a/ceph-releases/luminous/ubuntu/16.04/daemon/osd_scenarios/osd_disk_activate.sh
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/osd_scenarios/osd_disk_activate.sh
@@ -43,7 +43,11 @@ function osd_activate {
   OSD_ID=$(grep "${MOUNTED_PART}" /proc/mounts | awk '{print $2}' | grep -oh '[0-9]*')
   OSD_PATH=$(get_osd_path $OSD_ID)
   OSD_KEYRING="$OSD_PATH/keyring"
-  OSD_WEIGHT=$(df -P -k $OSD_PATH | tail -1 | awk '{ d= $2/1073741824 ; r = sprintf("%.2f", d); print r }')
+  if [[ ${OSD_BLUESTORE} -eq 1 ]] && [ -e "${OSD_PATH}block" ]; then
+    OSD_WEIGHT=$(awk "BEGIN { d= $(blockdev --getsize64 ${OSD_PATH}block)/1099511627776 ; r = sprintf(\"%.2f\", d); print r }")
+  else
+    OSD_WEIGHT=$(df -P -k $OSD_PATH | tail -1 | awk '{ d= $2/1073741824 ; r = sprintf("%.2f", d); print r }')
+  fi
   ceph ${CLI_OPTS} --name=osd.${OSD_ID} --keyring=$OSD_KEYRING osd crush create-or-move -- ${OSD_ID} ${OSD_WEIGHT} ${CRUSH_LOCATION}
 
   log "SUCCESS"


### PR DESCRIPTION
…s set to 0.00.

This was due to osd_disk_activate.sh and/or osd_common.sh calculating the weight as
the number of TiB for the OSD metadata partition which is normally 100MB.
Instead it will calculate the number of TiB on the ${OSD_PATH}/block device.