### PR TITLE
daemon: use stat instead of file

### DIFF
--- a/ceph-releases/jewel/ubuntu/14.04/daemon/zap_device.sh
+++ b/ceph-releases/jewel/ubuntu/14.04/daemon/zap_device.sh
@@ -12,7 +12,7 @@ function zap_device {
 
   # testing all the devices first so we just don't do anything if one device is wrong
   for device in $(comma_to_space ${OSD_DEVICE}); do
-    if ! file -s $device &> /dev/null; then
+    if [[ $(stat --format=%F "$device" 2> /dev/null) != "block special file" ]]; then
       log "Provided device $device does not exist."
       exit 1
     fi

--- a/ceph-releases/kraken/ubuntu/16.04/daemon/zap_device.sh
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/zap_device.sh
@@ -12,7 +12,7 @@ function zap_device {
 
   # testing all the devices first so we just don't do anything if one device is wrong
   for device in $(comma_to_space ${OSD_DEVICE}); do
-    if ! file -s $device &> /dev/null; then
+    if [[ $(stat --format=%F "$device" 2> /dev/null) != "block special file" ]]; then
       log "Provided device $device does not exist."
       exit 1
     fi

--- a/ceph-releases/luminous/ubuntu/16.04/daemon/zap_device.sh
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/zap_device.sh
@@ -12,7 +12,7 @@ function zap_device {
 
   # testing all the devices first so we just don't do anything if one device is wrong
   for device in $(comma_to_space ${OSD_DEVICE}); do
-    if ! file -s $device &> /dev/null; then
+    if [[ $(stat --format=%F "$device" 2> /dev/null) != "block special file" ]]; then
       log "Provided device $device does not exist."
       exit 1
     fi


### PR DESCRIPTION
The command "file" doesn't exist on centos, so using 'stat' instead.
This also fixes the purge scenario.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1457321
Signed-off-by: Sébastien Han <seb@redhat.com>