### PR TITLE
Fix an error when populating KV store.

### DIFF
--- a/ceph-releases/jewel/ubuntu/14.04/daemon/populate_kv.sh
+++ b/ceph-releases/jewel/ubuntu/14.04/daemon/populate_kv.sh
@@ -3,9 +3,9 @@ set -e
 
 function kv {
   # Note the 'cas' command puts a value in the KV store if it is empty
-  local key="$1"
-  shift
-  local value="$*"
+  local key
+  local value
+  read -r key value <<< "$*"
   log "Adding key ${key} with value ${value} to KV store."
   etcdctl "${ETCDCTL_OPTS[@]}" "${KV_TLS[@]}" set "${CLUSTER_PATH}""${key}" "${value}" || log "Value is already set"
 }

--- a/ceph-releases/kraken/ubuntu/16.04/daemon/populate_kv.sh
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/populate_kv.sh
@@ -3,9 +3,9 @@ set -e
 
 function kv {
   # Note the 'cas' command puts a value in the KV store if it is empty
-  local key="$1"
-  shift
-  local value="$*"
+  local key
+  local value
+  read -r key value <<< "$*"
   log "Adding key ${key} with value ${value} to KV store."
   etcdctl "${ETCDCTL_OPTS[@]}" "${KV_TLS[@]}" set "${CLUSTER_PATH}""${key}" "${value}" || log "Value is already set"
 }

--- a/ceph-releases/luminous/ubuntu/16.04/daemon/populate_kv.sh
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/populate_kv.sh
@@ -3,9 +3,9 @@ set -e
 
 function kv {
   # Note the 'cas' command puts a value in the KV store if it is empty
-  local key="$1"
-  shift
-  local value="$*"
+  local key
+  local value
+  read -r key value <<< "$*"
   log "Adding key ${key} with value ${value} to KV store."
   etcdctl "${ETCDCTL_OPTS[@]}" "${KV_TLS[@]}" set "${CLUSTER_PATH}""${key}" "${value}" || log "Value is already set"
 }


### PR DESCRIPTION
I found an error when populating KV store.
If we use the double quote here, the function kv will read all parameter as single variable $1.
And the key name on ETCD would be "max_open_files 131072" instead of "max_open_files".

e.g.
```txt
2017-07-12 02:07:14  bash: Adding key /auth/cephx true with value  to KV store.

2017-07-12 02:07:14  bash: Adding key /global/max_open_files 131072 with value  to KV store.

2017-07-12 02:07:14  bash: Adding key /osd/osd_journal_size 100 with value  to KV store.
```

We should remove the double quote and make it work.
```txt
2017-07-12 02:06:51  bash: Adding key /auth/cephx with value true to KV store.
true
2017-07-12 02:06:51  bash: Adding key /global/max_open_files with value 131072 to KV store.
131072
2017-07-12 02:06:51  bash: Adding key /osd/osd_journal_size with value 100 to KV store.
100
```
My env: 
```txt
etcdserver: 3.0.14
etcdctl version: 2.2.5
luminous 
ubuntu 16.04
```