### PR TITLE
tests: test with ansible==2.2.3

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -30,6 +30,6 @@ setenv=
   ceph_ansible: CEPH_ANSIBLE_BRANCH = master
   VAGRANT_PROVIDER={env:VAGRANT_PROVIDER:libvirt}
 deps=
-  ansible==2.2
+  ansible==2.2.3
 commands=
   bash {toxinidir}/tests/tox.sh


### PR DESCRIPTION
This avoids an issue we were seeing where tasks were not skipped when they should have been.

e.g. https://jenkins.ceph.com/view/ceph-docker/job/ceph-docker-nightly-ceph_ansible2.2-jewel-centos7-cluster/10/console

Signed-off-by: Andrew Schoen <aschoen@redhat.com>