### PR TITLE
daemon: fix default array for CRUSH_LOCATION

### DIFF
--- a/ceph-releases/jewel/ubuntu/14.04/daemon/osd_scenarios/osd_disk_activate.sh
+++ b/ceph-releases/jewel/ubuntu/14.04/daemon/osd_scenarios/osd_disk_activate.sh
@@ -43,7 +43,7 @@ function osd_activate {
   else
     OSD_WEIGHT=$(df -P -k "$OSD_PATH" | tail -1 | awk '{ d= $2/1073741824 ; r = sprintf("%.2f", d); print r }')
   fi
-  ceph "${CLI_OPTS[@]}" --name=osd."${OSD_ID}" --keyring="$OSD_KEYRING" osd crush create-or-move -- "${OSD_ID}" "${OSD_WEIGHT}" "${CRUSH_LOCATION}"
+  ceph "${CLI_OPTS[@]}" --name=osd."${OSD_ID}" --keyring="$OSD_KEYRING" osd crush create-or-move -- "${OSD_ID}" "${OSD_WEIGHT}" "${CRUSH_LOCATION[@]}"
 
   log "SUCCESS"
   exec /usr/bin/ceph-osd "${CLI_OPTS[@]}" -f -i "${OSD_ID}" --setuser ceph --setgroup disk

--- a/ceph-releases/jewel/ubuntu/14.04/daemon/variables_entrypoint.sh
+++ b/ceph-releases/jewel/ubuntu/14.04/daemon/variables_entrypoint.sh
@@ -61,7 +61,7 @@ ALL_SCENARIOS="populate_kvstore mon osd osd_directory osd_directory_single osd_c
 
 # Create a default array
 CRUSH_LOCATION_DEFAULT=("root=default" "host=${HOSTNAME}")
-CRUSH_LOCATION=("${CRUSH_LOCATION[@]:-${CRUSH_LOCATION_DEFAULT[@]}}")
+[[ -n "$CRUSH_LOCATION" ]] || read -ra CRUSH_LOCATION <<< "${CRUSH_LOCATION_DEFAULT[@]}"
 
 # This is ONLY used for the CLI calls, e.g: ceph $CLI_OPTS health
 CLI_OPTS=(--cluster ${CLUSTER})

--- a/ceph-releases/kraken/ubuntu/16.04/daemon/osd_scenarios/osd_disk_activate.sh
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/osd_scenarios/osd_disk_activate.sh
@@ -45,8 +45,11 @@ function osd_activate {
   if [[ ${OSD_BLUESTORE} -eq 1 ]]; then
     # Get the device used for block db and wal otherwise apply_ceph_ownership_to_disks will fail
     OSD_BLUESTORE_BLOCK_DB_TMP=$(resolve_symlink "${OSD_PATH}block.db")
+# shellcheck disable=SC2034
     OSD_BLUESTORE_BLOCK_DB=${OSD_BLUESTORE_BLOCK_DB_TMP%?}
+# shellcheck disable=SC2034
     OSD_BLUESTORE_BLOCK_WAL_TMP=$(resolve_symlink "${OSD_PATH}block.wal")
+# shellcheck disable=SC2034
     OSD_BLUESTORE_BLOCK_WAL=${OSD_BLUESTORE_BLOCK_WAL_TMP%?}
   fi
   apply_ceph_ownership_to_disks

--- a/ceph-releases/kraken/ubuntu/16.04/daemon/osd_scenarios/osd_disk_activate.sh
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/osd_scenarios/osd_disk_activate.sh
@@ -51,7 +51,12 @@ function osd_activate {
   fi
   apply_ceph_ownership_to_disks
 
-  ceph "${CLI_OPTS[@]}" --name=osd."${OSD_ID}" --keyring="$OSD_KEYRING" osd crush create-or-move -- "${OSD_ID}" "${OSD_WEIGHT}" "${CRUSH_LOCATION[@]}"
+  # only add crush_location if the current is empty
+  local crush_loc
+  crush_loc=$(ceph "${CLI_OPTS[@]}" --name=osd."${OSD_ID}" --keyring="$OSD_KEYRING" osd find "${OSD_ID}"|python -c 'import sys, json; print(json.load(sys.stdin)["crush_location"])')
+  if [[ "$crush_loc" == "{}" ]]; then
+    ceph "${CLI_OPTS[@]}" --name=osd."${OSD_ID}" --keyring="$OSD_KEYRING" osd crush create-or-move -- "${OSD_ID}" "${OSD_WEIGHT}" "${CRUSH_LOCATION[@]}"
+  fi
 
   log "SUCCESS"
   exec /usr/bin/ceph-osd "${CLI_OPTS[@]}" -f -i "${OSD_ID}" --setuser ceph --setgroup disk

--- a/ceph-releases/kraken/ubuntu/16.04/daemon/osd_scenarios/osd_disk_activate.sh
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/osd_scenarios/osd_disk_activate.sh
@@ -51,7 +51,7 @@ function osd_activate {
   fi
   apply_ceph_ownership_to_disks
 
-  ceph "${CLI_OPTS[@]}" --name=osd."${OSD_ID}" --keyring="$OSD_KEYRING" osd crush create-or-move -- "${OSD_ID}" "${OSD_WEIGHT}" "${CRUSH_LOCATION}"
+  ceph "${CLI_OPTS[@]}" --name=osd."${OSD_ID}" --keyring="$OSD_KEYRING" osd crush create-or-move -- "${OSD_ID}" "${OSD_WEIGHT}" "${CRUSH_LOCATION[@]}"
 
   log "SUCCESS"
   exec /usr/bin/ceph-osd "${CLI_OPTS[@]}" -f -i "${OSD_ID}" --setuser ceph --setgroup disk

--- a/ceph-releases/kraken/ubuntu/16.04/daemon/variables_entrypoint.sh
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/variables_entrypoint.sh
@@ -62,7 +62,7 @@ ALL_SCENARIOS="populate_kvstore mon osd osd_directory osd_directory_single osd_c
 
 # Create a default array
 CRUSH_LOCATION_DEFAULT=("root=default" "host=${HOSTNAME}")
-CRUSH_LOCATION=("${CRUSH_LOCATION[@]:-${CRUSH_LOCATION_DEFAULT[@]}}")
+[[ -n "$CRUSH_LOCATION" ]] || read -ra CRUSH_LOCATION <<< "${CRUSH_LOCATION_DEFAULT[@]}"
 
 # This is ONLY used for the CLI calls, e.g: ceph $CLI_OPTS health
 CLI_OPTS=(--cluster ${CLUSTER})

--- a/ceph-releases/luminous/ubuntu/16.04/daemon/osd_scenarios/osd_disk_activate.sh
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/osd_scenarios/osd_disk_activate.sh
@@ -75,7 +75,7 @@ function osd_activate {
   fi
   apply_ceph_ownership_to_disks
 
-  ceph "${CLI_OPTS[@]}" --name=osd."${OSD_ID}" --keyring="$OSD_KEYRING" osd crush create-or-move -- "${OSD_ID}" "${OSD_WEIGHT}" "${CRUSH_LOCATION}"
+  ceph "${CLI_OPTS[@]}" --name=osd."${OSD_ID}" --keyring="$OSD_KEYRING" osd crush create-or-move -- "${OSD_ID}" "${OSD_WEIGHT}" "${CRUSH_LOCATION[@]}"
 
   log "SUCCESS"
   exec /usr/bin/ceph-osd "${CLI_OPTS[@]}" -f -i "${OSD_ID}" --setuser ceph --setgroup disk

--- a/ceph-releases/luminous/ubuntu/16.04/daemon/osd_scenarios/osd_disk_activate.sh
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/osd_scenarios/osd_disk_activate.sh
@@ -75,7 +75,12 @@ function osd_activate {
   fi
   apply_ceph_ownership_to_disks
 
-  ceph "${CLI_OPTS[@]}" --name=osd."${OSD_ID}" --keyring="$OSD_KEYRING" osd crush create-or-move -- "${OSD_ID}" "${OSD_WEIGHT}" "${CRUSH_LOCATION[@]}"
+  # only add crush_location if the current is empty
+  local crush_loc
+  crush_loc=$(ceph "${CLI_OPTS[@]}" --name=osd."${OSD_ID}" --keyring="$OSD_KEYRING" osd find "${OSD_ID}"|python -c 'import sys, json; print(json.load(sys.stdin)["crush_location"])')
+  if [[ "$crush_loc" == "{}" ]]; then
+    ceph "${CLI_OPTS[@]}" --name=osd."${OSD_ID}" --keyring="$OSD_KEYRING" osd crush create-or-move -- "${OSD_ID}" "${OSD_WEIGHT}" "${CRUSH_LOCATION[@]}"
+  fi
 
   log "SUCCESS"
   exec /usr/bin/ceph-osd "${CLI_OPTS[@]}" -f -i "${OSD_ID}" --setuser ceph --setgroup disk

--- a/ceph-releases/luminous/ubuntu/16.04/daemon/variables_entrypoint.sh
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/variables_entrypoint.sh
@@ -64,7 +64,7 @@ ALL_SCENARIOS="populate_kvstore mon osd osd_directory osd_directory_single osd_c
 
 # Create a default array
 CRUSH_LOCATION_DEFAULT=("root=default" "host=${HOSTNAME}")
-CRUSH_LOCATION=("${CRUSH_LOCATION[@]:-${CRUSH_LOCATION_DEFAULT[@]}}")
+[[ -n "$CRUSH_LOCATION" ]] || read -ra CRUSH_LOCATION <<< "${CRUSH_LOCATION_DEFAULT[@]}"
 
 # This is ONLY used for the CLI calls, e.g: ceph $CLI_OPTS health
 CLI_OPTS=(--cluster ${CLUSTER})


### PR DESCRIPTION
Fixes: https://github.com/ceph/ceph-docker/pull/732 and https://github.com/ceph/ceph-docker/issues/509
Signed-off-by: Sébastien Han <seb@redhat.com>