### PR TITLE
Fix for mgr not starting because of missing cluster name. 

### DIFF
--- a/ceph-releases/luminous/ubuntu/16.04/daemon/start_mgr.sh
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/start_mgr.sh
@@ -11,7 +11,7 @@ function start_mgr {
     check_admin_key
 
     # Create ceph-mgr key
-    ceph "${CLI_OPTS}" auth get-or-create mgr."$MGR_NAME" mon 'allow profile mgr' osd 'allow *' mds 'allow *' -o "$MGR_KEYRING"
+    ceph "${CLI_OPTS[@]}" auth get-or-create mgr."$MGR_NAME" mon 'allow profile mgr' osd 'allow *' mds 'allow *' -o "$MGR_KEYRING"
     chown --verbose ceph. "$MGR_KEYRING"
     chmod 600 "$MGR_KEYRING"
 


### PR DESCRIPTION
Array expansion was missing. Hence only --cluster was added there. It then tried to open /etc/ceph/auth.conf which didn't exist and even if it did would have done the wrong thing.

Hence starting managers does not work in docker containers right now. They are needed for luminous however.

We could think about always starting managers with monitors as that is a recommended suggestion anyway. Would however reduce user control.