### PR TITLE
Add tests/teardown.sh

### DIFF
--- a/tests/teardown.sh
+++ b/tests/teardown.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -x
+
+# shellcheck source=/dev/null
+. "$WORKSPACE/.tox_vars"
+cd "$CEPH_ANSIBLE_SCENARIO_PATH" || exit 1
+vagrant destroy --force
+cd "$WORKSPACE" || exit

--- a/tests/tox.sh
+++ b/tests/tox.sh
@@ -11,6 +11,17 @@ set -ex
 
 # setup
 #################################################################################
+# If WORKSPACE is undefined, set it to $TOXINIDIR
+echo ${WORKSPACE:=$TOXINIDIR}
+
+# Write down a couple environment variables, for use in teardown
+OUR_TOX_VARS=$WORKSPACE/.tox_vars
+rm -f $OUR_TOX_VARS
+cat > $OUR_TOX_VARS << EOF
+export WORKSPACE=$WORKSPACE
+export CEPH_ANSIBLE_SCENARIO_PATH=$CEPH_ANSIBLE_SCENARIO_PATH
+EOF
+
 # Check distro and install deps
 if command -v apt-get &>/dev/null; then
     sudo apt-get install -y --force-yes docker.io
@@ -88,6 +99,4 @@ testinfra -n 4 --sudo -v --connection=ansible --ansible-inventory=$CEPH_ANSIBLE_
 
 # teardown
 #################################################################################
-cd $CEPH_ANSIBLE_SCENARIO_PATH
-vagrant destroy --force
-cd $WORKSPACE
+bash $TOXINIDIR/tests/teardown.sh


### PR DESCRIPTION
This is useful when executing tox outside a CI environment; if tests
fail nothing is cleaned up. While that might be desirable, let's provide
a way to manually tear everything down.

Signed-off-by: Zack Cerza <zack@redhat.com>