### PR TITLE
daemon: use a null operator to declare a variable

### DIFF
--- a/ceph-releases/jewel/ubuntu/14.04/daemon/common_functions.sh
+++ b/ceph-releases/jewel/ubuntu/14.04/daemon/common_functions.sh
@@ -122,7 +122,7 @@ function dev_part {
 }
 
 function osd_trying_to_determine_scenario {
-  ${OSD_DEVICE:-none}
+  : "${OSD_DEVICE:-none}"
   if [[ ${OSD_DEVICE} == "none" ]]; then
     log "Bootstrapped OSD(s) found; using OSD directory"
     source osd_directory.sh

--- a/ceph-releases/kraken/ubuntu/16.04/daemon/common_functions.sh
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/common_functions.sh
@@ -129,7 +129,7 @@ function dev_part {
 }
 
 function osd_trying_to_determine_scenario {
-  ${OSD_DEVICE:-none}
+  : "${OSD_DEVICE:-none}"
   if [[ ${OSD_DEVICE} == "none" ]]; then
     log "Bootstrapped OSD(s) found; using OSD directory"
     source osd_directory.sh

--- a/ceph-releases/luminous/ubuntu/16.04/daemon/common_functions.sh
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/common_functions.sh
@@ -129,7 +129,7 @@ function dev_part {
 }
 
 function osd_trying_to_determine_scenario {
-  ${OSD_DEVICE:-none}
+  : "${OSD_DEVICE:-none}"
   if [[ ${OSD_DEVICE} == "none" ]]; then
     log "Bootstrapped OSD(s) found; using OSD directory"
     source osd_directory.sh


### PR DESCRIPTION
Simply using ${OSD_DEVICE:-none} will let the shell execute its content.
To avoid this we use the no-op :, which evaluates its
argument and then throws it away, rather than executing it.

Signed-off-by: Sébastien Han <seb@redhat.com>