### PR TITLE
Update teardown script further

### DIFF
--- a/examples/kubernetes/delete_ceph_cluster.sh
+++ b/examples/kubernetes/delete_ceph_cluster.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 kubectl delete secret ceph-secret-admin --namespace kube-system
+kubectl get pv | grep 'ceph/' | awk {'print $1'} | xargs -I{} kubectl delete pv {}
 kubectl delete storageclass slow
-kubectl delete pv --all -n ceph
 kubectl delete namespace ceph
 kubectl label nodes --all node-type-

--- a/examples/kubernetes/delete_ceph_cluster.sh
+++ b/examples/kubernetes/delete_ceph_cluster.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 kubectl delete secret ceph-secret-admin --namespace kube-system
-kubectl get pv | grep 'ceph/' | awk {'print $1'} | xargs -I{} kubectl delete pv {}
+kubectl get pv | awk '/ceph/ {print $1}' | xargs -I{} kubectl delete pv {}
 kubectl delete storageclass slow
 kubectl delete namespace ceph
 kubectl label nodes --all node-type-


### PR DESCRIPTION
PVs are not namespaced , so we should pick up PVs only from ceph namespace.