### PR TITLE
OSD activate fails if cluster name includes number

### DIFF
--- a/ceph-releases/jewel/ubuntu/14.04/daemon/osd_scenarios/osd_disk_activate.sh
+++ b/ceph-releases/jewel/ubuntu/14.04/daemon/osd_scenarios/osd_disk_activate.sh
@@ -40,7 +40,7 @@ function osd_activate {
 
   ceph-disk -v --setuser ceph --setgroup disk activate ${CEPH_DISK_OPTIONS} --no-start-daemon ${DATA_PART}
 
-  OSD_ID=$(grep "${MOUNTED_PART}" /proc/mounts | awk '{print $2}' | grep -oh '[0-9]*')
+  OSD_ID=$(grep "${MOUNTED_PART}" /proc/mounts | awk '{print $2}' | sed -r 's/^.*-([0-9]+)$/\1/')
   OSD_PATH=$(get_osd_path $OSD_ID)
   OSD_KEYRING="$OSD_PATH/keyring"
   OSD_WEIGHT=$(df -P -k $OSD_PATH | tail -1 | awk '{ d= $2/1073741824 ; r = sprintf("%.2f", d); print r }')

--- a/ceph-releases/kraken/ubuntu/16.04/daemon/osd_scenarios/osd_disk_activate.sh
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/osd_scenarios/osd_disk_activate.sh
@@ -40,7 +40,7 @@ function osd_activate {
 
   ceph-disk -v --setuser ceph --setgroup disk activate ${CEPH_DISK_OPTIONS} --no-start-daemon ${DATA_PART}
 
-  OSD_ID=$(grep "${MOUNTED_PART}" /proc/mounts | awk '{print $2}' | grep -oh '[0-9]*')
+  OSD_ID=$(grep "${MOUNTED_PART}" /proc/mounts | awk '{print $2}' | sed -r 's/^.*-([0-9]+)$/\1/')
   OSD_PATH=$(get_osd_path $OSD_ID)
   OSD_KEYRING="$OSD_PATH/keyring"
   if [[ ${OSD_BLUESTORE} -eq 1 ]] && [ -e "${OSD_PATH}block" ]; then

--- a/ceph-releases/luminous/ubuntu/16.04/daemon/osd_scenarios/osd_disk_activate.sh
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/osd_scenarios/osd_disk_activate.sh
@@ -40,7 +40,7 @@ function osd_activate {
 
   ceph-disk -v --setuser ceph --setgroup disk activate ${CEPH_DISK_OPTIONS} --no-start-daemon ${DATA_PART}
 
-  OSD_ID=$(grep "${MOUNTED_PART}" /proc/mounts | awk '{print $2}' | grep -oh '[0-9]*')
+  OSD_ID=$(grep "${MOUNTED_PART}" /proc/mounts | awk '{print $2}' | sed -r 's/^.*-([0-9]+)$/\1/')
   OSD_PATH=$(get_osd_path $OSD_ID)
   OSD_KEYRING="$OSD_PATH/keyring"
   if [[ ${OSD_BLUESTORE} -eq 1 ]] && [ -e "${OSD_PATH}block" ]; then


### PR DESCRIPTION
When ceph cluster name includes number, osd disk activation will fail.

Fix: BZ-1458512 (https://bugzilla.redhat.com/show_bug.cgi?id=1458512)

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>