### PR TITLE
Update Docker to CMD

### DIFF
--- a/ceph-releases/hammer/ubuntu/14.04/demo/Dockerfile
+++ b/ceph-releases/hammer/ubuntu/14.04/demo/Dockerfile
@@ -17,4 +17,4 @@ VOLUME ["/etc/ceph","/var/lib/ceph"]
 EXPOSE 6789 6800 6801 6802 6803 6804 6805 80 5000
 
 # Execute the entrypoint
-ENTRYPOINT ["/entrypoint.sh"]
+CMD ["/entrypoint.sh"]


### PR DESCRIPTION
using calico networking, on stage entrypoint, cannot get ip. on stage cmd healthy, 
it looks like we have not been able to discover the network settings