### PR TITLE
Fix configuration of ceph-mgr in case ceph.conf was created from kvstore

### DIFF
--- a/ceph-releases/luminous/ubuntu/16.04/daemon/start_mgr.sh
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/start_mgr.sh
@@ -14,17 +14,17 @@ function start_mgr {
     ceph "${CLI_OPTS[@]}" auth get-or-create mgr."$MGR_NAME" mon 'allow profile mgr' osd 'allow *' mds 'allow *' -o "$MGR_KEYRING"
     chown --verbose ceph. "$MGR_KEYRING"
     chmod 600 "$MGR_KEYRING"
+  fi
 
-    if [[ "$MGR_DASHBOARD" == 1 ]]; then
-      if ! grep -E "\[mgr\]" /etc/ceph/"${CLUSTER}".conf; then
-        cat <<ENDHERE >>/etc/ceph/"${CLUSTER}".conf
+  if [[ "$MGR_DASHBOARD" == 1 ]]; then
+    if ! grep -E "\[mgr\]" /etc/ceph/"${CLUSTER}".conf; then
+      cat <<ENDHERE >>/etc/ceph/"${CLUSTER}".conf
 
 [mgr]
 mgr_modules = dashboard
 ENDHERE
-      fi
-      ceph "${CLI_OPTS[@]}" config-key put mgr/dashboard/server_addr "$MGR_IP"
     fi
+    ceph "${CLI_OPTS[@]}" config-key put mgr/dashboard/server_addr "$MGR_IP"
   fi
 
   log "SUCCESS"

--- a/ceph-releases/luminous/ubuntu/16.04/daemon/start_mgr.sh
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/start_mgr.sh
@@ -5,11 +5,12 @@ function start_mgr {
   get_config
   check_config
 
+  # ensure we have the admin key
+  get_admin_key
+  check_admin_key
+
   # Check to see if our MGR has been initialized
   if [ ! -e "$MGR_KEYRING" ]; then
-    get_admin_key
-    check_admin_key
-
     # Create ceph-mgr key
     ceph "${CLI_OPTS[@]}" auth get-or-create mgr."$MGR_NAME" mon 'allow profile mgr' osd 'allow *' mds 'allow *' -o "$MGR_KEYRING"
     chown --verbose ceph. "$MGR_KEYRING"


### PR DESCRIPTION
If ceph configuration was created from kvstore the configuration for the
ceph manager daemon must be recreate at each start.