### PR TITLE
Mon: Allow to deploy with custom admin secret

### DIFF
--- a/ceph-releases/jewel/ubuntu/14.04/daemon/config.kv.etcd.sh
+++ b/ceph-releases/jewel/ubuntu/14.04/daemon/config.kv.etcd.sh
@@ -56,7 +56,14 @@ function get_mon_config {
     done
 
     log "Creating Keyrings."
-    ceph-authtool "$ADMIN_KEYRING" --create-keyring --gen-key -n client.admin --set-uid=0 --cap mon 'allow *' --cap osd 'allow *' --cap mds 'allow'
+    if [ -z "$ADMIN_SECRET" ]; then
+      # Automatically generate administrator key
+      CLI+=(--gen-key)
+    else
+      # Generate custom provided administrator key
+      CLI+=("--add-key=$ADMIN_SECRET")
+    fi
+    ceph-authtool "$ADMIN_KEYRING" --create-keyring "${CLI[@]}" -n client.admin --set-uid=0 --cap mon 'allow *' --cap osd 'allow *' --cap mds 'allow'
     ceph-authtool "$MON_KEYRING" --create-keyring --gen-key -n mon. --cap mon 'allow *'
 
     for item in ${OSD_BOOTSTRAP_KEYRING}:Osd ${MDS_BOOTSTRAP_KEYRING}:Mds ${RGW_BOOTSTRAP_KEYRING}:Rgw; do

--- a/ceph-releases/jewel/ubuntu/14.04/daemon/config.static.sh
+++ b/ceph-releases/jewel/ubuntu/14.04/daemon/config.static.sh
@@ -38,8 +38,14 @@ ENDHERE
   fi
 
   if [ ! -e "$ADMIN_KEYRING" ]; then
-    # Generate administrator key
-    ceph-authtool "$ADMIN_KEYRING" --create-keyring --gen-key -n client.admin --set-uid=0 --cap mon 'allow *' --cap osd 'allow *' --cap mds 'allow'
+    if [ -z "$ADMIN_SECRET" ]; then
+      # Automatically generate administrator key
+      CLI+=(--gen-key)
+    else
+      # Generate custom provided administrator key
+      CLI+=("--add-key=$ADMIN_SECRET")
+    fi
+    ceph-authtool "$ADMIN_KEYRING" --create-keyring "${CLI[@]}" -n client.admin --set-uid=0 --cap mon 'allow *' --cap osd 'allow *' --cap mds 'allow'
   fi
 
   if [ ! -e "$MON_KEYRING" ]; then

--- a/ceph-releases/kraken/ubuntu/16.04/daemon/config.kv.etcd.sh
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/config.kv.etcd.sh
@@ -57,7 +57,14 @@ function get_mon_config {
 
     log "Creating Keyrings."
     ceph-authtool "$ADMIN_KEYRING" --create-keyring --gen-key -n client.admin --set-uid=0 --cap mon 'allow *' --cap osd 'allow *' --cap mds 'allow'
-    ceph-authtool "$MON_KEYRING" --create-keyring --gen-key -n mon. --cap mon 'allow *'
+    if [ -z "$ADMIN_SECRET" ]; then
+      # Automatically generate administrator key
+      CLI+=(--gen-key)
+    else
+      # Generate custom provided administrator key
+      CLI+=("--add-key=$ADMIN_SECRET")
+    fi
+    ceph-authtool "$ADMIN_KEYRING" --create-keyring "${CLI[@]}" -n client.admin --set-uid=0 --cap mon 'allow *' --cap osd 'allow *' --cap mds 'allow'
 
     for item in ${OSD_BOOTSTRAP_KEYRING}:Osd ${MDS_BOOTSTRAP_KEYRING}:Mds ${RGW_BOOTSTRAP_KEYRING}:Rgw; do
       local array

--- a/ceph-releases/kraken/ubuntu/16.04/daemon/config.static.sh
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/config.static.sh
@@ -38,8 +38,14 @@ ENDHERE
   fi
 
   if [ ! -e "$ADMIN_KEYRING" ]; then
-    # Generate administrator key
-    ceph-authtool "$ADMIN_KEYRING" --create-keyring --gen-key -n client.admin --set-uid=0 --cap mon 'allow *' --cap osd 'allow *' --cap mds 'allow'
+    if [ -z "$ADMIN_SECRET" ]; then
+      # Automatically generate administrator key
+      CLI+=(--gen-key)
+    else
+      # Generate custom provided administrator key
+      CLI+=("--add-key=$ADMIN_SECRET")
+    fi
+    ceph-authtool "$ADMIN_KEYRING" --create-keyring "${CLI[@]}" -n client.admin --set-uid=0 --cap mon 'allow *' --cap osd 'allow *' --cap mds 'allow'
   fi
 
   if [ ! -e "$MON_KEYRING" ]; then

--- a/ceph-releases/luminous/ubuntu/16.04/daemon/config.kv.etcd.sh
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/config.kv.etcd.sh
@@ -56,7 +56,12 @@ function get_mon_config {
     done
 
     log "Creating Keyrings."
-    ceph-authtool "$ADMIN_KEYRING" --create-keyring --gen-key -n client.admin --set-uid=0 --cap mon 'allow *' --cap osd 'allow *' --cap mds 'allow'
+    if [ -z "$ADMIN_SECRET" ]; then
+      CLI+=(--gen-key)
+    else
+      CLI+=("--add-key=$ADMIN_SECRET")
+    fi
+    ceph-authtool "$ADMIN_KEYRING" --create-keyring "${CLI[@]}" -n client.admin --set-uid=0 --cap mon 'allow *' --cap osd 'allow *' --cap mds 'allow'
     ceph-authtool "$MON_KEYRING" --create-keyring --gen-key -n mon. --cap mon 'allow *'
 
     for item in ${OSD_BOOTSTRAP_KEYRING}:Osd ${MDS_BOOTSTRAP_KEYRING}:Mds ${RGW_BOOTSTRAP_KEYRING}:Rgw; do

--- a/ceph-releases/luminous/ubuntu/16.04/daemon/config.static.sh
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/config.static.sh
@@ -66,8 +66,14 @@ ENDHERE
   fi
 
   if [ ! -e "$ADMIN_KEYRING" ]; then
-    # Generate administrator key
-    ceph-authtool "$ADMIN_KEYRING" --create-keyring --gen-key -n client.admin --set-uid=0 --cap mon 'allow *' --cap osd 'allow *' --cap mds 'allow'
+    if [ -z "$ADMIN_SECRET" ]; then
+      # Automatically generate administrator key
+      CLI+=(--gen-key)
+    else
+      # Generate custom provided administrator key
+      CLI+=("--add-key=$ADMIN_SECRET")
+    fi
+    ceph-authtool "$ADMIN_KEYRING" --create-keyring -n client.admin "${CLI[@]}" --set-uid=0 --cap mon 'allow *' --cap osd 'allow *' --cap mds 'allow'
   fi
 
   if [ ! -e "$MON_KEYRING" ]; then


### PR DESCRIPTION
Add a new parameter `ADMIN_SECRET` that allow to deploy a ceph cluster
with a custom admin secret.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>