### PR TITLE
add summary, display-name, tags LABELs for RHEL

### DIFF
--- a/ceph-releases/jewel/rhel/7.3/daemon/Dockerfile
+++ b/ceph-releases/jewel/rhel/7.3/daemon/Dockerfile
@@ -43,3 +43,6 @@ LABEL install="/usr/bin/docker run --rm --privileged -v /:/host -e MON_IP=\${MON
 LABEL com.redhat.component="rhceph-rhel7-docker"
 LABEL name="rhceph"
 LABEL description="Red Hat Ceph Storage 2"
+LABEL summary="Provides the latest Red Hat Ceph Storage 2 on RHEL 7 in a fully featured and supported base image."
+LABEL io.k8s.display-name="Red Hat Ceph Storage 2 on RHEL 7"
+LABEL io.openshift.tags="rhceph ceph"

--- a/ceph-releases/luminous/rhel/7.3/daemon/Dockerfile
+++ b/ceph-releases/luminous/rhel/7.3/daemon/Dockerfile
@@ -43,3 +43,6 @@ LABEL install="/usr/bin/docker run --rm --privileged -v /:/host -e MON_IP=\${MON
 LABEL com.redhat.component="rhceph-rhel7-docker"
 LABEL name="rhceph"
 LABEL description="Red Hat Ceph Storage 3"
+LABEL summary="Provides the latest Red Hat Ceph Storage 3 on RHEL 7 in a fully featured and supported base image."
+LABEL io.k8s.display-name="Red Hat Ceph Storage 3 on RHEL 7"
+LABEL io.openshift.tags="rhceph ceph"


### PR DESCRIPTION
Prior to this change, The Red Hat Ceph Storage container images did not override labels from the RHEL 7 base image. In Red Hat's container catalog, the entry for rhceph displays some text about RHEL 7, not Ceph.

Override the RHEL 7 base image's labels with our product's labels.