### PR TITLE
daemon: improve ceph health check error

### DIFF
--- a/ceph-releases/jewel/ubuntu/14.04/daemon/common_functions.sh
+++ b/ceph-releases/jewel/ubuntu/14.04/daemon/common_functions.sh
@@ -236,3 +236,15 @@ function apply_ceph_ownership_to_disks {
   fi
   chown --verbose ceph. $(dev_part ${OSD_DEVICE} 1)
 }
+
+function ceph_health {
+  local bootstrap_user=$1
+  local bootstrap_key=$2
+
+  if ! timeout 10 ceph ${CLI_OPTS} --name $bootstrap_user --keyring $bootstrap_key health; then
+    log "Timed out while trying to reach out to the Ceph Monitor(s)."
+    log "Make sure your Ceph monitors are up and running in quorum."
+    log "Also verify the validity of client.bootstrap-osd keyring."
+    exit 1
+  fi
+}

--- a/ceph-releases/jewel/ubuntu/14.04/daemon/osd_scenarios/osd_directory.sh
+++ b/ceph-releases/jewel/ubuntu/14.04/daemon/osd_scenarios/osd_directory.sh
@@ -60,7 +60,8 @@ function osd_directory {
         log "ERROR- $OSD_BOOTSTRAP_KEYRING must exist. You can extract it from your current monitor by running 'ceph auth get client.bootstrap-osd -o $OSD_BOOTSTRAP_KEYRING '"
         exit 1
       fi
-      timeout 10 ceph ${CLI_OPTS} --name client.bootstrap-osd --keyring $OSD_BOOTSTRAP_KEYRING health || exit 1
+      ceph_health client.bootstrap-osd $OSD_BOOTSTRAP_KEYRING
+
       # add the osd key
       ceph ${CLI_OPTS} --name client.bootstrap-osd --keyring $OSD_BOOTSTRAP_KEYRING auth add osd.${OSD_ID} -i ${OSD_KEYRING} osd 'allow *' mon 'allow profile osd'  || log $1
       log "done adding key"

--- a/ceph-releases/jewel/ubuntu/14.04/daemon/osd_scenarios/osd_disk_prepare.sh
+++ b/ceph-releases/jewel/ubuntu/14.04/daemon/osd_scenarios/osd_disk_prepare.sh
@@ -16,7 +16,8 @@ function osd_disk_prepare {
     log "ERROR- $OSD_BOOTSTRAP_KEYRING must exist. You can extract it from your current monitor by running 'ceph auth get client.bootstrap-osd -o $OSD_BOOTSTRAP_KEYRING'"
     exit 1
   fi
-  timeout 10 ceph ${CLI_OPTS} --name client.bootstrap-osd --keyring $OSD_BOOTSTRAP_KEYRING health || exit 1
+
+  ceph_health client.bootstrap-osd $OSD_BOOTSTRAP_KEYRING
 
   # check device status first
   if ! parted --script ${OSD_DEVICE} print > /dev/null 2>&1; then

--- a/ceph-releases/jewel/ubuntu/14.04/daemon/start_rgw.sh
+++ b/ceph-releases/jewel/ubuntu/14.04/daemon/start_rgw.sh
@@ -18,7 +18,7 @@ function start_rgw {
       exit 1
     fi
 
-    timeout 10 ceph ${CLI_OPTS} --name client.bootstrap-rgw --keyring $RGW_BOOTSTRAP_KEYRING health || exit 1
+    ceph_health client.bootstrap-rgw $RGW_BOOTSTRAP_KEYRING
 
     # Generate the RGW key
     ceph ${CLI_OPTS} --name client.bootstrap-rgw --keyring $RGW_BOOTSTRAP_KEYRING auth get-or-create client.rgw.${RGW_NAME} osd 'allow rwx' mon 'allow rw' -o $RGW_KEYRING

--- a/ceph-releases/kraken/ubuntu/16.04/daemon/common_functions.sh
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/common_functions.sh
@@ -282,3 +282,15 @@ function apply_ceph_ownership_to_disks {
 function get_part_uuid {
   blkid -o value -s PARTUUID ${1}
 }
+
+function ceph_health {
+  local bootstrap_user=$1
+  local bootstrap_key=$2
+
+  if ! timeout 10 ceph ${CLI_OPTS} --name $bootstrap_user --keyring $bootstrap_key health; then
+    log "Timed out while trying to reach out to the Ceph Monitor(s)."
+    log "Make sure your Ceph monitors are up and running in quorum."
+    log "Also verify the validity of client.bootstrap-osd keyring."
+    exit 1
+  fi
+}

--- a/ceph-releases/kraken/ubuntu/16.04/daemon/osd_scenarios/osd_directory.sh
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/osd_scenarios/osd_directory.sh
@@ -60,7 +60,8 @@ function osd_directory {
         log "ERROR- $OSD_BOOTSTRAP_KEYRING must exist. You can extract it from your current monitor by running 'ceph auth get client.bootstrap-osd -o $OSD_BOOTSTRAP_KEYRING '"
         exit 1
       fi
-      timeout 10 ceph ${CLI_OPTS} --name client.bootstrap-osd --keyring $OSD_BOOTSTRAP_KEYRING health || exit 1
+      ceph_health client.bootstrap-osd $OSD_BOOTSTRAP_KEYRING
+
       # add the osd key
       ceph ${CLI_OPTS} --name client.bootstrap-osd --keyring $OSD_BOOTSTRAP_KEYRING auth add osd.${OSD_ID} -i ${OSD_KEYRING} osd 'allow *' mon 'allow profile osd'  || log $1
       log "done adding key"

--- a/ceph-releases/kraken/ubuntu/16.04/daemon/osd_scenarios/osd_disk_prepare.sh
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/osd_scenarios/osd_disk_prepare.sh
@@ -16,7 +16,8 @@ function osd_disk_prepare {
     log "ERROR- $OSD_BOOTSTRAP_KEYRING must exist. You can extract it from your current monitor by running 'ceph auth get client.bootstrap-osd -o $OSD_BOOTSTRAP_KEYRING'"
     exit 1
   fi
-  timeout 10 ceph ${CLI_OPTS} --name client.bootstrap-osd --keyring $OSD_BOOTSTRAP_KEYRING health || exit 1
+
+  ceph_health client.bootstrap-osd $OSD_BOOTSTRAP_KEYRING
 
   # check device status first
   if ! parted --script ${OSD_DEVICE} print > /dev/null 2>&1; then

--- a/ceph-releases/kraken/ubuntu/16.04/daemon/start_rgw.sh
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/start_rgw.sh
@@ -18,7 +18,7 @@ function start_rgw {
       exit 1
     fi
 
-    timeout 10 ceph ${CLI_OPTS} --name client.bootstrap-rgw --keyring $RGW_BOOTSTRAP_KEYRING health || exit 1
+    ceph_health client.bootstrap-rgw $RGW_BOOTSTRAP_KEYRING
 
     # Generate the RGW key
     ceph ${CLI_OPTS} --name client.bootstrap-rgw --keyring $RGW_BOOTSTRAP_KEYRING auth get-or-create client.rgw.${RGW_NAME} osd 'allow rwx' mon 'allow rw' -o $RGW_KEYRING

--- a/ceph-releases/luminous/ubuntu/16.04/daemon/common_functions.sh
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/common_functions.sh
@@ -282,3 +282,15 @@ function apply_ceph_ownership_to_disks {
 function get_part_uuid {
   blkid -o value -s PARTUUID ${1}
 }
+
+function ceph_health {
+  local bootstrap_user=$1
+  local bootstrap_key=$2
+
+  if ! timeout 10 ceph ${CLI_OPTS} --name $bootstrap_user --keyring $bootstrap_key health; then
+    log "Timed out while trying to reach out to the Ceph Monitor(s)."
+    log "Make sure your Ceph monitors are up and running in quorum."
+    log "Also verify the validity of client.bootstrap-osd keyring."
+    exit 1
+  fi
+}

--- a/ceph-releases/luminous/ubuntu/16.04/daemon/osd_scenarios/osd_directory.sh
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/osd_scenarios/osd_directory.sh
@@ -60,7 +60,8 @@ function osd_directory {
         log "ERROR- $OSD_BOOTSTRAP_KEYRING must exist. You can extract it from your current monitor by running 'ceph auth get client.bootstrap-osd -o $OSD_BOOTSTRAP_KEYRING '"
         exit 1
       fi
-      timeout 10 ceph ${CLI_OPTS} --name client.bootstrap-osd --keyring $OSD_BOOTSTRAP_KEYRING health || exit 1
+      ceph_health client.bootstrap-osd $OSD_BOOTSTRAP_KEYRING
+
       # add the osd key
       ceph ${CLI_OPTS} --name client.bootstrap-osd --keyring $OSD_BOOTSTRAP_KEYRING auth add osd.${OSD_ID} -i ${OSD_KEYRING} osd 'allow *' mon 'allow profile osd'  || log $1
       log "done adding key"

--- a/ceph-releases/luminous/ubuntu/16.04/daemon/osd_scenarios/osd_disk_prepare.sh
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/osd_scenarios/osd_disk_prepare.sh
@@ -16,7 +16,8 @@ function osd_disk_prepare {
     log "ERROR- $OSD_BOOTSTRAP_KEYRING must exist. You can extract it from your current monitor by running 'ceph auth get client.bootstrap-osd -o $OSD_BOOTSTRAP_KEYRING'"
     exit 1
   fi
-  timeout 10 ceph ${CLI_OPTS} --name client.bootstrap-osd --keyring $OSD_BOOTSTRAP_KEYRING health || exit 1
+
+  ceph_health client.bootstrap-osd $OSD_BOOTSTRAP_KEYRING
 
   # check device status first
   if ! parted --script ${OSD_DEVICE} print > /dev/null 2>&1; then

--- a/ceph-releases/luminous/ubuntu/16.04/daemon/start_rgw.sh
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/start_rgw.sh
@@ -18,7 +18,7 @@ function start_rgw {
       exit 1
     fi
 
-    timeout 10 ceph ${CLI_OPTS} --name client.bootstrap-rgw --keyring $RGW_BOOTSTRAP_KEYRING health || exit 1
+    ceph_health client.bootstrap-rgw $RGW_BOOTSTRAP_KEYRING
 
     # Generate the RGW key
     ceph ${CLI_OPTS} --name client.bootstrap-rgw --keyring $RGW_BOOTSTRAP_KEYRING auth get-or-create client.rgw.${RGW_NAME} osd 'allow rwx' mon 'allow rw' -o $RGW_KEYRING


### PR DESCRIPTION
Prior to this change if the command to get the ceph health failed we
didn't have any indication of what went wrong. This is now easier to
debug.

Signed-off-by: Sébastien Han <seb@redhat.com>