### PR TITLE
daemon: fix array

### DIFF
--- a/ceph-releases/jewel/ubuntu/14.04/daemon/config.kv.etcd.sh
+++ b/ceph-releases/jewel/ubuntu/14.04/daemon/config.kv.etcd.sh
@@ -60,7 +60,8 @@ function get_mon_config {
     ceph-authtool "$MON_KEYRING" --create-keyring --gen-key -n mon. --cap mon 'allow *'
 
     for item in ${OSD_BOOTSTRAP_KEYRING}:Osd ${MDS_BOOTSTRAP_KEYRING}:Mds ${RGW_BOOTSTRAP_KEYRING}:Rgw; do
-      local array=("${item//:/ }")
+      local array
+      IFS=" " read -r -a array <<< "${item//:/ }"
       local keyring=${array[0]}
       local bootstrap="bootstrap-${array[1]}"
       ceph-authtool "$keyring" --create-keyring --gen-key -n client."$(to_lowercase "$bootstrap")" --cap mon "allow profile $(to_lowercase "$bootstrap")"
@@ -90,7 +91,7 @@ function get_mon_config {
 function import_bootstrap_keyrings {
   for item in ${OSD_BOOTSTRAP_KEYRING}:Osd ${MDS_BOOTSTRAP_KEYRING}:Mds ${RGW_BOOTSTRAP_KEYRING}:Rgw; do
     local array
-    array=("${item//:/ }")
+    IFS=" " read -r -a array <<< "${item//:/ }"
     local keyring
     keyring=${array[0]}
     local bootstrap_keyring

--- a/ceph-releases/kraken/ubuntu/16.04/daemon/config.kv.etcd.sh
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/config.kv.etcd.sh
@@ -60,7 +60,8 @@ function get_mon_config {
     ceph-authtool "$MON_KEYRING" --create-keyring --gen-key -n mon. --cap mon 'allow *'
 
     for item in ${OSD_BOOTSTRAP_KEYRING}:Osd ${MDS_BOOTSTRAP_KEYRING}:Mds ${RGW_BOOTSTRAP_KEYRING}:Rgw; do
-      local array=("${item//:/ }")
+      local array
+      IFS=" " read -r -a array <<< "${item//:/ }"
       local keyring=${array[0]}
       local bootstrap="bootstrap-${array[1]}"
       ceph-authtool "$keyring" --create-keyring --gen-key -n client."$(to_lowercase "$bootstrap")" --cap mon "allow profile $(to_lowercase "$bootstrap")"
@@ -90,7 +91,7 @@ function get_mon_config {
 function import_bootstrap_keyrings {
   for item in ${OSD_BOOTSTRAP_KEYRING}:Osd ${MDS_BOOTSTRAP_KEYRING}:Mds ${RGW_BOOTSTRAP_KEYRING}:Rgw; do
     local array
-    array=("${item//:/ }")
+    IFS=" " read -r -a array <<< "${item//:/ }"
     local keyring
     keyring=${array[0]}
     local bootstrap_keyring

--- a/ceph-releases/luminous/ubuntu/16.04/daemon/config.kv.etcd.sh
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/config.kv.etcd.sh
@@ -60,7 +60,8 @@ function get_mon_config {
     ceph-authtool "$MON_KEYRING" --create-keyring --gen-key -n mon. --cap mon 'allow *'
 
     for item in ${OSD_BOOTSTRAP_KEYRING}:Osd ${MDS_BOOTSTRAP_KEYRING}:Mds ${RGW_BOOTSTRAP_KEYRING}:Rgw; do
-      local array=("${item//:/ }")
+      local array
+      IFS=" " read -r -a array <<< "${item//:/ }"
       local keyring=${array[0]}
       local bootstrap="bootstrap-${array[1]}"
       ceph-authtool "$keyring" --create-keyring --gen-key -n client."$(to_lowercase "$bootstrap")" --cap mon "allow profile $(to_lowercase "$bootstrap")"
@@ -90,7 +91,7 @@ function get_mon_config {
 function import_bootstrap_keyrings {
   for item in ${OSD_BOOTSTRAP_KEYRING}:Osd ${MDS_BOOTSTRAP_KEYRING}:Mds ${RGW_BOOTSTRAP_KEYRING}:Rgw; do
     local array
-    array=("${item//:/ }")
+    IFS=" " read -r -a array <<< "${item//:/ }"
     local keyring
     keyring=${array[0]}
     local bootstrap_keyring


### PR DESCRIPTION
Problem: array=("${item//:/ }")

Quoting an array that contains multiple words (processed by bash)
doesn't treat the array with multiple fields, in the current case [0] is
'ceph.keyring Rgw' where it should only be 'ceph.keyring'.

Using a new IFS and read like suggested in
https://github.com/koalaman/shellcheck/wiki/SC2206 helps us.

That was though... One again thanks koalaman.

Signed-off-by: Sébastien Han <seb@redhat.com>