### PR TITLE
osd_disk_prepare: Replace `sleep 5` by a `wait_for_file` call

### DIFF
--- a/ceph-releases/jewel/ubuntu/14.04/daemon/common_functions.sh
+++ b/ceph-releases/jewel/ubuntu/14.04/daemon/common_functions.sh
@@ -247,6 +247,7 @@ function apply_ceph_ownership_to_disks {
     wait_for_file "$(dev_part "${OSD_DEVICE}" 2)"
     chown --verbose ceph. "$(dev_part "${OSD_DEVICE}" 2)"
   fi
+  wait_for_file "$(dev_part "${OSD_DEVICE}" 1)"
   chown --verbose ceph. "$(dev_part "${OSD_DEVICE}" 1)"
 }
 

--- a/ceph-releases/jewel/ubuntu/14.04/daemon/osd_scenarios/osd_disk_prepare.sh
+++ b/ceph-releases/jewel/ubuntu/14.04/daemon/osd_scenarios/osd_disk_prepare.sh
@@ -76,7 +76,5 @@ function osd_disk_prepare {
   # watch the udev event queue, and exit if all current events are handled
   udevadm settle --timeout=600
 
-  sleep 5
-
   apply_ceph_ownership_to_disks
 }


### PR DESCRIPTION
this `sleep 5` has been added to fix a `no such file or directory`
error but making a call to `wait_for_file()` in
`apply_ceph_ownership_to_disks()` is a better fix.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>