### PR TITLE
daemon: try to fetch the last version of monmap

### DIFF
--- a/ceph-releases/jewel/ubuntu/14.04/daemon/start_mon.sh
+++ b/ceph-releases/jewel/ubuntu/14.04/daemon/start_mon.sh
@@ -126,9 +126,11 @@ function start_mon {
     # Prepare the monitor daemon's directory with the map and keyring
     ceph-mon --setuser ceph --setgroup ceph --cluster ${CLUSTER} --mkfs -i ${MON_NAME} --inject-monmap $MONMAP --keyring $MON_KEYRING --mon-data "$MON_DATA_DIR"
   else
+    log "Trying to get the most recent monmap..."
+    # Ignore when we timeout, in most cases that means the cluster has no quorum or
+    # no mons are up and running yet
+    timeout 5 ceph ${CLI_OPTS} mon getmap -o $MONMAP || true
     ceph-mon --setuser ceph --setgroup ceph --cluster ${CLUSTER} -i ${MON_NAME} --inject-monmap $MONMAP --keyring $MON_KEYRING --mon-data "$MON_DATA_DIR"
-    # Ignore when we timeout in most cases that means the cluster has no qorum or
-    # no mons are up and running
     timeout 7 ceph ${CLI_OPTS} mon add "${MON_NAME}" "${MON_IP}:6789" || true
   fi
 

--- a/ceph-releases/kraken/ubuntu/16.04/daemon/start_mon.sh
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/start_mon.sh
@@ -126,9 +126,11 @@ function start_mon {
     # Prepare the monitor daemon's directory with the map and keyring
     ceph-mon --setuser ceph --setgroup ceph --cluster ${CLUSTER} --mkfs -i ${MON_NAME} --inject-monmap $MONMAP --keyring $MON_KEYRING --mon-data "$MON_DATA_DIR"
   else
+    log "Trying to get the most recent monmap..."
+    # Ignore when we timeout, in most cases that means the cluster has no quorum or
+    # no mons are up and running yet
+    timeout 5 ceph ${CLI_OPTS} mon getmap -o $MONMAP || true
     ceph-mon --setuser ceph --setgroup ceph --cluster ${CLUSTER} -i ${MON_NAME} --inject-monmap $MONMAP --keyring $MON_KEYRING --mon-data "$MON_DATA_DIR"
-    # Ignore when we timeout in most cases that means the cluster has no qorum or
-    # no mons are up and running
     timeout 7 ceph ${CLI_OPTS} mon add "${MON_NAME}" "${MON_IP}:6789" || true
   fi
 

--- a/ceph-releases/luminous/ubuntu/16.04/daemon/start_mon.sh
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/start_mon.sh
@@ -126,9 +126,11 @@ function start_mon {
     # Prepare the monitor daemon's directory with the map and keyring
     ceph-mon --setuser ceph --setgroup ceph --cluster ${CLUSTER} --mkfs -i ${MON_NAME} --inject-monmap $MONMAP --keyring $MON_KEYRING --mon-data "$MON_DATA_DIR"
   else
+    log "Trying to get the most recent monmap..."
+    # Ignore when we timeout, in most cases that means the cluster has no quorum or
+    # no mons are up and running yet
+    timeout 5 ceph ${CLI_OPTS} mon getmap -o $MONMAP || true
     ceph-mon --setuser ceph --setgroup ceph --cluster ${CLUSTER} -i ${MON_NAME} --inject-monmap $MONMAP --keyring $MON_KEYRING --mon-data "$MON_DATA_DIR"
-    # Ignore when we timeout in most cases that means the cluster has no qorum or
-    # no mons are up and running
     timeout 7 ceph ${CLI_OPTS} mon add "${MON_NAME}" "${MON_IP}:6789" || true
   fi
 


### PR DESCRIPTION
When the container restarts we re-inject the old version of the map
which results in the monitor failing to start/join the existing quorum.
So now we fetch the latest version prior to re-run it.

Fixes: https://github.com/ceph/ceph-docker/issues/626
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1448954

Signed-off-by: Sébastien Han <seb@redhat.com>
(cherry picked from commit b59bcbec66c3ca1a444bac5676d9773933883d66)