### PR TITLE
tests: more testing scenarios

### DIFF
--- a/tests/setup.yml
+++ b/tests/setup.yml
@@ -2,9 +2,34 @@
 
 - hosts: all
   gather_facts: true
+  become: yes
   tasks :
+    - name: check if it is Atomic host
+      stat: path=/run/ostree-booted
+      register: stat_ostree
+      always_run: true
+
+    - name: set fact for using Atomic host
+      set_fact:
+        is_atomic: '{{ stat_ostree.stat.exists }}'
+
+    - name: install docker on redhat systems
+      package:
+        name: docker
+        state: present
+      when:
+        - ansible_os_family == 'RedHat'
+        - not is_atomic
+
+    - name: install docker.io on debian systems
+      package:
+        name: docker.io
+        state: present
+      when:
+        - ansible_os_family == 'Debian'
+        - not is_atomic
+
     - name: allow nodes to use an insecure registry
-      become: yes
       blockinfile:
         dest: /etc/sysconfig/docker
         block: |
@@ -13,7 +38,6 @@
         marker: "# {mark} ANSIBLE MANAGED BLOCK" 
 
     - name: restart docker
-      become: yes
       service:
         name: docker
         state: restarted

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {ceph_ansible,ceph_ansible2.2}-{jewel,kraken}-{xenial,centos7}-{cluster}
+envlist = {ceph_ansible,ceph_ansible2.2}-{jewel,kraken}-{xenial,centos7}-{cluster,dedicated_journal,dmcrypt_journal_collocation}
 skipsdist = True
 
 [testenv]
@@ -15,7 +15,9 @@ setenv=
   ANSIBLE_ACTION_PLUGINS = {toxinidir}/ceph-ansible/plugins/actions
   # only available for ansible >= 2.2
   ANSIBLE_STDOUT_CALLBACK = debug
-  CEPH_ANSIBLE_SCENARIO_PATH = {toxinidir}/ceph-ansible/tests/functional/centos/7/docker-cluster
+  cluster: CEPH_ANSIBLE_SCENARIO_PATH = {toxinidir}/ceph-ansible/tests/functional/centos/7/docker-cluster
+  dedicated_journal: CEPH_ANSIBLE_SCENARIO_PATH = {toxinidir}/ceph-ansible/tests/functional/centos/7/docker-cluster-dedicated-journal
+  dmcrypt_journal_collocation: CEPH_ANSIBLE_SCENARIO_PATH = {toxinidir}/ceph-ansible/tests/functional/centos/7/docker-cluster-dmcrypt-journal-collocation
   # we're reusing the same test scenario from ceph-ansible so
   # for now we can reuse this same address
   REGISTRY_ADDRESS = 192.168.15.1:5000

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {ceph_ansible,ceph_ansible2.2}-{jewel,kraken}-{xenial,centos7}-{cluster,dedicated_journal,dmcrypt_journal_collocation}
+envlist = {ceph_ansible,ceph_ansible2.2}-{jewel,kraken,luminous}-{xenial,centos7}-{cluster,dedicated_journal,dmcrypt_journal_collocation}
 skipsdist = True
 
 [testenv]
@@ -25,6 +25,7 @@ setenv=
   xenial: IMAGE_DISTRO = ubuntu/16.04
   jewel: CEPH_STABLE_RELEASE = jewel
   kraken: CEPH_STABLE_RELEASE = kraken
+  luminous: CEPH_STABLE_RELEASE = luminous
   ceph_ansible2.2: CEPH_ANSIBLE_BRANCH = stable-2.2
   ceph_ansible: CEPH_ANSIBLE_BRANCH = master
   VAGRANT_PROVIDER={env:VAGRANT_PROVIDER:libvirt}


### PR DESCRIPTION
This adds ``dedicated_journal`` and ``dmcrypt_journal_collocation`` tests from ceph-ansible. It also adds ``luminous`` as a ceph release factor so we can test luminous containers as well.