### PR TITLE
daemon: fix array

### DIFF
--- a/ceph-releases/jewel/ubuntu/14.04/daemon/config.kv.etcd.sh
+++ b/ceph-releases/jewel/ubuntu/14.04/daemon/config.kv.etcd.sh
@@ -60,7 +60,7 @@ function get_mon_config {
     ceph-authtool "$MON_KEYRING" --create-keyring --gen-key -n mon. --cap mon 'allow *'
 
     for item in ${OSD_BOOTSTRAP_KEYRING}:Osd ${MDS_BOOTSTRAP_KEYRING}:Mds ${RGW_BOOTSTRAP_KEYRING}:Rgw; do
-      local array=($"{item//:/ }")
+      local array=("${item//:/ }")
       local keyring=${array[0]}
       local bootstrap="bootstrap-${array[1]}"
       ceph-authtool "$keyring" --create-keyring --gen-key -n client."$(to_lowercase "$bootstrap")" --cap mon "allow profile $(to_lowercase "$bootstrap")"

--- a/ceph-releases/kraken/ubuntu/16.04/daemon/config.kv.etcd.sh
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/config.kv.etcd.sh
@@ -60,7 +60,7 @@ function get_mon_config {
     ceph-authtool "$MON_KEYRING" --create-keyring --gen-key -n mon. --cap mon 'allow *'
 
     for item in ${OSD_BOOTSTRAP_KEYRING}:Osd ${MDS_BOOTSTRAP_KEYRING}:Mds ${RGW_BOOTSTRAP_KEYRING}:Rgw; do
-      local array=($"{item//:/ }")
+      local array=("${item//:/ }")
       local keyring=${array[0]}
       local bootstrap="bootstrap-${array[1]}"
       ceph-authtool "$keyring" --create-keyring --gen-key -n client."$(to_lowercase "$bootstrap")" --cap mon "allow profile $(to_lowercase "$bootstrap")"

--- a/ceph-releases/luminous/ubuntu/16.04/daemon/config.kv.etcd.sh
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/config.kv.etcd.sh
@@ -60,7 +60,7 @@ function get_mon_config {
     ceph-authtool "$MON_KEYRING" --create-keyring --gen-key -n mon. --cap mon 'allow *'
 
     for item in ${OSD_BOOTSTRAP_KEYRING}:Osd ${MDS_BOOTSTRAP_KEYRING}:Mds ${RGW_BOOTSTRAP_KEYRING}:Rgw; do
-      local array=($"{item//:/ }")
+      local array=("${item//:/ }")
       local keyring=${array[0]}
       local bootstrap="bootstrap-${array[1]}"
       ceph-authtool "$keyring" --create-keyring --gen-key -n client."$(to_lowercase "$bootstrap")" --cap mon "allow profile $(to_lowercase "$bootstrap")"


### PR DESCRIPTION
The double brackets are non-needed on an array and even if I wanted to
use them they were mispositionned.

```
creating /etc/ceph/ceph.client.admin.keyring
creating /etc/ceph/ceph.mon.keyring
creating {item//:/ }
bufferlist::write_file({item//:/ }): failed to open file: (2) No such
file or directory
could not write {item//:/ }
```

Signed-off-by: Sébastien Han <seb@redhat.com>