### PR TITLE
Make ceph.conf.jinja template use environ()

### DIFF
--- a/examples/kubernetes/generator/templates/ceph/ceph.conf.jinja
+++ b/examples/kubernetes/generator/templates/ceph/ceph.conf.jinja
@@ -1,71 +1,71 @@
 [global]
 fsid = {{ fsid }}
-cephx = {{ auth_cephx|default("true") }}
-cephx_require_signatures = {{ auth_cephx_require_signatures|default("false") }}
-cephx_cluster_require_signatures = {{ auth_cephx_cluster_require_signatures|default("true") }}
-cephx_service_require_signatures = {{ auth_cephx_service_require_signatures|default("false") }}
+cephx = {{ environ("auth_cephx", "true") }}
+cephx_require_signatures = {{ environ("auth_cephx_require_signatures", "false") }}
+cephx_cluster_require_signatures = {{ environ("auth_cephx_cluster_require_signatures", "true") }}
+cephx_service_require_signatures = {{ environ("auth_cephx_service_require_signatures", "false") }}
 
 # auth
-max_open_files = {{ global_max_open_files|default("131072") }}
-osd_pool_default_pg_num = {{ global_osd_pool_default_pg_num|default("128") }}
-osd_pool_default_pgp_num = {{ global_osd_pool_default_pgp_num|default("128") }}
-osd_pool_default_size = {{ global_osd_pool_default_size|default("3") }}
-osd_pool_default_min_size = {{ global_osd_pool_default_min_size|default("1") }}
+max_open_files = {{ environ("global_max_open_files", "131072") }}
+osd_pool_default_pg_num = {{ environ("global_osd_pool_default_pg_num", "128") }}
+osd_pool_default_pgp_num = {{ environ("global_osd_pool_default_pgp_num", "128") }}
+osd_pool_default_size = {{ environ("global_osd_pool_default_size", "3") }}
+osd_pool_default_min_size = {{ environ("global_osd_pool_default_min_size", "1") }}
 
-mon_osd_full_ratio = {{ global_mon_osd_full_ratio|default(".95") }}
-mon_osd_nearfull_ratio = {{ global_mon_osd_nearfull_ratio|default(".85") }}
+mon_osd_full_ratio = {{ environ("global_mon_osd_full_ratio", ".95") }}
+mon_osd_nearfull_ratio = {{ environ("global_mon_osd_nearfull_ratio", ".85") }}
 
-mon_host = {{ global_mon_host|default('ceph-mon') }}
+mon_host = {{ environ("global_mon_host", "ceph-mon") }}
 
 [mon]
-mon_osd_down_out_interval = {{ mon_mon_osd_down_out_interval|default("600") }}
-mon_osd_min_down_reporters = {{ mon_mon_osd_min_down_reporters|default("4") }}
-mon_clock_drift_allowed = {{ mon_mon_clock_drift_allowed|default(".15") }}
-mon_clock_drift_warn_backoff = {{ mon_mon_clock_drift_warn_backoff|default("30") }}
-mon_osd_report_timeout = {{ mon_mon_osd_report_timeout|default("300") }}
+mon_osd_down_out_interval = {{ environ("mon_mon_osd_down_out_interval", "600") }}
+mon_osd_min_down_reporters = {{ environ("mon_mon_osd_min_down_reporters", "4") }}
+mon_clock_drift_allowed = {{ environ("mon_mon_clock_drift_allowed", ".15") }}
+mon_clock_drift_warn_backoff = {{ environ("mon_mon_clock_drift_warn_backoff", "30") }}
+mon_osd_report_timeout = {{ environ("mon_mon_osd_report_timeout", "300") }}
 
 
 [osd]
-journal_size = {{ osd_journal_size|default("100") }}
-cluster_network = {{ osd_cluster_network|default('10.244.0.0/16') }}
-public_network = {{ osd_public_network|default('10.244.0.0/16') }}
-osd_mkfs_type = {{ osd_osd_mkfs_type|default("xfs") }}
-osd_mkfs_options_xfs = {{ osd_osd_mkfs_options_xfs|default("-f -i size=2048") }}
-osd_mon_heartbeat_interval = {{ osd_osd_mon_heartbeat_interval|default("30") }}
-osd_max_object_name_len = {{ osd_max_object_name_len|default("256") }}
+journal_size = {{ environ("osd_journal_size", "100") }}
+cluster_network = {{ environ("osd_cluster_network", "10.244.0.0/16") }}
+public_network = {{ environ("osd_public_network", "10.244.0.0/16") }}
+osd_mkfs_type = {{ environ("osd_osd_mkfs_type", "xfs") }}
+osd_mkfs_options_xfs = {{ environ("osd_osd_mkfs_options_xfs", "-f -i size=2048") }}
+osd_mon_heartbeat_interval = {{ environ("osd_osd_mon_heartbeat_interval", "30") }}
+osd_max_object_name_len = {{ environ("osd_max_object_name_len", "256") }}
 
 #crush
-osd_pool_default_crush_rule = {{ osd_pool_default_crush_rule|default("0") }}
-osd_crush_update_on_start = {{ osd_osd_crush_update_on_start|default("true") }}
+osd_pool_default_crush_rule = {{ environ("osd_pool_default_crush_rule", "0") }}
+osd_crush_update_on_start = {{ environ("osd_osd_crush_update_on_start", "true") }}
 
 #backend
-osd_objectstore = {{ osd_osd_objectstore|default("filestore") }}
+osd_objectstore = {{ environ("osd_osd_objectstore", "filestore") }}
 
 #performance tuning
-filestore_merge_threshold = {{ osd_filestore_merge_threshold|default("40") }}
-filestore_split_multiple = {{ osd_filestore_split_multiple|default("8") }}
-osd_op_threads = {{ osd_osd_op_threads|default("8") }}
-filestore_op_threads = {{ osd_filestore_op_threads|default("8") }}
-filestore_max_sync_interval = {{ osd_filestore_max_sync_interval|default("5") }}
-osd_max_scrubs = {{ osd_osd_max_scrubs|default("1") }}
+filestore_merge_threshold = {{ environ("osd_filestore_merge_threshold", "40") }}
+filestore_split_multiple = {{ environ("osd_filestore_split_multiple", "8") }}
+osd_op_threads = {{ environ("osd_osd_op_threads", "8") }}
+filestore_op_threads = {{ environ("osd_filestore_op_threads", "8") }}
+filestore_max_sync_interval = {{ environ("osd_filestore_max_sync_interval", "5") }}
+osd_max_scrubs = {{ environ("osd_osd_max_scrubs", "1") }}
 
 
 #recovery tuning
-osd_recovery_max_active = {{ osd_osd_recovery_max_active|default("5") }}
-osd_max_backfills = {{ osd_osd_max_backfills|default("2") }}
-osd_recovery_op_priority = {{ osd_osd_recovery_op_priority|default("2") }}
-osd_client_op_priority = {{ osd_osd_client_op_priority|default("63") }}
-osd_recovery_max_chunk = {{ osd_osd_recovery_max_chunk|default("1048576") }}
-osd_recovery_threads = {{ osd_osd_recovery_threads|default("1") }}
+osd_recovery_max_active = {{ environ("osd_osd_recovery_max_active", "5") }}
+osd_max_backfills = {{ environ("osd_osd_max_backfills", "2") }}
+osd_recovery_op_priority = {{ environ("osd_osd_recovery_op_priority", "2") }}
+osd_client_op_priority = {{ environ("osd_osd_client_op_priority", "63") }}
+osd_recovery_max_chunk = {{ environ("osd_osd_recovery_max_chunk", "1048576") }}
+osd_recovery_threads = {{ environ("osd_osd_recovery_threads", "1") }}
 
 #ports
-ms_bind_port_min = {{ osd_ms_bind_port_min|default("6800") }}
-ms_bind_port_max = {{ osd_ms_bind_port_max|default("7100") }}
+ms_bind_port_min = {{ environ("osd_ms_bind_port_min", "6800") }}
+ms_bind_port_max = {{ environ("osd_ms_bind_port_max", "7100") }}
 
 [client]
-rbd_cache_enabled = {{ client_rbd_cache_enabled|default("true") }}
-rbd_cache_writethrough_until_flush = {{ client_rbd_cache_writethrough_until_flush|default("true") }}
-rbd_default_features = {{ client_rbd_default_features|default("1") }}
+rbd_cache_enabled = {{ environ("client_rbd_cache_enabled", "true") }}
+rbd_cache_writethrough_until_flush = {{ environ("client_rbd_cache_writethrough_until_flush", "true") }}
+rbd_default_features = {{ environ("client_rbd_default_features", "1") }}
 
 [mds]
-mds_cache_size = {{ mds_mds_cache_size|default("100000") }}
+mds_cache_size = {{ environ("mds_mds_cache_size", "100000") }}


### PR DESCRIPTION
Per this issue [1] with jinja2-cli, the appropriate usage for
capturing environment variables is
`{{ environ('FOO', 'somedefault') }}`. Without the format written as such,
environment variables set via `export FOO=somedefault` will not be
reflected in the rendered template.

[1] https://github.com/mattrobenolt/jinja2-cli/issues/31