### PR TITLE
daemon: add e2fsprogs for ext4

### DIFF
--- a/ceph-releases/jewel/centos/7/base/Dockerfile
+++ b/ceph-releases/jewel/centos/7/base/Dockerfile
@@ -12,7 +12,7 @@ ENV CONFD_VERSION 0.10.0
 RUN rpm --import 'https://download.ceph.com/keys/release.asc'
 RUN rpm -Uvh http://download.ceph.com/rpm-${CEPH_VERSION}/el7/noarch/ceph-release-1-1.el7.noarch.rpm
 RUN yum install -y epel-release && yum clean all
-ARG PACKAGES="unzip ceph-mon ceph-osd ceph-mds ceph-base ceph-common ceph-radosgw rbd-mirror device-mapper sharutils etcd kubernetes-client"
+ARG PACKAGES="unzip ceph-mon ceph-osd ceph-mds ceph-base ceph-common ceph-radosgw rbd-mirror device-mapper sharutils etcd kubernetes-client e2fsprogs"
 RUN yum install -y $PACKAGES && rpm -q $PACKAGES && yum clean all
 
 # Install confd

--- a/ceph-releases/jewel/rhel/7.3/daemon/Dockerfile
+++ b/ceph-releases/jewel/rhel/7.3/daemon/Dockerfile
@@ -6,7 +6,7 @@ LABEL Maintainer="Sebastien Han 'seb@redhat.com', Ken Dreyer 'kdreyer@redhat.com
 
 ENV container docker
 
-ARG PACKAGES="ceph-mon ceph-osd ceph-mds ceph-radosgw rbd-mirror nfs-ganesha-rgw"
+ARG PACKAGES="ceph-mon ceph-osd ceph-mds ceph-radosgw rbd-mirror nfs-ganesha-rgw e2fsprogs"
 RUN yum -y update && \
     yum -y install $PACKAGES && \
     rpm -q $PACKAGES && \

--- a/ceph-releases/kraken/centos/7/daemon/Dockerfile
+++ b/ceph-releases/kraken/centos/7/daemon/Dockerfile
@@ -12,7 +12,7 @@ ENV CONFD_VERSION 0.10.0
 RUN rpm --import 'https://download.ceph.com/keys/release.asc'
 RUN rpm -Uvh http://download.ceph.com/rpm-${CEPH_VERSION}/el7/noarch/ceph-release-1-1.el7.noarch.rpm
 RUN yum install -y epel-release && yum clean all
-ARG PACKAGES="unzip ceph-mon ceph-osd ceph-mds ceph-mgr ceph-base ceph-common ceph-radosgw rbd-mirror device-mapper sharutils etcd kubernetes-client"
+ARG PACKAGES="unzip ceph-mon ceph-osd ceph-mds ceph-mgr ceph-base ceph-common ceph-radosgw rbd-mirror device-mapper sharutils etcd kubernetes-client e2fsprogs"
 RUN yum install -y $PACKAGES && rpm -q $PACKAGES && yum clean all
 
 # Install confd

--- a/ceph-releases/luminous/centos/7/daemon/Dockerfile
+++ b/ceph-releases/luminous/centos/7/daemon/Dockerfile
@@ -12,7 +12,7 @@ ENV CONFD_VERSION 0.10.0
 RUN rpm --import 'https://download.ceph.com/keys/release.asc'
 RUN rpm -Uvh http://download.ceph.com/rpm-${CEPH_VERSION}/el7/noarch/ceph-release-1-1.el7.noarch.rpm
 RUN yum install -y epel-release && yum clean all
-ARG PACKAGES="unzip ceph-mon ceph-osd ceph-mds ceph-mgr ceph-base ceph-common ceph-radosgw rbd-mirror device-mapper sharutils etcd kubernetes-client"
+ARG PACKAGES="unzip ceph-mon ceph-osd ceph-mds ceph-mgr ceph-base ceph-common ceph-radosgw rbd-mirror device-mapper sharutils etcd kubernetes-client e2fsprogs"
 RUN yum install -y $PACKAGES && rpm -q $PACKAGES && yum clean all
 
 # Install confd

--- a/ceph-releases/luminous/rhel/7.3/daemon/Dockerfile
+++ b/ceph-releases/luminous/rhel/7.3/daemon/Dockerfile
@@ -6,7 +6,7 @@ LABEL Maintainer="Sebastien Han 'seb@redhat.com'"
 
 ENV container docker
 
-ARG PACKAGES="ceph-mon ceph-osd ceph-mds ceph-radosgw rbd-mirror nfs-ganesha-rgw"
+ARG PACKAGES="ceph-mon ceph-osd ceph-mds ceph-radosgw rbd-mirror nfs-ganesha-rgw e2fsprogs"
 RUN yum -y update && \
     yum -y install $PACKAGES && \
     rpm -q $PACKAGES && \


### PR DESCRIPTION
The container can not bootstrap a dmcrypt scenario since it tries to
create an ext4 partition. Since ext4 is not present, the preparation
fails.

Fixes: https://github.com/ceph/ceph-ansible/issues/1496

Signed-off-by: Sébastien Han <seb@redhat.com>