### PR TITLE
Add missing ceph namespace on RBD provisioner deployment

### DIFF
--- a/examples/kubernetes/README.md
+++ b/examples/kubernetes/README.md
@@ -175,7 +175,7 @@ ceph-osd-j1gyd         1/1       Running   2          2m
 First, create a RBD provisioner pod:
 
 ```
-$ kubectl create -f https://raw.githubusercontent.com/kubernetes-incubator/external-storage/master/ceph/rbd/deployment.yaml
+$ kubectl create -f https://raw.githubusercontent.com/kubernetes-incubator/external-storage/master/ceph/rbd/deployment.yaml --namespace=ceph
 ```
 Then, if there is no Ceph admin secret with type `kubernetes.io/rbd`, create one:
 


### PR DESCRIPTION
As all the other resources are created on the ceph namespace, it makes sense to create the provisioner on the same namespace. 