### PR TITLE
Helm charts: fixes&compat. fixes, still most from known issues remain

### DIFF
--- a/examples/helm/build-all.sh
+++ b/examples/helm/build-all.sh
@@ -6,8 +6,8 @@ function list_dirs () {
 function build_charts () {
   echo "Building Charts"
   list_dirs | while read CHART; do
-    if [ -f "${CHART}/Makefile" ]; then make -C ${CHART}; fi
-    if [ -f "${CHART}/requirements.yaml" ]; then helm dep up ${CHART}; fi
+    if [ -f "${CHART}/Makefile" ]; then make -C "${CHART}"; fi
+    if [ -f "${CHART}/requirements.yaml" ]; then helm dep up "${CHART}"; fi
     if [ -f "${CHART}/Chart.yaml" ]; then 
       helm package "./${CHART}"
     fi

--- a/examples/helm/build-all.sh
+++ b/examples/helm/build-all.sh
@@ -8,7 +8,9 @@ function build_charts () {
   list_dirs | while read CHART; do
     if [ -f ${CHART}/Makefile ]; then make -C ${CHART}; fi
     if [ -f ${CHART}/requirements.yaml ]; then helm dep up ${CHART}; fi
-    helm package ./${CHART}
+    if [ -f ${CHART}/Chart.yaml ]; then 
+      helm package ./${CHART};
+    fi
   done
 }
 

--- a/examples/helm/build-all.sh
+++ b/examples/helm/build-all.sh
@@ -6,10 +6,10 @@ function list_dirs () {
 function build_charts () {
   echo "Building Charts"
   list_dirs | while read CHART; do
-    if [ -f ${CHART}/Makefile ]; then make -C ${CHART}; fi
-    if [ -f ${CHART}/requirements.yaml ]; then helm dep up ${CHART}; fi
-    if [ -f ${CHART}/Chart.yaml ]; then 
-      helm package ./${CHART}
+    if [ -f "${CHART}/Makefile" ]; then make -C ${CHART}; fi
+    if [ -f "${CHART}/requirements.yaml" ]; then helm dep up ${CHART}; fi
+    if [ -f "${CHART}/Chart.yaml" ]; then 
+      helm package "./${CHART}"
     fi
   done
 }

--- a/examples/helm/build-all.sh
+++ b/examples/helm/build-all.sh
@@ -9,7 +9,7 @@ function build_charts () {
     if [ -f ${CHART}/Makefile ]; then make -C ${CHART}; fi
     if [ -f ${CHART}/requirements.yaml ]; then helm dep up ${CHART}; fi
     if [ -f ${CHART}/Chart.yaml ]; then 
-      helm package ./${CHART};
+      helm package ./${CHART}
     fi
   done
 }

--- a/examples/helm/ceph/templates/jobs/job.yaml
+++ b/examples/helm/ceph/templates/jobs/job.yaml
@@ -1,8 +1,12 @@
+{{- if .Capabilities.APIVersions.Has "batch/v1"}}
+apiVersion: batch/v1
+{{- else }}
 apiVersion: extensions/v1beta1
+{{- end }}
 kind: Job
 metadata:
   labels:
-    version: v0.1.0
+    version: {{ .Chart.Version }}
     app: ceph
     release: {{ .Release.Name }}
     daemon: secret-generator
@@ -11,7 +15,7 @@ spec:
   template:
     metadata:
       labels:
-        version: v0.1.0
+        version: {{ .Chart.Version }}
         app: ceph
         release: {{ .Release.Name }}
         daemon: secret-generator
@@ -21,8 +25,8 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: main
-          image: docker.io/kollakube/centos-binary-ceph-init-k8s:4.0.0
-          imagePullPolicy: Always
+          image: {{ .Values.images.ceph_init }}
+          imagePullPolicy: {{ .Values.image_policy.pull }}
           env:
             - name: CEPH_GEN_DIR
               value: /opt/ceph

--- a/examples/helm/ceph/templates/mds/deployment.yaml
+++ b/examples/helm/ceph/templates/mds/deployment.yaml
@@ -4,7 +4,7 @@ kind: Deployment
 apiVersion: extensions/v1beta1
 metadata:
   labels:
-    version: v0.1.0
+    version: {{ .Chart.Version }}
     app: ceph
     daemon: mds
     release: {{ .Release.Name }}
@@ -15,7 +15,7 @@ spec:
     metadata:
       name: ceph-mds
       labels:
-        version: v0.1.0
+        version: {{ .Chart.Version }}
         app: ceph
         daemon: mds
         release: {{ .Release.Name }}
@@ -38,6 +38,10 @@ spec:
               value: k8s
             - name: CLUSTER
               value: {{ .Values.ceph.cluster }}
+          {{- if .Values.debug_level }}
+            - name: DEBUG
+              value: {{ .Values.debug_level }}
+          {{- end }}
           volumeMounts:
             - name: ceph-conf
               mountPath: /etc/ceph/ceph.conf
@@ -54,15 +58,15 @@ spec:
             - name: ceph-bootstrap-osd-keyring
               mountPath: /var/lib/ceph/bootstrap-osd/ceph.keyring
               subPath: ceph.keyring
-              readOnly: true
+              readOnly: false
             - name: ceph-bootstrap-mds-keyring
               mountPath: /var/lib/ceph/bootstrap-mds/ceph.keyring
               subPath: ceph.keyring
-              readOnly: true
+              readOnly: false
             - name: ceph-bootstrap-rgw-keyring
               mountPath: /var/lib/ceph/bootstrap-rgw/ceph.keyring
               subPath: ceph.keyring
-              readOnly: true
+              readOnly: false
           livenessProbe:
               tcpSocket:
                 port: 6800

--- a/examples/helm/ceph/templates/mon/deployment.yaml
+++ b/examples/helm/ceph/templates/mon/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 apiVersion: extensions/v1beta1
 metadata:
   labels:
-    version: v0.1.0
+    version: {{ .Chart.Version }}
     app: ceph
     daemon: moncheck
     release: {{ .Release.Name }}
@@ -14,7 +14,7 @@ spec:
     metadata:
       name: ceph-mon
       labels:
-        version: v0.1.0
+        version: {{ .Chart.Version }}
         app: ceph
         daemon: moncheck
         release: {{ .Release.Name }}
@@ -35,6 +35,10 @@ spec:
               value: "1"
             - name: CLUSTER
               value: {{ .Values.ceph.cluster }}
+          {{- if .Values.debug_level }}
+            - name: DEBUG
+              value: {{ .Values.debug_level }}
+          {{- end }}
           volumeMounts:
             - name: ceph-conf
               mountPath: /etc/ceph/ceph.conf
@@ -51,15 +55,15 @@ spec:
             - name: ceph-bootstrap-osd-keyring
               mountPath: /var/lib/ceph/bootstrap-osd/ceph.keyring
               subPath: ceph.keyring
-              readOnly: true
+              readOnly: false
             - name: ceph-bootstrap-mds-keyring
               mountPath: /var/lib/ceph/bootstrap-mds/ceph.keyring
               subPath: ceph.keyring
-              readOnly: true
+              readOnly: false
             - name: ceph-bootstrap-rgw-keyring
               mountPath: /var/lib/ceph/bootstrap-rgw/ceph.keyring
               subPath: ceph.keyring
-              readOnly: true
+              readOnly: false
           resources:
             requests:
               memory: {{ .Values.resources.mon_check.requests.memory | quote }}

--- a/examples/helm/ceph/templates/mon/service.yaml
+++ b/examples/helm/ceph/templates/mon/service.yaml
@@ -7,6 +7,9 @@ metadata:
     app: ceph
     daemon: mon
     release: {{ .Release.Name }}
+  annotations:
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+  #https://github.com/ceph/ceph-docker/issues/573
 spec:
   ports:
   - port: {{ .Values.service.mon.port }}

--- a/examples/helm/ceph/templates/mon/statefulset.yaml
+++ b/examples/helm/ceph/templates/mon/statefulset.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1beta1
 kind: StatefulSet
 metadata:
   labels:
-    version: v0.1.0
+    version: {{ .Chart.Version }}
     app: ceph
     daemon: mon
     release: {{ .Release.Name }}
@@ -15,7 +15,7 @@ spec:
     metadata:
       name: ceph-mon
       labels:
-        version: v0.1.0
+        version: {{ .Chart.Version }}
         app: ceph
         daemon: mon
         release: {{ .Release.Name }}
@@ -54,13 +54,17 @@ spec:
             - name: KV_TYPE
               value: k8s
             - name: NETWORK_AUTO_DETECT
-              value: "0"
+              value: "4"
             - name: MON_IP
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
             - name: CLUSTER
               value: {{ .Values.ceph.cluster }}
+          {{- if .Values.debug_level }}
+            - name: DEBUG
+              value: {{ .Values.debug_level }}
+          {{- end }}
           volumeMounts:
             - name: ceph-conf
               mountPath: /etc/ceph/ceph.conf
@@ -73,19 +77,19 @@ spec:
             - name: ceph-mon-keyring
               mountPath: /etc/ceph/ceph.mon.keyring
               subPath: ceph.mon.keyring
-              readOnly: true
+              readOnly: false
             - name: ceph-bootstrap-osd-keyring
               mountPath: /var/lib/ceph/bootstrap-osd/ceph.keyring
               subPath: ceph.keyring
-              readOnly: true
+              readOnly: false
             - name: ceph-bootstrap-mds-keyring
               mountPath: /var/lib/ceph/bootstrap-mds/ceph.keyring
               subPath: ceph.keyring
-              readOnly: true
+              readOnly: false
             - name: ceph-bootstrap-rgw-keyring
               mountPath: /var/lib/ceph/bootstrap-rgw/ceph.keyring
               subPath: ceph.keyring
-              readOnly: true
+              readOnly: false
           livenessProbe:
               tcpSocket:
                 port: {{ .Values.service.mon.port }}

--- a/examples/helm/ceph/templates/osd/daemonset.yaml
+++ b/examples/helm/ceph/templates/osd/daemonset.yaml
@@ -4,7 +4,7 @@ apiVersion: extensions/v1beta1
 metadata:
   name: ceph-osd
   labels:
-    version: v0.1.0
+    version: {{ .Chart.Version }}
     app: ceph
     daemon: osd
     release: {{ .Release.Name }}
@@ -12,7 +12,7 @@ spec:
   template:
     metadata:
       labels:
-        version: v0.1.0
+        version: {{ .Chart.Version }}
         app: ceph
         daemon: osd
         release: {{ .Release.Name }}
@@ -48,15 +48,15 @@ spec:
             - name: ceph-bootstrap-osd-keyring
               mountPath: /var/lib/ceph/bootstrap-osd/ceph.keyring
               subPath: ceph.keyring
-              readOnly: true
+              readOnly: false
             - name: ceph-bootstrap-mds-keyring
               mountPath: /var/lib/ceph/bootstrap-mds/ceph.keyring
               subPath: ceph.keyring
-              readOnly: true
+              readOnly: false
             - name: ceph-bootstrap-rgw-keyring
               mountPath: /var/lib/ceph/bootstrap-rgw/ceph.keyring
               subPath: ceph.keyring
-              readOnly: true
+              readOnly: false
           securityContext:
             privileged: true
           env:
@@ -68,6 +68,10 @@ spec:
               value: {{ .Values.ceph.cluster }}
             - name: CEPH_GET_ADMIN_KEY
               value: "1"
+          {{- if .Values.debug_level }}
+            - name: DEBUG
+              value: {{ .Values.debug_level }}
+          {{- end }}
           livenessProbe:
               tcpSocket:
                 port: 6800

--- a/examples/helm/ceph/templates/rgw/deployment.yaml
+++ b/examples/helm/ceph/templates/rgw/deployment.yaml
@@ -36,6 +36,10 @@ spec:
               value: k8s
             - name: CLUSTER
               value: ceph
+          {{- if .Values.debug_level }}
+            - name: DEBUG
+              value: {{ .Values.debug_level }}
+          {{- end }}
           volumeMounts:
             - name: ceph-conf
               mountPath: /etc/ceph/ceph.conf
@@ -52,7 +56,7 @@ spec:
             - name: ceph-bootstrap-rgw-keyring
               mountPath: /var/lib/ceph/bootstrap-rgw/ceph.keyring
               subPath: ceph.keyring
-              readOnly: true
+              readOnly: false
           livenessProbe:
               tcpSocket:
                 port: {{ .Values.service.rgw.port }}

--- a/examples/helm/ceph/values.yaml
+++ b/examples/helm/ceph/values.yaml
@@ -1,9 +1,15 @@
 images:
   daemon: docker.io/ceph/daemon:latest
   exporter: digitalocean/ceph_exporter:1.0.0
+  ceph_init: docker.io/kollakube/centos-binary-ceph-init-k8s:4.0.0
 
 image_policy:
   pull: Always
+
+# As per: https://github.com/ceph/ceph-docker/blob/master/ceph-releases/luminous/ubuntu/16.04/daemon/debug.sh
+# Available options are: verbose,fstree and stayalive.
+# They can be used altogether like this: DEBUG=verbose,fstree=http://myfstree,stayalive
+debug_level: verbose
 
 labels:
   node_selector_key: ceph-storage
@@ -20,6 +26,7 @@ service:
     name: ceph-exporter
     port: 9128
 
+#When undefined here, it both networks default to: 10.244.0.0/16 (flannel)
 network:
   cluster: 10.192.0.0/10
   public: 10.192.0.0/10
@@ -136,6 +143,13 @@ resources:
     limits:
       memory: "1Gi"
       cpu: "1000m"
+  exporter:
+    requests:
+      memory: "10Mi"
+      cpu: "250m"
+    limits:
+      memory: "50Mi"
+      cpu: "500m"
 
 storageclass:
   name: general

--- a/examples/helm/deploy_steps.md
+++ b/examples/helm/deploy_steps.md
@@ -26,7 +26,7 @@ echo "cleaning up ceph folder on the nodes (rm -rf /var/lib/ceph-helm ). If you 
 sleep 2 #give user a chance to cancel it :)
 for node in $(kubectl get nodes | grep Ready | cut -f1 -d" ") 
 do 
-  echo "Running: ssh root@$x rm -rf /var/lib/ceph-helm"
+  echo "Running: ssh root@$node rm -rf /var/lib/ceph-helm"
   ssh root@$node 'hostname; rm -rf /var/lib/ceph-helm'
 done
 set -e

--- a/examples/helm/deploy_steps.md
+++ b/examples/helm/deploy_steps.md
@@ -1,0 +1,50 @@
+
+# Unless already in place, build k8s cluster
+Can be done using kubeadm, by using: https://github.com/ReSearchITEng/kubeadm-playbook
+
+# Only once, run this setup:
+```bash
+git clone https://github.com/ReSearchITEng/ceph-docker #This one has some fixes which were not yet merged in origin
+helm serve &
+helm repo add marina http://127.0.0.1:8879/charts
+#Label the nodes that will take part in the Ceph cluster
+kubectl get nodes -L kubeadm.alpha.kubernetes.io/role --no-headers | awk '$NF ~ /^<none>/ { print $1}' | while read NODE ; do
+  kubectl label node $NODE --overwrite ceph-storage=enabled
+done
+```
+
+# Every time you make a change to the helm chart, rebuild it and retest it with this script:
+```bash
+PatchV=${PatchV:-2}
+hfV=${hfV:-1}
+cd ceph-docker/examples/helm/
+helm delete $(helm list | grep ceph | awk '{print $1}' )
+echo "going to remove ceph namespace to ensure secrets are removed also(, or remove them manually)"
+kubectl delete namespace ceph #to ensure secrets are removed also, or remove them manually
+while [[ $(kubectl get ns | grep -w -c 'ceph' || true ) -gt 1 ]]; do sleep 1; done
+echo "cleaning up ceph folder on the nodes (rm -rf /var/lib/ceph-helm ). If you are ok with it, hit enter now"
+sleep 2 #give user a chance to cancel it :)
+for node in $(kubectl get nodes | grep Ready | cut -f1 -d" ") 
+do 
+  echo "Running: ssh root@$x rm -rf /var/lib/ceph-helm"
+  ssh root@$node 'hostname; rm -rf /var/lib/ceph-helm'
+done
+set -e
+set -o pipefail
+kubectl create namespace ceph; 
+(( hfV++ ))
+echo "Going to create new helm package version: 0.${PatchV}.${hfV}"
+echo "pack&deploy hfV=$hfV" 
+helm package --version 0.${PatchV}.${hfV} ceph
+helm repo update
+helm install --namespace ceph marina/ceph --version 0.${PatchV}.${hfV} --set network.cluster='10.244.0.0/16',network.public='10.244.0.0/16',images.daemon=docker.io/ceph/daemon:build-master-jewel-ubuntu-14.04
+set +e
+```
+Note: when flanned is used, the network should be set to: '10.244.0.0/16'. If it's calico or something else, put values accordingly.
+
+# ceph docker images tags one may want to test:
+tag-build-master-kraken-ubuntu-16.04 (new image)    
+tag-build-master-luminous-centos-7 (new image)   
+tag-build-master-jewel-centos-7 (new image)    
+build-master-jewel-ubuntu-14.04  (old image created 10 months ago)   
+build-master-kraken-ubuntu-16.04 (old image created 3 months ago)   


### PR DESCRIPTION
adopt k8s 1.6 also, added limits for node exporter, fixed build script, made some files from readOnly to readwrite so chown will not fail, added addnotation as per issue 573, added debug option, exposed the ceph_init image, changed NETWORK_AUTO_DETECT to 4 in statefull set (as per one issue)
It has been tested, things improved, but still most of the already reported issues remain, including lack of compatibility with the new images...