### PR TITLE
Workaround for ceph-disk not unlocking block device for bluestore

### DIFF
--- a/ceph-releases/luminous/ubuntu/16.04/daemon/osd_scenarios/parse_osd_dmcrypt_key.py
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/osd_scenarios/parse_osd_dmcrypt_key.py
@@ -1,0 +1,5 @@
+import base64
+import sys
+
+for line in sys.stdin:
+	sys.stdout.write(base64.b64decode(line.decode("utf-8")))


### PR DESCRIPTION
This is a temporary workaround until this is implemented upstream.

ceph-disk does not unlock the blockdevice for bluestore when using --dmcrypt with activate.

It can be instructed to unlock the blockdevice with ceph-disk activate-block --dmcrypt however I'm not sure thats a good idea.