### PR TITLE
Fix forego breaking docker build

### DIFF
--- a/ceph-releases/jewel/centos/7/base/Dockerfile
+++ b/ceph-releases/jewel/centos/7/base/Dockerfile
@@ -12,7 +12,7 @@ ENV CONFD_VERSION 0.10.0
 RUN rpm --import 'https://download.ceph.com/keys/release.asc'
 RUN rpm -Uvh http://download.ceph.com/rpm-${CEPH_VERSION}/el7/noarch/ceph-release-1-1.el7.noarch.rpm
 RUN yum install -y epel-release && yum clean all
-ARG PACKAGES="unzip ceph-mon ceph-osd ceph-mds ceph-base ceph-common ceph-radosgw rbd-mirror device-mapper sharutils etcd kubernetes-client e2fsprogs"
+ARG PACKAGES="unzip ceph-mon ceph-osd ceph-mds ceph-base ceph-common ceph-radosgw rbd-mirror device-mapper sharutils etcd kubernetes-client e2fsprogs wget"
 RUN yum install -y $PACKAGES && rpm -q $PACKAGES && yum clean all
 
 # Install confd
@@ -20,8 +20,8 @@ ADD https://github.com/kelseyhightower/confd/releases/download/v${CONFD_VERSION}
 RUN chmod +x /usr/local/bin/confd && mkdir -p /etc/confd/conf.d && mkdir -p /etc/confd/templates
 
 # Download forego
-ADD https://bin.equinox.io/c/ekMN3bCZFUn/forego-stable-linux-amd64.tgz /forego.tgz
-RUN cd /usr/local/bin && tar xfz /forego.tgz && chmod +x /usr/local/bin/forego && rm /forego.tgz
+RUN wget -O /forego.tgz 'https://bin.equinox.io/c/ekMN3bCZFUn/forego-stable-linux-amd64.tgz' && \
+  cd /usr/local/bin && tar xfz /forego.tgz && chmod +x /usr/local/bin/forego && rm /forego.tgz
 
 ADD entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/ceph-releases/jewel/fedora/24/base/Dockerfile
+++ b/ceph-releases/jewel/fedora/24/base/Dockerfile
@@ -10,9 +10,6 @@ ENV CONFD_VERSION 0.10.0
 # Download confd
 ADD https://github.com/kelseyhightower/confd/releases/download/v${CONFD_VERSION}/confd-${CONFD_VERSION}-linux-amd64 /usr/local/bin/confd
 
-# Download forego
-ADD https://bin.equinox.io/c/ekMN3bCZFUn/forego-stable-linux-amd64.tgz /forego.tgz
-
 ARG PACKAGES="unzip ceph-mon ceph-osd ceph-mds ceph-base ceph-common ceph-radosgw rbd-mirror device-mapper sharutils etcd kubernetes-client nfs-ganesha-vfs wget systemd-udev nfs-ganesha-ceph"
 
 # install prerequisites
@@ -23,6 +20,7 @@ RUN dnf install -y $PACKAGES && \
     chmod +x /usr/local/bin/confd && mkdir -p /etc/confd/conf.d && mkdir -p /etc/confd/templates && \
 \
 # Install forego
+    wget -O /forego.tgz 'https://bin.equinox.io/c/ekMN3bCZFUn/forego-stable-linux-amd64.tgz' && \
     cd /usr/local/bin && tar xfz /forego.tgz && chmod +x /usr/local/bin/forego && rm /forego.tgz
 
 ADD entrypoint.sh /entrypoint.sh

--- a/ceph-releases/jewel/ubuntu/14.04/base/Dockerfile
+++ b/ceph-releases/jewel/ubuntu/14.04/base/Dockerfile
@@ -14,9 +14,6 @@ ENV KUBECTL_VERSION v1.6.0
 # Download confd
 ADD https://github.com/kelseyhightower/confd/releases/download/v${CONFD_VERSION}/confd-${CONFD_VERSION}-linux-amd64 /usr/local/bin/confd
 
-# Download forego
-ADD https://bin.equinox.io/c/ekMN3bCZFUn/forego-stable-linux-amd64.tgz /forego.tgz
-
 # Packages list
 ARG PACKAGES="ceph radosgw rbd-mirror"
 
@@ -38,6 +35,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update &&  apt-get install -y wget un
     chmod +x /usr/local/bin/confd && mkdir -p /etc/confd/conf.d && mkdir -p /etc/confd/templates && \
 \
 # Install forego
+    wget -O /forego.tgz 'https://bin.equinox.io/c/ekMN3bCZFUn/forego-stable-linux-amd64.tgz' && \
     cd /usr/local/bin && tar xfz /forego.tgz && chmod +x /usr/local/bin/forego && rm /forego.tgz
 
 # Install kubectl

--- a/ceph-releases/jewel/ubuntu/16.04/base/Dockerfile
+++ b/ceph-releases/jewel/ubuntu/16.04/base/Dockerfile
@@ -12,9 +12,6 @@ ENV KUBECTL_VERSION v1.6.0
 # Download confd
 ADD https://github.com/kelseyhightower/confd/releases/download/v${CONFD_VERSION}/confd-${CONFD_VERSION}-linux-amd64 /usr/local/bin/confd
 
-# Download forego
-ADD https://bin.equinox.io/c/ekMN3bCZFUn/forego-stable-linux-amd64.tgz /forego.tgz
-
 # Packages list
 ARG PACKAGES="ceph radosgw rbd-mirror sharutils etcd"
 
@@ -31,6 +28,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y wget unz
     chmod +x /usr/local/bin/confd && mkdir -p /etc/confd/conf.d && mkdir -p /etc/confd/templates && \
 \
 # Install forego
+    wget -O /forego.tgz 'https://bin.equinox.io/c/ekMN3bCZFUn/forego-stable-linux-amd64.tgz' && \
     cd /usr/local/bin && tar xfz /forego.tgz && chmod +x /usr/local/bin/forego && rm /forego.tgz
 
 # Install kubectl

--- a/ceph-releases/kraken/centos/7/daemon/Dockerfile
+++ b/ceph-releases/kraken/centos/7/daemon/Dockerfile
@@ -12,7 +12,7 @@ ENV CONFD_VERSION 0.10.0
 RUN rpm --import 'https://download.ceph.com/keys/release.asc'
 RUN rpm -Uvh http://download.ceph.com/rpm-${CEPH_VERSION}/el7/noarch/ceph-release-1-1.el7.noarch.rpm
 RUN yum install -y epel-release && yum clean all
-ARG PACKAGES="unzip ceph-mon ceph-osd ceph-mds ceph-mgr ceph-base ceph-common ceph-radosgw rbd-mirror device-mapper sharutils etcd kubernetes-client e2fsprogs"
+ARG PACKAGES="unzip ceph-mon ceph-osd ceph-mds ceph-mgr ceph-base ceph-common ceph-radosgw rbd-mirror device-mapper sharutils etcd kubernetes-client e2fsprogs wget"
 RUN yum install -y $PACKAGES && rpm -q $PACKAGES && yum clean all
 
 # Install confd
@@ -20,8 +20,8 @@ ADD https://github.com/kelseyhightower/confd/releases/download/v${CONFD_VERSION}
 RUN chmod +x /usr/local/bin/confd && mkdir -p /etc/confd/conf.d && mkdir -p /etc/confd/templates
 
 # Download forego
-ADD https://bin.equinox.io/c/ekMN3bCZFUn/forego-stable-linux-amd64.tgz /forego.tgz
-RUN cd /usr/local/bin && tar xfz /forego.tgz && chmod +x /usr/local/bin/forego && rm /forego.tgz
+RUN wget -O /forego.tgz 'https://bin.equinox.io/c/ekMN3bCZFUn/forego-stable-linux-amd64.tgz' && \
+  cd /usr/local/bin && tar xfz /forego.tgz && chmod +x /usr/local/bin/forego && rm /forego.tgz
 
 # Add bootstrap script, ceph defaults key/values for KV store
 ADD *.sh ceph.defaults check_zombie_mons.py ./osd_scenarios/* entrypoint.sh.in disabled_scenario /

--- a/ceph-releases/kraken/ubuntu/16.04/daemon/Dockerfile
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/Dockerfile
@@ -12,9 +12,6 @@ ENV KUBECTL_VERSION v1.6.0
 # Download confd
 ADD https://github.com/kelseyhightower/confd/releases/download/v${CONFD_VERSION}/confd-${CONFD_VERSION}-linux-amd64 /usr/local/bin/confd
 
-# Download forego
-ADD https://bin.equinox.io/c/ekMN3bCZFUn/forego-stable-linux-amd64.tgz /forego.tgz
-
 # Packages list
 ARG PACKAGES="ceph-mon ceph-osd ceph-mds ceph-mgr ceph-base ceph-common radosgw rbd-mirror sharutils etcd"
 
@@ -32,6 +29,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y wget unz
     chmod +x /usr/local/bin/confd && mkdir -p /etc/confd/conf.d && mkdir -p /etc/confd/templates && \
 \
 # Install forego
+    wget -O /forego.tgz 'https://bin.equinox.io/c/ekMN3bCZFUn/forego-stable-linux-amd64.tgz' && \
     cd /usr/local/bin && tar xfz /forego.tgz && chmod +x /usr/local/bin/forego && rm /forego.tgz
 
 # Install kubectl

--- a/ceph-releases/luminous/centos/7/daemon/Dockerfile
+++ b/ceph-releases/luminous/centos/7/daemon/Dockerfile
@@ -12,7 +12,7 @@ ENV CONFD_VERSION 0.10.0
 RUN rpm --import 'https://download.ceph.com/keys/release.asc'
 RUN rpm -Uvh http://download.ceph.com/rpm-${CEPH_VERSION}/el7/noarch/ceph-release-1-1.el7.noarch.rpm
 RUN yum install -y epel-release && yum clean all
-ARG PACKAGES="unzip ceph-mon ceph-osd ceph-mds ceph-mgr ceph-base ceph-common ceph-radosgw rbd-mirror device-mapper sharutils etcd kubernetes-client e2fsprogs s3cmd"
+ARG PACKAGES="unzip ceph-mon ceph-osd ceph-mds ceph-mgr ceph-base ceph-common ceph-radosgw rbd-mirror device-mapper sharutils etcd kubernetes-client e2fsprogs s3cmd wget"
 RUN yum install -y $PACKAGES && rpm -q $PACKAGES && yum clean all
 
 # Install confd
@@ -20,8 +20,8 @@ ADD https://github.com/kelseyhightower/confd/releases/download/v${CONFD_VERSION}
 RUN chmod +x /usr/local/bin/confd && mkdir -p /etc/confd/conf.d && mkdir -p /etc/confd/templates
 
 # Download forego
-ADD https://bin.equinox.io/c/ekMN3bCZFUn/forego-stable-linux-amd64.tgz /forego.tgz
-RUN cd /usr/local/bin && tar xfz /forego.tgz && chmod +x /usr/local/bin/forego && rm /forego.tgz
+RUN wget -O /forego.tgz 'https://bin.equinox.io/c/ekMN3bCZFUn/forego-stable-linux-amd64.tgz' && \
+  cd /usr/local/bin && tar xfz /forego.tgz && chmod +x /usr/local/bin/forego && rm /forego.tgz
 
 # Add s3cfg file
 ADD s3cfg /root/.s3cfg

--- a/ceph-releases/luminous/ubuntu/16.04/daemon/Dockerfile
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/Dockerfile
@@ -12,9 +12,6 @@ ENV KUBECTL_VERSION v1.6.0
 # Download confd
 ADD https://github.com/kelseyhightower/confd/releases/download/v${CONFD_VERSION}/confd-${CONFD_VERSION}-linux-amd64 /usr/local/bin/confd
 
-# Download forego
-ADD https://bin.equinox.io/c/ekMN3bCZFUn/forego-stable-linux-amd64.tgz /forego.tgz
-
 # Packages list
 ARG PACKAGES="ceph-mon ceph-osd ceph-mds ceph-mgr ceph-base ceph-common radosgw rbd-mirror sharutils etcd s3cmd"
 
@@ -32,6 +29,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y wget unz
     chmod +x /usr/local/bin/confd && mkdir -p /etc/confd/conf.d && mkdir -p /etc/confd/templates && \
 \
 # Install forego
+    wget -O /forego.tgz 'https://bin.equinox.io/c/ekMN3bCZFUn/forego-stable-linux-amd64.tgz' && \
     cd /usr/local/bin && tar xfz /forego.tgz && chmod +x /usr/local/bin/forego && rm /forego.tgz
 
 # Install kubectl


### PR DESCRIPTION
`ADD` appears to download the file and also automatically untar the archive if it ends in .tgz.

The build started to fail because /forego.tgz is a directory.

I'm not sure how many docker versions the file needs to support, if this breaks things for somebody on older versions I'd recommend to remove `ADD` all together and wget it explicitly. This would also slightly reduce the image size if you get+remove the archive within the same layer.