### PR TITLE
daemon: improve debugging line

### DIFF
--- a/ceph-releases/jewel/ubuntu/14.04/daemon/debug.sh
+++ b/ceph-releases/jewel/ubuntu/14.04/daemon/debug.sh
@@ -11,6 +11,9 @@ for option in $(comma_to_space ${DEBUG}); do
   case $option in
     verbose)
       echo "VERBOSE: activating bash debugging mode."
+      echo "To run Ceph daemons in debugging mode, pass the CEPH_ARGS variable like this:"
+      echo "-e CEPH_ARGS='--debug-ms 1 --debug-osd 10'"
+      export PS4='+${BASH_SOURCE}:${LINENO}: ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
       set -x
       ;;
     fstree*)
@@ -51,6 +54,9 @@ for option in $(comma_to_space ${DEBUG}); do
       echo "$option is not a valid debug option."
       echo "Available options are: verbose,fstree and stayalive."
       echo "They can be used altogether like this: '-e DEBUG=verbose,fstree=http://myfstree,stayalive"
+      echo ""
+      echo "To run Ceph daemons in debugging mode, pass the CEPH_ARGS variable like this:"
+      echo "-e CEPH_ARGS='--debug-ms 1 --debug-osd 10'"
       exit 1
       ;;
   esac

--- a/ceph-releases/jewel/ubuntu/14.04/daemon/debug.sh
+++ b/ceph-releases/jewel/ubuntu/14.04/daemon/debug.sh
@@ -10,14 +10,14 @@ function extract_param {
 for option in $(comma_to_space ${DEBUG}); do
   case $option in
     verbose)
-      echo "VERBOSE: activating bash debugging mode."
-      echo "To run Ceph daemons in debugging mode, pass the CEPH_ARGS variable like this:"
-      echo "-e CEPH_ARGS='--debug-ms 1 --debug-osd 10'"
+      log "VERBOSE: activating bash debugging mode."
+      log "To run Ceph daemons in debugging mode, pass the CEPH_ARGS variable like this:"
+      log "-e CEPH_ARGS='--debug-ms 1 --debug-osd 10'"
       export PS4='+${BASH_SOURCE}:${LINENO}: ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
       set -x
       ;;
     fstree*)
-      echo "FSTREE: uncompressing content of $(extract_param $option)"
+      log "FSTREE: uncompressing content of $(extract_param $option)"
       # NOTE (leseb): the entrypoint should already be running from /
       # This is just a safeguard
       pushd / > /dev/null
@@ -33,11 +33,11 @@ for option in $(comma_to_space ${DEBUG}); do
       for sub_level in $(seq 2 -1 0); do
         tar -tf patch.tar | cut -d "/" -f $((sub_level+1)) | egrep -sqw "bin|etc|lib|lib64|opt|run|usr|sbin|var" && strip_level=$sub_level || true
       done
-      echo "The main directory is at level $strip_level"
-      echo ""
-      echo "SHA1 of the archive is: $(sha1sum patch.tar)"
-      echo ""
-      echo "Now, we print the SHA1 of each file."
+      log "The main directory is at level $strip_level"
+      log ""
+      log "SHA1 of the archive is: $(sha1sum patch.tar)"
+      log ""
+      log "Now, we print the SHA1 of each file."
       for f in $(tar xfpv patch.tar --show-transformed-names --strip=$strip_level); do
         if [[ ! -d $f ]]; then
           sha1sum $f
@@ -47,16 +47,16 @@ for option in $(comma_to_space ${DEBUG}); do
       popd > /dev/null
       ;;
     stayalive)
-      echo "STAYALIVE: container will not die if a command fails."
+      log "STAYALIVE: container will not die if a command fails."
       source docker_exec.sh
       ;;
     *)
-      echo "$option is not a valid debug option."
-      echo "Available options are: verbose,fstree and stayalive."
-      echo "They can be used altogether like this: '-e DEBUG=verbose,fstree=http://myfstree,stayalive"
-      echo ""
-      echo "To run Ceph daemons in debugging mode, pass the CEPH_ARGS variable like this:"
-      echo "-e CEPH_ARGS='--debug-ms 1 --debug-osd 10'"
+      log "$option is not a valid debug option."
+      log "Available options are: verbose, fstree and stayalive."
+      log "They can be used altogether like this: '-e DEBUG=verbose,fstree=http://myfstree,stayalive'"
+      log ""
+      log "To run Ceph daemons in debugging mode, pass the CEPH_ARGS variable like this:"
+      log "-e CEPH_ARGS='--debug-ms 1 --debug-osd 10'"
       exit 1
       ;;
   esac

--- a/ceph-releases/kraken/ubuntu/16.04/daemon/debug.sh
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/debug.sh
@@ -11,6 +11,9 @@ for option in $(comma_to_space ${DEBUG}); do
   case $option in
     verbose)
       echo "VERBOSE: activating bash debugging mode."
+      echo "To run Ceph daemons in debugging mode, pass the CEPH_ARGS variable like this:"
+      echo "-e CEPH_ARGS='--debug-ms 1 --debug-osd 10'"
+      export PS4='+${BASH_SOURCE}:${LINENO}: ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
       set -x
       ;;
     fstree*)
@@ -51,6 +54,9 @@ for option in $(comma_to_space ${DEBUG}); do
       echo "$option is not a valid debug option."
       echo "Available options are: verbose,fstree and stayalive."
       echo "They can be used altogether like this: '-e DEBUG=verbose,fstree=http://myfstree,stayalive"
+      echo ""
+      echo "To run Ceph daemons in debugging mode, pass the CEPH_ARGS variable like this:"
+      echo "-e CEPH_ARGS='--debug-ms 1 --debug-osd 10'"
       exit 1
       ;;
   esac

--- a/ceph-releases/kraken/ubuntu/16.04/daemon/debug.sh
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/debug.sh
@@ -10,14 +10,14 @@ function extract_param {
 for option in $(comma_to_space ${DEBUG}); do
   case $option in
     verbose)
-      echo "VERBOSE: activating bash debugging mode."
-      echo "To run Ceph daemons in debugging mode, pass the CEPH_ARGS variable like this:"
-      echo "-e CEPH_ARGS='--debug-ms 1 --debug-osd 10'"
+      log "VERBOSE: activating bash debugging mode."
+      log "To run Ceph daemons in debugging mode, pass the CEPH_ARGS variable like this:"
+      log "-e CEPH_ARGS='--debug-ms 1 --debug-osd 10'"
       export PS4='+${BASH_SOURCE}:${LINENO}: ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
       set -x
       ;;
     fstree*)
-      echo "FSTREE: uncompressing content of $(extract_param $option)"
+      log "FSTREE: uncompressing content of $(extract_param $option)"
       # NOTE (leseb): the entrypoint should already be running from /
       # This is just a safeguard
       pushd / > /dev/null
@@ -33,11 +33,11 @@ for option in $(comma_to_space ${DEBUG}); do
       for sub_level in $(seq 2 -1 0); do
         tar -tf patch.tar | cut -d "/" -f $((sub_level+1)) | egrep -sqw "bin|etc|lib|lib64|opt|run|usr|sbin|var" && strip_level=$sub_level || true
       done
-      echo "The main directory is at level $strip_level"
-      echo ""
-      echo "SHA1 of the archive is: $(sha1sum patch.tar)"
-      echo ""
-      echo "Now, we print the SHA1 of each file."
+      log "The main directory is at level $strip_level"
+      log ""
+      log "SHA1 of the archive is: $(sha1sum patch.tar)"
+      log ""
+      log "Now, we print the SHA1 of each file."
       for f in $(tar xfpv patch.tar --show-transformed-names --strip=$strip_level); do
         if [[ ! -d $f ]]; then
           sha1sum $f
@@ -47,16 +47,16 @@ for option in $(comma_to_space ${DEBUG}); do
       popd > /dev/null
       ;;
     stayalive)
-      echo "STAYALIVE: container will not die if a command fails."
+      log "STAYALIVE: container will not die if a command fails."
       source docker_exec.sh
       ;;
     *)
-      echo "$option is not a valid debug option."
-      echo "Available options are: verbose,fstree and stayalive."
-      echo "They can be used altogether like this: '-e DEBUG=verbose,fstree=http://myfstree,stayalive"
-      echo ""
-      echo "To run Ceph daemons in debugging mode, pass the CEPH_ARGS variable like this:"
-      echo "-e CEPH_ARGS='--debug-ms 1 --debug-osd 10'"
+      log "$option is not a valid debug option."
+      log "Available options are: verbose, fstree and stayalive."
+      log "They can be used altogether like this: '-e DEBUG=verbose,fstree=http://myfstree,stayalive'"
+      log ""
+      log "To run Ceph daemons in debugging mode, pass the CEPH_ARGS variable like this:"
+      log "-e CEPH_ARGS='--debug-ms 1 --debug-osd 10'"
       exit 1
       ;;
   esac

--- a/ceph-releases/luminous/ubuntu/16.04/daemon/debug.sh
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/debug.sh
@@ -11,6 +11,9 @@ for option in $(comma_to_space ${DEBUG}); do
   case $option in
     verbose)
       echo "VERBOSE: activating bash debugging mode."
+      echo "To run Ceph daemons in debugging mode, pass the CEPH_ARGS variable like this:"
+      echo "-e CEPH_ARGS='--debug-ms 1 --debug-osd 10'"
+      export PS4='+${BASH_SOURCE}:${LINENO}: ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
       set -x
       ;;
     fstree*)
@@ -51,6 +54,9 @@ for option in $(comma_to_space ${DEBUG}); do
       echo "$option is not a valid debug option."
       echo "Available options are: verbose,fstree and stayalive."
       echo "They can be used altogether like this: '-e DEBUG=verbose,fstree=http://myfstree,stayalive"
+      echo ""
+      echo "To run Ceph daemons in debugging mode, pass the CEPH_ARGS variable like this:"
+      echo "-e CEPH_ARGS='--debug-ms 1 --debug-osd 10'"
       exit 1
       ;;
   esac

--- a/ceph-releases/luminous/ubuntu/16.04/daemon/debug.sh
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/debug.sh
@@ -10,14 +10,14 @@ function extract_param {
 for option in $(comma_to_space ${DEBUG}); do
   case $option in
     verbose)
-      echo "VERBOSE: activating bash debugging mode."
-      echo "To run Ceph daemons in debugging mode, pass the CEPH_ARGS variable like this:"
-      echo "-e CEPH_ARGS='--debug-ms 1 --debug-osd 10'"
+      log "VERBOSE: activating bash debugging mode."
+      log "To run Ceph daemons in debugging mode, pass the CEPH_ARGS variable like this:"
+      log "-e CEPH_ARGS='--debug-ms 1 --debug-osd 10'"
       export PS4='+${BASH_SOURCE}:${LINENO}: ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
       set -x
       ;;
     fstree*)
-      echo "FSTREE: uncompressing content of $(extract_param $option)"
+      log "FSTREE: uncompressing content of $(extract_param $option)"
       # NOTE (leseb): the entrypoint should already be running from /
       # This is just a safeguard
       pushd / > /dev/null
@@ -33,11 +33,11 @@ for option in $(comma_to_space ${DEBUG}); do
       for sub_level in $(seq 2 -1 0); do
         tar -tf patch.tar | cut -d "/" -f $((sub_level+1)) | egrep -sqw "bin|etc|lib|lib64|opt|run|usr|sbin|var" && strip_level=$sub_level || true
       done
-      echo "The main directory is at level $strip_level"
-      echo ""
-      echo "SHA1 of the archive is: $(sha1sum patch.tar)"
-      echo ""
-      echo "Now, we print the SHA1 of each file."
+      log "The main directory is at level $strip_level"
+      log ""
+      log "SHA1 of the archive is: $(sha1sum patch.tar)"
+      log ""
+      log "Now, we print the SHA1 of each file."
       for f in $(tar xfpv patch.tar --show-transformed-names --strip=$strip_level); do
         if [[ ! -d $f ]]; then
           sha1sum $f
@@ -47,16 +47,16 @@ for option in $(comma_to_space ${DEBUG}); do
       popd > /dev/null
       ;;
     stayalive)
-      echo "STAYALIVE: container will not die if a command fails."
+      log "STAYALIVE: container will not die if a command fails."
       source docker_exec.sh
       ;;
     *)
-      echo "$option is not a valid debug option."
-      echo "Available options are: verbose,fstree and stayalive."
-      echo "They can be used altogether like this: '-e DEBUG=verbose,fstree=http://myfstree,stayalive"
-      echo ""
-      echo "To run Ceph daemons in debugging mode, pass the CEPH_ARGS variable like this:"
-      echo "-e CEPH_ARGS='--debug-ms 1 --debug-osd 10'"
+      log "$option is not a valid debug option."
+      log "Available options are: verbose, fstree and stayalive."
+      log "They can be used altogether like this: '-e DEBUG=verbose,fstree=http://myfstree,stayalive'"
+      log ""
+      log "To run Ceph daemons in debugging mode, pass the CEPH_ARGS variable like this:"
+      log "-e CEPH_ARGS='--debug-ms 1 --debug-osd 10'"
       exit 1
       ;;
   esac


### PR DESCRIPTION
When setting DEBUG=verbose, this only activates bash tracing with set
-x. This patch adds more info during the debug like the name of the
script and the line being executed. See:

$ ./a.sh
+./a.sh:6: echo a
a

Signed-off-by: Sébastien Han <seb@redhat.com>