### PR TITLE
Jinja template processor for Kubernetes example

### DIFF
--- a/examples/kubernetes/create_ceph_cluster.sh
+++ b/examples/kubernetes/create_ceph_cluster.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ex
 
-./create_secrets.sh
+./create_secrets.sh "$@"
 
 kubectl create \
 -f ceph-mds-v1-dp.yaml \

--- a/examples/kubernetes/create_secrets.sh
+++ b/examples/kubernetes/create_secrets.sh
@@ -2,7 +2,7 @@
 set -ex
 
 cd generator
-./generate_secrets.sh all `./generate_secrets.sh fsid`
+./generate_secrets.sh all `./generate_secrets.sh fsid` "$@"
 
 kubectl create namespace ceph
 kubectl create secret generic ceph-conf-combined --from-file=ceph.conf --from-file=ceph.client.admin.keyring --from-file=ceph.mon.keyring --namespace=ceph

--- a/examples/kubernetes/generator/generate_secrets.sh
+++ b/examples/kubernetes/generator/generate_secrets.sh
@@ -1,5 +1,23 @@
 #!/bin/bash
 
+TEMPLATE_ENGINE=jinja
+
+proc-template() {
+  FILE=$1
+  shift
+  if [ "$TEMPLATE_ENGINE" == "sigil" ]; then
+    echo $(sigil -p -f ${FILE}.tmpl "$@")
+  else
+    TMPFILE=$(mktemp)
+    for a in $@; do
+      echo ${a/=/: !!str } >> $TMPFILE
+    done
+    conf=$(jinja2 --format=yaml ${FILE}.jinja $TMPFILE)
+    rm $TMPFILE
+    echo "${conf}"
+  fi
+}
+
 gen-fsid() {
   echo "$(uuidgen)"
 }
@@ -7,49 +25,49 @@ gen-fsid() {
 gen-ceph-conf-raw() {
   fsid=${1:?}
   shift
-  conf=$(sigil -p -f templates/ceph/ceph.conf.tmpl "fsid=${fsid}" $@)
+  conf=$(proc-template templates/ceph/ceph.conf "fsid=${fsid}" "$@")
   echo "${conf}"
 }
 
 gen-ceph-conf() {
   fsid=${1:?}
   shift
-  conf=$(sigil -p -f templates/ceph/ceph.conf.tmpl "fsid=${fsid}" $@)
+  conf=$(proc-template templates/ceph/ceph.conf "fsid=${fsid}" "$@")
   echo "${conf}"
 }
 
 gen-admin-keyring() {
   key=$(python ceph-key.py)
-  keyring=$(sigil -f templates/ceph/admin.keyring.tmpl "key=${key}")
+  keyring=$(proc-template templates/ceph/admin.keyring "key=${key}")
   echo "${keyring}"
 }
 
 gen-mon-keyring() {
   key=$(python ceph-key.py)
-  keyring=$(sigil -f templates/ceph/mon.keyring.tmpl "key=${key}")
+  keyring=$(proc-template templates/ceph/mon.keyring "key=${key}")
   echo "${keyring}"
 }
 
 gen-combined-conf() {
   fsid=${1:?}
   shift
-  conf=$(sigil -p -f templates/ceph/ceph.conf.tmpl "fsid=${fsid}" $@)
+  conf=$(proc-template templates/ceph/ceph.conf "fsid=${fsid}" $@)
   echo "${conf}" > ceph.conf
 
   key=$(python ceph-key.py)
-  keyring=$(sigil -f templates/ceph/admin.keyring.tmpl "key=${key}")
+  keyring=$(proc-template templates/ceph/admin.keyring "key=${key}")
   echo "${key}" > ceph-client-key
   echo "${keyring}" > ceph.client.admin.keyring
 
   key=$(python ceph-key.py)
-  keyring=$(sigil -f templates/ceph/mon.keyring.tmpl "key=${key}")
+  keyring=$(proc-template templates/ceph/mon.keyring "key=${key}")
   echo "${keyring}" > ceph.mon.keyring
 }
 
 gen-bootstrap-keyring() {
   service="${1:-osd}"
   key=$(python ceph-key.py)
-  bootstrap=$(sigil -f templates/ceph/bootstrap.keyring.tmpl "key=${key}" "service=${service}")
+  bootstrap=$(proc-template templates/ceph/bootstrap.keyring "key=${key}" "service=${service}")
   echo "${bootstrap}"
 }
 
@@ -60,23 +78,26 @@ gen-all-bootstrap-keyrings() {
 }
 
 gen-all() {
-  gen-combined-conf $@
+  gen-combined-conf "$@"
   gen-all-bootstrap-keyrings
 }
 
 
 main() {
   set -eo pipefail
-  case "$1" in
-  fsid)            shift; gen-fsid $@;;
-  ceph-conf-raw)            shift; gen-ceph-conf-raw $@;;
-  ceph-conf)            shift; gen-ceph-conf $@;;
-  admin-keyring)            shift; gen-admin-keyring $@;;
-  mon-keyring)            shift; gen-mon-keyring $@;;
-  bootstrap-keyring)            shift; gen-bootstrap-keyring $@;;
-  combined-conf)               shift; gen-combined-conf $@;;
-  all)                         shift; gen-all $@;;
+  OP=$1
+  shift
+  case "$OP" in
+  fsid)              gen-fsid "$@";;
+  ceph-conf-raw)     gen-ceph-conf-raw "$@";;
+  ceph-conf)         gen-ceph-conf "$@";;
+  admin-keyring)     gen-admin-keyring "$@";;
+  mon-keyring)       gen-mon-keyring "$@";;
+  bootstrap-keyring) gen-bootstrap-keyring "$@";;
+  combined-conf)     gen-combined-conf "$@";;
+  all)               gen-all "$@";;
   esac
 }
 
 main "$@"
+

--- a/examples/kubernetes/generator/templates/ceph/admin.keyring.jinja
+++ b/examples/kubernetes/generator/templates/ceph/admin.keyring.jinja
@@ -1,0 +1,6 @@
+[client.admin]
+  key = {{ key }}
+  auid = 0
+  caps mds = "allow *"
+  caps mon = "allow *"
+  caps osd = "allow *"

--- a/examples/kubernetes/generator/templates/ceph/bootstrap.keyring.jinja
+++ b/examples/kubernetes/generator/templates/ceph/bootstrap.keyring.jinja
@@ -1,0 +1,3 @@
+[client.bootstrap-{{ service }}]
+  key = {{ key }}
+  caps mon = "allow profile bootstrap-{{ service }}"

--- a/examples/kubernetes/generator/templates/ceph/ceph.conf.jinja
+++ b/examples/kubernetes/generator/templates/ceph/ceph.conf.jinja
@@ -1,0 +1,71 @@
+[global]
+fsid = {{ fsid }}
+cephx = {{ auth_cephx|default("true") }}
+cephx_require_signatures = {{ auth_cephx_require_signatures|default("false") }}
+cephx_cluster_require_signatures = {{ auth_cephx_cluster_require_signatures|default("true") }}
+cephx_service_require_signatures = {{ auth_cephx_service_require_signatures|default("false") }}
+
+# auth
+max_open_files = {{ global_max_open_files|default("131072") }}
+osd_pool_default_pg_num = {{ global_osd_pool_default_pg_num|default("128") }}
+osd_pool_default_pgp_num = {{ global_osd_pool_default_pgp_num|default("128") }}
+osd_pool_default_size = {{ global_osd_pool_default_size|default("3") }}
+osd_pool_default_min_size = {{ global_osd_pool_default_min_size|default("1") }}
+
+mon_osd_full_ratio = {{ global_mon_osd_full_ratio|default(".95") }}
+mon_osd_nearfull_ratio = {{ global_mon_osd_nearfull_ratio|default(".85") }}
+
+mon_host = {{ global_mon_host|default('ceph-mon') }}
+
+[mon]
+mon_osd_down_out_interval = {{ mon_mon_osd_down_out_interval|default("600") }}
+mon_osd_min_down_reporters = {{ mon_mon_osd_min_down_reporters|default("4") }}
+mon_clock_drift_allowed = {{ mon_mon_clock_drift_allowed|default(".15") }}
+mon_clock_drift_warn_backoff = {{ mon_mon_clock_drift_warn_backoff|default("30") }}
+mon_osd_report_timeout = {{ mon_mon_osd_report_timeout|default("300") }}
+
+
+[osd]
+journal_size = {{ osd_journal_size|default("100") }}
+cluster_network = {{ osd_cluster_network|default('10.244.0.0/16') }}
+public_network = {{ osd_public_network|default('10.244.0.0/16') }}
+osd_mkfs_type = {{ osd_osd_mkfs_type|default("xfs") }}
+osd_mkfs_options_xfs = {{ osd_osd_mkfs_options_xfs|default("-f -i size=2048") }}
+osd_mon_heartbeat_interval = {{ osd_osd_mon_heartbeat_interval|default("30") }}
+osd_max_object_name_len = {{ osd_max_object_name_len|default("256") }}
+
+#crush
+osd_pool_default_crush_rule = {{ osd_pool_default_crush_rule|default("0") }}
+osd_crush_update_on_start = {{ osd_osd_crush_update_on_start|default("true") }}
+
+#backend
+osd_objectstore = {{ osd_osd_objectstore|default("filestore") }}
+
+#performance tuning
+filestore_merge_threshold = {{ osd_filestore_merge_threshold|default("40") }}
+filestore_split_multiple = {{ osd_filestore_split_multiple|default("8") }}
+osd_op_threads = {{ osd_osd_op_threads|default("8") }}
+filestore_op_threads = {{ osd_filestore_op_threads|default("8") }}
+filestore_max_sync_interval = {{ osd_filestore_max_sync_interval|default("5") }}
+osd_max_scrubs = {{ osd_osd_max_scrubs|default("1") }}
+
+
+#recovery tuning
+osd_recovery_max_active = {{ osd_osd_recovery_max_active|default("5") }}
+osd_max_backfills = {{ osd_osd_max_backfills|default("2") }}
+osd_recovery_op_priority = {{ osd_osd_recovery_op_priority|default("2") }}
+osd_client_op_priority = {{ osd_osd_client_op_priority|default("63") }}
+osd_recovery_max_chunk = {{ osd_osd_recovery_max_chunk|default("1048576") }}
+osd_recovery_threads = {{ osd_osd_recovery_threads|default("1") }}
+
+#ports
+ms_bind_port_min = {{ osd_ms_bind_port_min|default("6800") }}
+ms_bind_port_max = {{ osd_ms_bind_port_max|default("7100") }}
+
+[client]
+rbd_cache_enabled = {{ client_rbd_cache_enabled|default("true") }}
+rbd_cache_writethrough_until_flush = {{ client_rbd_cache_writethrough_until_flush|default("true") }}
+rbd_default_features = {{ client_rbd_default_features|default("1") }}
+
+[mds]
+mds_cache_size = {{ mds_mds_cache_size|default("100000") }}

--- a/examples/kubernetes/generator/templates/ceph/input.yaml
+++ b/examples/kubernetes/generator/templates/ceph/input.yaml
@@ -1,0 +1,3 @@
+fsid: foo
+osd_cluster_network: "'10.23.0.0/16'"
+osd_public_network: "'10.23.0.0/16'"

--- a/examples/kubernetes/generator/templates/ceph/mon.keyring.jinja
+++ b/examples/kubernetes/generator/templates/ceph/mon.keyring.jinja
@@ -1,0 +1,3 @@
+[mon.]
+  key = {{ key }}
+  caps mon = "allow *"


### PR DESCRIPTION
These two commits add templates and code to use jinja2 as template processor. sigil can still be enabled setting the TEMPLATE_ENGINE variable.

sigil is not easy to come by, while jinja2 is available on Fedora (python3-jinja2-cli package) and can be installed easily using pip ([jinja2-cli](https://pypi.python.org/pypi/jinja2-cli) package). The language is used for popular projects like ansible or Django.

This addresses issue #338 even though it is not entirely without dependencies.