### PR TITLE
daemon: use bash syntax validation command

### DIFF
--- a/ceph-releases/jewel/centos/7/daemon/Dockerfile
+++ b/ceph-releases/jewel/centos/7/daemon/Dockerfile
@@ -13,7 +13,8 @@ ADD *.sh ceph.defaults check_zombie_mons.py ./osd_scenarios/* entrypoint.sh.in d
 # Modify the entrypoint
 RUN chmod +x /generate_entrypoint.sh && \
   bash -c "/generate_entrypoint.sh" && \
-  rm -f /generate_entrypoint.sh
+  rm -f /generate_entrypoint.sh && \
+  bash -n /*.sh
 
 # Add templates for confd
 ADD ./confd/templates/* /etc/confd/templates/

--- a/ceph-releases/jewel/fedora/24/daemon/Dockerfile
+++ b/ceph-releases/jewel/fedora/24/daemon/Dockerfile
@@ -13,7 +13,8 @@ ADD *.sh ceph.defaults check_zombie_mons.py ./osd_scenarios/* entrypoint.sh.in d
 # Modify the entrypoint
 RUN chmod +x /generate_entrypoint.sh && \
   bash -c "/generate_entrypoint.sh" && \
-  rm -f /generate_entrypoint.sh
+  rm -f /generate_entrypoint.sh && \
+  bash -n /*.sh
 
 # Add templates for confd
 ADD ./confd/templates/* /etc/confd/templates/

--- a/ceph-releases/jewel/opensuse/Leap_42.2/daemon/Dockerfile
+++ b/ceph-releases/jewel/opensuse/Leap_42.2/daemon/Dockerfile
@@ -14,7 +14,8 @@ ADD *.sh ceph.defaults check_zombie_mons.py ./osd_scenarios/* entrypoint.sh.in d
 # Modify the entrypoint
 RUN chmod +x /generate_entrypoint.sh && \
   bash -c "/generate_entrypoint.sh" && \
-  rm -f /generate_entrypoint.sh
+  rm -f /generate_entrypoint.sh && \
+  bash -n /*.sh
 
 # Add volumes for Ceph config and data
 VOLUME ["/etc/ceph","/var/lib/ceph", "/etc/ganesha"]

--- a/ceph-releases/jewel/rhel/7.3/daemon/Dockerfile
+++ b/ceph-releases/jewel/rhel/7.3/daemon/Dockerfile
@@ -26,7 +26,8 @@ ADD *.sh ceph.defaults check_zombie_mons.py ./osd_scenarios/* entrypoint.sh.in d
 # Modify the entrypoint
 RUN chmod +x /generate_entrypoint.sh && \
   bash -c "/generate_entrypoint.sh" && \
-  rm -f /generate_entrypoint.sh
+  rm -f /generate_entrypoint.sh && \
+  bash -n /*.sh
 
 # Execute the entrypoint
 WORKDIR /

--- a/ceph-releases/jewel/ubuntu/14.04/daemon/Dockerfile
+++ b/ceph-releases/jewel/ubuntu/14.04/daemon/Dockerfile
@@ -14,7 +14,8 @@ ADD *.sh ceph.defaults check_zombie_mons.py ./osd_scenarios/* entrypoint.sh.in d
 # Modify the entrypoint
 RUN chmod +x /generate_entrypoint.sh && \
   bash -c "/generate_entrypoint.sh" && \
-  rm -f /generate_entrypoint.sh
+  rm -f /generate_entrypoint.sh && \
+  bash -n /*.sh
 
 # Add templates for confd
 ADD ./confd/templates/* /etc/confd/templates/

--- a/ceph-releases/jewel/ubuntu/16.04/daemon/Dockerfile
+++ b/ceph-releases/jewel/ubuntu/16.04/daemon/Dockerfile
@@ -16,7 +16,8 @@ ADD *.sh ceph.defaults check_zombie_mons.py ./osd_scenarios/* entrypoint.sh.in d
 # Modify the entrypoint
 RUN chmod +x /generate_entrypoint.sh && \
   bash -c "/generate_entrypoint.sh" && \
-  rm -f /generate_entrypoint.sh
+  rm -f /generate_entrypoint.sh && \
+  bash -n /*.sh
 
 # Add templates for confd
 ADD ./confd/templates/* /etc/confd/templates/

--- a/ceph-releases/kraken/centos/7/daemon/Dockerfile
+++ b/ceph-releases/kraken/centos/7/daemon/Dockerfile
@@ -29,7 +29,8 @@ ADD *.sh ceph.defaults check_zombie_mons.py ./osd_scenarios/* entrypoint.sh.in d
 # Modify the entrypoint
 RUN chmod +x /generate_entrypoint.sh && \
   bash -c "/generate_entrypoint.sh" && \
-  rm -f /generate_entrypoint.sh
+  rm -f /generate_entrypoint.sh && \
+  bash -n /*.sh
 
 # Add templates for confd
 ADD ./confd/templates/* /etc/confd/templates/

--- a/ceph-releases/kraken/ubuntu/16.04/daemon/Dockerfile
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/Dockerfile
@@ -44,7 +44,8 @@ ADD *.sh ceph.defaults check_zombie_mons.py ./osd_scenarios/* entrypoint.sh.in d
 # Modify the entrypoint
 RUN chmod +x /generate_entrypoint.sh && \
   bash -c "/generate_entrypoint.sh" && \
-  rm -f /generate_entrypoint.sh
+  rm -f /generate_entrypoint.sh && \
+  bash -n /*.sh
 
 # Add templates for confd
 ADD ./confd/templates/* /etc/confd/templates/

--- a/ceph-releases/luminous/centos/7/daemon/Dockerfile
+++ b/ceph-releases/luminous/centos/7/daemon/Dockerfile
@@ -29,7 +29,8 @@ ADD *.sh ceph.defaults check_zombie_mons.py ./osd_scenarios/* entrypoint.sh.in d
 # Modify the entrypoint
 RUN chmod +x /generate_entrypoint.sh && \
   bash -c "/generate_entrypoint.sh" && \
-  rm -f /generate_entrypoint.sh
+  rm -f /generate_entrypoint.sh && \
+  bash -n /*.sh
 
 # Add templates for confd
 ADD ./confd/templates/* /etc/confd/templates/

--- a/ceph-releases/luminous/rhel/7.3/daemon/Dockerfile
+++ b/ceph-releases/luminous/rhel/7.3/daemon/Dockerfile
@@ -26,7 +26,8 @@ ADD *.sh ceph.defaults check_zombie_mons.py ./osd_scenarios/* entrypoint.sh.in d
 # Modify the entrypoint
 RUN chmod +x /generate_entrypoint.sh && \
   bash -c "/generate_entrypoint.sh" && \
-  rm -f /generate_entrypoint.sh
+  rm -f /generate_entrypoint.sh && \
+  bash -n /*.sh
 
 # Execute the entrypoint
 WORKDIR /

--- a/ceph-releases/luminous/ubuntu/16.04/daemon/Dockerfile
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/Dockerfile
@@ -44,7 +44,8 @@ ADD *.sh ceph.defaults check_zombie_mons.py ./osd_scenarios/* entrypoint.sh.in d
 # Modify the entrypoint
 RUN chmod +x /generate_entrypoint.sh && \
   bash -c "/generate_entrypoint.sh" && \
-  rm -f /generate_entrypoint.sh
+  rm -f /generate_entrypoint.sh && \
+  bash -n /*.sh
 
 # Add templates for confd
 ADD ./confd/templates/* /etc/confd/templates/


### PR DESCRIPTION
It's better to detect bash script syntax errors at build time instead of
runtime.

Signed-off-by: Sébastien Han <seb@redhat.com>