### PR TITLE
rgw: ability to specify bind ip

### DIFF
--- a/ceph-releases/jewel/ubuntu/14.04/daemon/start_rgw.sh
+++ b/ceph-releases/jewel/ubuntu/14.04/daemon/start_rgw.sh
@@ -28,7 +28,7 @@ function start_rgw {
 
   log "SUCCESS"
 
-  local rgw_frontends="civetweb port=$RGW_CIVETWEB_PORT"
+  local rgw_frontends="civetweb port=$RGW_CIVETWEB_IP:$RGW_CIVETWEB_PORT"
   if [ "$RGW_REMOTE_CGI" -eq 1 ]; then
     rgw_frontends="fastcgi socket_port=$RGW_REMOTE_CGI_PORT socket_host=$RGW_REMOTE_CGI_HOST"
   fi

--- a/ceph-releases/jewel/ubuntu/14.04/daemon/variables_entrypoint.sh
+++ b/ceph-releases/jewel/ubuntu/14.04/daemon/variables_entrypoint.sh
@@ -43,6 +43,7 @@ ALL_SCENARIOS="populate_kvstore mon osd osd_directory osd_directory_single osd_c
 : "${RGW_NAME:=${HOSTNAME}}"
 : "${RGW_ZONEGROUP:=}"
 : "${RGW_ZONE:=}"
+: "${RGW_CIVETWEB_IP:=0.0.0.0}"
 : "${RGW_CIVETWEB_PORT:=8080}"
 : "${RGW_REMOTE_CGI:=0}"
 : "${RGW_REMOTE_CGI_PORT:=9000}"

--- a/ceph-releases/kraken/ubuntu/16.04/daemon/start_rgw.sh
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/start_rgw.sh
@@ -28,7 +28,7 @@ function start_rgw {
 
   log "SUCCESS"
 
-  local rgw_frontends="civetweb port=$RGW_CIVETWEB_PORT"
+  local rgw_frontends="civetweb port=$RGW_CIVETWEB_IP:$RGW_CIVETWEB_PORT"
   if [ "$RGW_REMOTE_CGI" -eq 1 ]; then
     rgw_frontends="fastcgi socket_port=$RGW_REMOTE_CGI_PORT socket_host=$RGW_REMOTE_CGI_HOST"
   fi

--- a/ceph-releases/kraken/ubuntu/16.04/daemon/variables_entrypoint.sh
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/variables_entrypoint.sh
@@ -43,6 +43,7 @@ ALL_SCENARIOS="populate_kvstore mon osd osd_directory osd_directory_single osd_c
 : "${RGW_NAME:=${HOSTNAME}}"
 : "${RGW_ZONEGROUP:=}"
 : "${RGW_ZONE:=}"
+: "${RGW_CIVETWEB_IP:=0.0.0.0}"
 : "${RGW_CIVETWEB_PORT:=8080}"
 : "${RGW_REMOTE_CGI:=0}"
 : "${RGW_REMOTE_CGI_PORT:=9000}"

--- a/ceph-releases/luminous/ubuntu/16.04/daemon/start_rgw.sh
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/start_rgw.sh
@@ -28,7 +28,7 @@ function start_rgw {
 
   log "SUCCESS"
 
-  local rgw_frontends="civetweb port=$RGW_CIVETWEB_PORT"
+  local rgw_frontends="civetweb port=$RGW_CIVETWEB_IP:$RGW_CIVETWEB_PORT"
   if [ "$RGW_REMOTE_CGI" -eq 1 ]; then
     rgw_frontends="fastcgi socket_port=$RGW_REMOTE_CGI_PORT socket_host=$RGW_REMOTE_CGI_HOST"
   fi

--- a/ceph-releases/luminous/ubuntu/16.04/daemon/variables_entrypoint.sh
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/variables_entrypoint.sh
@@ -43,6 +43,7 @@ ALL_SCENARIOS="populate_kvstore mon osd osd_directory osd_directory_single osd_c
 : "${RGW_NAME:=${HOSTNAME}}"
 : "${RGW_ZONEGROUP:=}"
 : "${RGW_ZONE:=}"
+: "${RGW_CIVETWEB_IP:=0.0.0.0}"
 : "${RGW_CIVETWEB_PORT:=8080}"
 : "${RGW_REMOTE_CGI:=0}"
 : "${RGW_REMOTE_CGI_PORT:=9000}"


### PR DESCRIPTION
You can now specify on which IP rgw will listen, for that simply set an
IP to RGW_CIVETWEB_IP.

Signed-off-by: Sébastien Han <seb@redhat.com>