### PR TITLE
dockerfile: chmod +x is not needed

### DIFF
--- a/ceph-releases/jewel/centos/7/daemon/Dockerfile
+++ b/ceph-releases/jewel/centos/7/daemon/Dockerfile
@@ -11,8 +11,7 @@ MAINTAINER Sébastien Han "seb@redhat.com"
 ADD *.sh ceph.defaults check_zombie_mons.py ./osd_scenarios/* entrypoint.sh.in disabled_scenario /
 
 # Modify the entrypoint
-RUN chmod +x /generate_entrypoint.sh && \
-  bash -c "/generate_entrypoint.sh" && \
+RUN bash "/generate_entrypoint.sh" && \
   rm -f /generate_entrypoint.sh && \
   bash -n /*.sh
 

--- a/ceph-releases/jewel/fedora/24/daemon/Dockerfile
+++ b/ceph-releases/jewel/fedora/24/daemon/Dockerfile
@@ -11,8 +11,7 @@ MAINTAINER Sébastien Han "seb@redhat.com"
 ADD *.sh ceph.defaults check_zombie_mons.py ./osd_scenarios/* entrypoint.sh.in disabled_scenario /
 
 # Modify the entrypoint
-RUN chmod +x /generate_entrypoint.sh && \
-  bash -c "/generate_entrypoint.sh" && \
+RUN bash "/generate_entrypoint.sh" && \
   rm -f /generate_entrypoint.sh && \
   bash -n /*.sh
 

--- a/ceph-releases/jewel/opensuse/Leap_42.2/daemon/Dockerfile
+++ b/ceph-releases/jewel/opensuse/Leap_42.2/daemon/Dockerfile
@@ -12,8 +12,7 @@ ADD ./confd/conf.d/* /etc/confd/conf.d/
 ADD *.sh ceph.defaults check_zombie_mons.py ./osd_scenarios/* entrypoint.sh.in disabled_scenario /
 
 # Modify the entrypoint
-RUN chmod +x /generate_entrypoint.sh && \
-  bash -c "/generate_entrypoint.sh" && \
+RUN bash "/generate_entrypoint.sh" && \
   rm -f /generate_entrypoint.sh && \
   bash -n /*.sh
 

--- a/ceph-releases/jewel/rhel/7.3/daemon/Dockerfile
+++ b/ceph-releases/jewel/rhel/7.3/daemon/Dockerfile
@@ -24,8 +24,7 @@ VOLUME ["/etc/ceph","/var/lib/ceph","/etc/ganesha"]
 ADD *.sh ceph.defaults check_zombie_mons.py ./osd_scenarios/* entrypoint.sh.in disabled_scenario /
 
 # Modify the entrypoint
-RUN chmod +x /generate_entrypoint.sh && \
-  bash -c "/generate_entrypoint.sh" && \
+RUN bash "/generate_entrypoint.sh" && \
   rm -f /generate_entrypoint.sh && \
   bash -n /*.sh
 

--- a/ceph-releases/jewel/ubuntu/14.04/daemon/Dockerfile
+++ b/ceph-releases/jewel/ubuntu/14.04/daemon/Dockerfile
@@ -12,8 +12,7 @@ ADD *.sh ceph.defaults check_zombie_mons.py ./osd_scenarios/* entrypoint.sh.in /
 ADD *.sh ceph.defaults check_zombie_mons.py ./osd_scenarios/* entrypoint.sh.in disabled_scenario /
 
 # Modify the entrypoint
-RUN chmod +x /generate_entrypoint.sh && \
-  bash -c "/generate_entrypoint.sh" && \
+RUN bash "/generate_entrypoint.sh" && \
   rm -f /generate_entrypoint.sh && \
   bash -n /*.sh
 

--- a/ceph-releases/jewel/ubuntu/16.04/daemon/Dockerfile
+++ b/ceph-releases/jewel/ubuntu/16.04/daemon/Dockerfile
@@ -14,8 +14,7 @@ ADD *.sh ceph.defaults check_zombie_mons.py ./osd_scenarios/* entrypoint.sh.in /
 ADD *.sh ceph.defaults check_zombie_mons.py ./osd_scenarios/* entrypoint.sh.in disabled_scenario /
 
 # Modify the entrypoint
-RUN chmod +x /generate_entrypoint.sh && \
-  bash -c "/generate_entrypoint.sh" && \
+RUN bash "/generate_entrypoint.sh" && \
   rm -f /generate_entrypoint.sh && \
   bash -n /*.sh
 

--- a/ceph-releases/kraken/centos/7/daemon/Dockerfile
+++ b/ceph-releases/kraken/centos/7/daemon/Dockerfile
@@ -27,8 +27,7 @@ RUN cd /usr/local/bin && tar xfz /forego.tgz && chmod +x /usr/local/bin/forego &
 ADD *.sh ceph.defaults check_zombie_mons.py ./osd_scenarios/* entrypoint.sh.in disabled_scenario /
 
 # Modify the entrypoint
-RUN chmod +x /generate_entrypoint.sh && \
-  bash -c "/generate_entrypoint.sh" && \
+RUN bash "/generate_entrypoint.sh" && \
   rm -f /generate_entrypoint.sh && \
   bash -n /*.sh
 

--- a/ceph-releases/kraken/ubuntu/16.04/daemon/Dockerfile
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/Dockerfile
@@ -42,8 +42,7 @@ RUN chmod +x /usr/local/bin/kubectl
 ADD *.sh ceph.defaults check_zombie_mons.py ./osd_scenarios/* entrypoint.sh.in disabled_scenario /
 
 # Modify the entrypoint
-RUN chmod +x /generate_entrypoint.sh && \
-  bash -c "/generate_entrypoint.sh" && \
+RUN bash "/generate_entrypoint.sh" && \
   rm -f /generate_entrypoint.sh && \
   bash -n /*.sh
 

--- a/ceph-releases/luminous/centos/7/daemon/Dockerfile
+++ b/ceph-releases/luminous/centos/7/daemon/Dockerfile
@@ -30,8 +30,7 @@ ADD s3cfg /root/.s3cfg
 ADD *.sh ceph.defaults check_zombie_mons.py ./osd_scenarios/* entrypoint.sh.in disabled_scenario /
 
 # Modify the entrypoint
-RUN chmod +x /generate_entrypoint.sh && \
-  bash -c "/generate_entrypoint.sh" && \
+RUN bash "/generate_entrypoint.sh" && \
   rm -f /generate_entrypoint.sh && \
   bash -n /*.sh
 

--- a/ceph-releases/luminous/rhel/7.3/daemon/Dockerfile
+++ b/ceph-releases/luminous/rhel/7.3/daemon/Dockerfile
@@ -24,8 +24,7 @@ VOLUME ["/etc/ceph","/var/lib/ceph","/etc/ganesha"]
 ADD *.sh ceph.defaults check_zombie_mons.py ./osd_scenarios/* entrypoint.sh.in disabled_scenario /
 
 # Modify the entrypoint
-RUN chmod +x /generate_entrypoint.sh && \
-  bash -c "/generate_entrypoint.sh" && \
+RUN bash "/generate_entrypoint.sh" && \
   rm -f /generate_entrypoint.sh && \
   bash -n /*.sh
 

--- a/ceph-releases/luminous/ubuntu/16.04/daemon/Dockerfile
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/Dockerfile
@@ -45,8 +45,7 @@ ADD s3cfg /root/.s3cfg
 ADD *.sh ceph.defaults check_zombie_mons.py ./osd_scenarios/* entrypoint.sh.in disabled_scenario /
 
 # Modify the entrypoint
-RUN chmod +x /generate_entrypoint.sh && \
-  bash -c "/generate_entrypoint.sh" && \
+RUN bash "/generate_entrypoint.sh" && \
   rm -f /generate_entrypoint.sh && \
   bash -n /*.sh
 


### PR DESCRIPTION
Since we directly call the bash command, using chmod +x to make the file
executable is not needed. Moreover since we don't pass any argument to
the script generate_entrypoint.sh there is no need for '-c' option.

Somehow this resolves the issue during our build:

```
Step 16 : RUN chmod +x /generate_entrypoint.sh &&   bash -c
"/generate_entrypoint.sh" &&   rm -f /generate_entrypoint.sh &&   bash
-n /*.sh
 ---> Running in 6fa5c8d5735e
 bash: /generate_entrypoint.sh: /bin/bash: bad interpreter: Text file
 busy
```

Signed-off-by: Sébastien Han <seb@redhat.com>