### PR TITLE
start mon: use -c instead of --inject-monmap

### DIFF
--- a/ceph-releases/jewel/ubuntu/14.04/daemon/start_mon.sh
+++ b/ceph-releases/jewel/ubuntu/14.04/daemon/start_mon.sh
@@ -126,11 +126,8 @@ function start_mon {
     # Prepare the monitor daemon's directory with the map and keyring
     ceph-mon --setuser ceph --setgroup ceph --cluster ${CLUSTER} --mkfs -i ${MON_NAME} --inject-monmap $MONMAP --keyring $MON_KEYRING --mon-data "$MON_DATA_DIR"
   else
-    log "Trying to get the most recent monmap..."
-    # Ignore when we timeout, in most cases that means the cluster has no quorum or
-    # no mons are up and running yet
-    timeout 5 ceph ${CLI_OPTS} mon getmap -o $MONMAP || true
-    ceph-mon --setuser ceph --setgroup ceph --cluster ${CLUSTER} -i ${MON_NAME} --inject-monmap $MONMAP --keyring $MON_KEYRING --mon-data "$MON_DATA_DIR"
+    log "Existing mon, trying to rejoin cluster..."
+    ceph-mon --setuser ceph --setgroup ceph --cluster ${CLUSTER} -i ${MON_NAME} -c /etc/ceph/${CLUSTER}.conf --keyring $MON_KEYRING --mon-data "$MON_DATA_DIR"
     timeout 7 ceph ${CLI_OPTS} mon add "${MON_NAME}" "${MON_IP}:6789" || true
   fi
 

--- a/ceph-releases/kraken/ubuntu/16.04/daemon/start_mon.sh
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/start_mon.sh
@@ -126,11 +126,8 @@ function start_mon {
     # Prepare the monitor daemon's directory with the map and keyring
     ceph-mon --setuser ceph --setgroup ceph --cluster ${CLUSTER} --mkfs -i ${MON_NAME} --inject-monmap $MONMAP --keyring $MON_KEYRING --mon-data "$MON_DATA_DIR"
   else
-    log "Trying to get the most recent monmap..."
-    # Ignore when we timeout, in most cases that means the cluster has no quorum or
-    # no mons are up and running yet
-    timeout 5 ceph ${CLI_OPTS} mon getmap -o $MONMAP || true
-    ceph-mon --setuser ceph --setgroup ceph --cluster ${CLUSTER} -i ${MON_NAME} --inject-monmap $MONMAP --keyring $MON_KEYRING --mon-data "$MON_DATA_DIR"
+    log "Existing mon, trying to rejoin cluster..."
+    ceph-mon --setuser ceph --setgroup ceph --cluster ${CLUSTER} -i ${MON_NAME} -c /etc/ceph/${CLUSTER}.conf --keyring $MON_KEYRING --mon-data "$MON_DATA_DIR"
     timeout 7 ceph ${CLI_OPTS} mon add "${MON_NAME}" "${MON_IP}:6789" || true
   fi
 

--- a/ceph-releases/luminous/ubuntu/16.04/daemon/start_mon.sh
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/start_mon.sh
@@ -126,11 +126,8 @@ function start_mon {
     # Prepare the monitor daemon's directory with the map and keyring
     ceph-mon --setuser ceph --setgroup ceph --cluster ${CLUSTER} --mkfs -i ${MON_NAME} --inject-monmap $MONMAP --keyring $MON_KEYRING --mon-data "$MON_DATA_DIR"
   else
-    log "Trying to get the most recent monmap..."
-    # Ignore when we timeout, in most cases that means the cluster has no quorum or
-    # no mons are up and running yet
-    timeout 5 ceph ${CLI_OPTS} mon getmap -o $MONMAP || true
-    ceph-mon --setuser ceph --setgroup ceph --cluster ${CLUSTER} -i ${MON_NAME} --inject-monmap $MONMAP --keyring $MON_KEYRING --mon-data "$MON_DATA_DIR"
+    log "Existing mon, trying to rejoin cluster..."
+    ceph-mon --setuser ceph --setgroup ceph --cluster ${CLUSTER} -i ${MON_NAME} -c /etc/ceph/${CLUSTER}.conf --keyring $MON_KEYRING --mon-data "$MON_DATA_DIR"
     timeout 7 ceph ${CLI_OPTS} mon add "${MON_NAME}" "${MON_IP}:6789" || true
   fi
 


### PR DESCRIPTION
In a scenario where all mon hsots are rebooted some mons fail to come
back up, using -c which points at the configuration file is safer
because we can know that all monitors are defined there.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1455357

Signed-off-by: Andrew Schoen <aschoen@redhat.com>