### PR TITLE
daemon: do not chown recursively osd directory

### DIFF
--- a/ceph-releases/jewel/ubuntu/14.04/daemon/common_functions.sh
+++ b/ceph-releases/jewel/ubuntu/14.04/daemon/common_functions.sh
@@ -71,7 +71,8 @@ function create_mandatory_directories {
   mkdir -p /var/lib/ceph/mds/"${CLUSTER}-${MDS_NAME}"
 
   # Adjust the owner of all those directories
-  chown --verbose -R ceph. /var/run/ceph/ /var/lib/ceph/*
+  chown --verbose -R ceph. /var/run/ceph/
+  find -L /var/lib/ceph/ -mindepth 1 -maxdepth 3 -exec chown --verbose ceph. {} \;
 }
 
 

--- a/ceph-releases/kraken/ubuntu/16.04/daemon/common_functions.sh
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/common_functions.sh
@@ -74,7 +74,8 @@ function create_mandatory_directories {
   mkdir -p /var/lib/ceph/mgr/"${CLUSTER}-$MGR_NAME"
 
   # Adjust the owner of all those directories
-  chown --verbose -R ceph. /var/run/ceph/ /var/lib/ceph/*
+  chown --verbose -R ceph. /var/run/ceph/
+  find -L /var/lib/ceph/ -mindepth 1 -maxdepth 3 -exec chown --verbose ceph. {} \;
 }
 
 # Print resolved symbolic links of a device

--- a/ceph-releases/luminous/ubuntu/16.04/daemon/common_functions.sh
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/common_functions.sh
@@ -74,7 +74,8 @@ function create_mandatory_directories {
   mkdir -p /var/lib/ceph/mgr/"${CLUSTER}-$MGR_NAME"
 
   # Adjust the owner of all those directories
-  chown --verbose -R ceph. /var/run/ceph/ /var/lib/ceph/*
+  chown --verbose -R ceph. /var/run/ceph/
+  find -L /var/lib/ceph/ -mindepth 1 -maxdepth 3 -exec chown --verbose ceph. {} \;
 }
 
 # Print resolved symbolic links of a device


### PR DESCRIPTION
We now limit the depth to 3 which means:

[root@ceph-osd0 ~]# find -L /var/lib/ceph/ -mindepth 1 -maxdepth 3
/var/lib/ceph/bootstrap-osd
/var/lib/ceph/bootstrap-osd/ceph.keyring
/var/lib/ceph/bootstrap-mds
/var/lib/ceph/bootstrap-mds/ceph.keyring
/var/lib/ceph/bootstrap-rgw
/var/lib/ceph/bootstrap-rgw/ceph.keyring
/var/lib/ceph/mon
/var/lib/ceph/mon/ceph-ceph-osd0
/var/lib/ceph/osd
/var/lib/ceph/mds
/var/lib/ceph/mds/ceph-mds-ceph-osd0
/var/lib/ceph/radosgw
/var/lib/ceph/radosgw/ceph-osd0
/var/lib/ceph/tmp
/var/lib/ceph/tmp/ceph-disk.prepare.lock
/var/lib/ceph/mgr
/var/lib/ceph/mgr/ceph-ceph-osd0
/var/lib/ceph/osd-lockbox
/var/lib/ceph/osd-lockbox/6e6cc345-ef0e-45a4-ab31-1fa7399ce51f
/var/lib/ceph/osd-lockbox/2f81eda4-392e-4ea3-b3f5-b55f3661bd4b
/var/lib/ceph/osd-lockbox/4ff79546-b0f6-4ecf-af34-5f0e9dfd50f5
/var/lib/ceph/osd-lockbox/13d95905-91e3-46aa-ae6a-e2a5ebcaa341
/var/lib/ceph/osd-lockbox/e1fe8db4-ab9e-49c0-b332-6ed93799ce43
/var/lib/ceph/osd-lockbox/35316996-20e1-4bec-afe8-fa2c7c09f688
/var/lib/ceph/osd-lockbox/1f3e2097-529e-4f64-ba51-647ffdddd190
/var/lib/ceph/osd-lockbox/626edc3f-1b37-4c32-9d5e-38dcd41a2204

Fixes: https://github.com/ceph/ceph-docker/issues/739
Signed-off-by: Sébastien Han <seb@redhat.com>