### PR TITLE
daemon: fix array for creating monmap in k8s

### DIFF
--- a/ceph-releases/jewel/ubuntu/14.04/daemon/config.k8s.sh
+++ b/ceph-releases/jewel/ubuntu/14.04/daemon/config.k8s.sh
@@ -27,6 +27,7 @@ function get_mon_config {
   IFS=" " read -r -a monmap_add_array <<< "${monmap_add}"
 
   if [[ -z "${monmap_add// }" ]]; then
+    log "No Ceph Monitor pods discovered. Abort mission!"
     exit 1
   fi
 

--- a/ceph-releases/jewel/ubuntu/14.04/daemon/config.k8s.sh
+++ b/ceph-releases/jewel/ubuntu/14.04/daemon/config.k8s.sh
@@ -24,7 +24,7 @@ function get_mon_config {
     (( timeout-- ))
     sleep 1
   done
-  monmap_add_array=("${monmap_add}")
+  IFS=" " read -r -a monmap_add_array <<< "${monmap_add}"
 
   if [[ -z "${monmap_add// }" ]]; then
     exit 1

--- a/ceph-releases/kraken/ubuntu/16.04/daemon/config.k8s.sh
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/config.k8s.sh
@@ -27,6 +27,7 @@ function get_mon_config {
   IFS=" " read -r -a monmap_add_array <<< "${monmap_add}"
 
   if [[ -z "${monmap_add// }" ]]; then
+    log "No Ceph Monitor pods discovered. Abort mission!"
     exit 1
   fi
 

--- a/ceph-releases/kraken/ubuntu/16.04/daemon/config.k8s.sh
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/config.k8s.sh
@@ -24,7 +24,7 @@ function get_mon_config {
     (( timeout-- ))
     sleep 1
   done
-  monmap_add_array=("${monmap_add}")
+  IFS=" " read -r -a monmap_add_array <<< "${monmap_add}"
 
   if [[ -z "${monmap_add// }" ]]; then
     exit 1

--- a/ceph-releases/luminous/ubuntu/16.04/daemon/config.k8s.sh
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/config.k8s.sh
@@ -27,6 +27,7 @@ function get_mon_config {
   IFS=" " read -r -a monmap_add_array <<< "${monmap_add}"
 
   if [[ -z "${monmap_add// }" ]]; then
+    log "No Ceph Monitor pods discovered. Abort mission!"
     exit 1
   fi
 

--- a/ceph-releases/luminous/ubuntu/16.04/daemon/config.k8s.sh
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/config.k8s.sh
@@ -24,7 +24,7 @@ function get_mon_config {
     (( timeout-- ))
     sleep 1
   done
-  monmap_add_array=("${monmap_add}")
+  IFS=" " read -r -a monmap_add_array <<< "${monmap_add}"
 
   if [[ -z "${monmap_add// }" ]]; then
     exit 1


### PR DESCRIPTION
Quoting an array that contains multiple words (processed by bash)
doesn't treat the array with multiple fields.

Using a new IFS and read like suggested in
https://github.com/koalaman/shellcheck/wiki/SC2206 helps us.

Fixes: https://github.com/ceph/ceph-docker/issues/681
Signed-off-by: Sébastien Han <seb@redhat.com>