### PR TITLE
Update teardown script

### DIFF
--- a/examples/kubernetes/delete_ceph_cluster.sh
+++ b/examples/kubernetes/delete_ceph_cluster.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-kubectl delete namespace ceph
 kubectl delete secret ceph-secret-admin --namespace kube-system
 kubectl delete storageclass slow
-kubectl delete pv --all
+kubectl delete pv --all -n ceph
+kubectl delete namespace ceph
 kubectl label nodes --all node-type-


### PR DESCRIPTION
PVs are not namespaced in kubernetes. This script can potentially delete all the other PVs in the cluster. Thus namespacing the deletion of the PVs. Also it would be a good practice to delete the namespace at last.