### PR TITLE
Fix improper following of device symlinks

### DIFF
--- a/ceph-releases/jewel/ubuntu/14.04/daemon/common_functions.sh
+++ b/ceph-releases/jewel/ubuntu/14.04/daemon/common_functions.sh
@@ -85,8 +85,6 @@ function dev_part {
     # This device is a symlink. Work out it's actual device
     local actual_device
     actual_device=$(readlink -f "${osd_device}")
-    local bn
-    bn=$(basename "${osd_device}")
     if [[ "${actual_device:0-1:1}" == [0-9] ]]; then
       local desired_partition="${actual_device}p${osd_partition}"
     else
@@ -99,13 +97,13 @@ function dev_part {
     symdir=$(dirname "${osd_device}")
     local link=""
     local pfxlen=0
-    for option in ${symdir}*; do
+    for option in ${symdir}/*; do
       [[ -e $option ]] || break
-      if [[ $(readlink -f "$symdir"/"$option") == "$desired_partition" ]]; then
+      if [[ $(readlink -f "$option") == "$desired_partition" ]]; then
         local optprefixlen
-        optprefixlen=$(prefix_length "$option" "$bn")
+        optprefixlen=$(prefix_length "$option" "$osd_device")
         if [[ $optprefixlen > $pfxlen ]]; then
-          link=$symdir/$option
+          link=$option
           pfxlen=$optprefixlen
         fi
       fi

--- a/ceph-releases/kraken/ubuntu/16.04/daemon/common_functions.sh
+++ b/ceph-releases/kraken/ubuntu/16.04/daemon/common_functions.sh
@@ -92,8 +92,6 @@ function dev_part {
     # This device is a symlink. Work out it's actual device
     local actual_device
     actual_device=$(readlink -f "${osd_device}")
-    local bn
-    bn=$(basename "${osd_device}")
     if [[ "${actual_device:0-1:1}" == [0-9] ]]; then
       local desired_partition="${actual_device}p${osd_partition}"
     else
@@ -106,13 +104,13 @@ function dev_part {
     symdir=$(dirname "${osd_device}")
     local link=""
     local pfxlen=0
-    for option in ${symdir}*; do
+    for option in ${symdir}/*; do
       [[ -e $option ]] || break
-      if [[ $(readlink -f "$symdir"/"$option") == "$desired_partition" ]]; then
+      if [[ $(readlink -f "$option") == "$desired_partition" ]]; then
         local optprefixlen
-        optprefixlen=$(prefix_length "$option" "$bn")
+        optprefixlen=$(prefix_length "$option" "$osd_device")
         if [[ $optprefixlen > $pfxlen ]]; then
-          link=$symdir/$option
+          link=$option
           pfxlen=$optprefixlen
         fi
       fi

--- a/ceph-releases/luminous/ubuntu/16.04/daemon/common_functions.sh
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/common_functions.sh
@@ -92,8 +92,6 @@ function dev_part {
     # This device is a symlink. Work out it's actual device
     local actual_device
     actual_device=$(readlink -f "${osd_device}")
-    local bn
-    bn=$(basename "${osd_device}")
     if [[ "${actual_device:0-1:1}" == [0-9] ]]; then
       local desired_partition="${actual_device}p${osd_partition}"
     else
@@ -106,13 +104,13 @@ function dev_part {
     symdir=$(dirname "${osd_device}")
     local link=""
     local pfxlen=0
-    for option in ${symdir}*; do
+    for option in ${symdir}/*; do
       [[ -e $option ]] || break
-      if [[ $(readlink -f "$symdir"/"$option") == "$desired_partition" ]]; then
+      if [[ $(readlink -f "$option") == "$desired_partition" ]]; then
         local optprefixlen
-        optprefixlen=$(prefix_length "$option" "$bn")
+        optprefixlen=$(prefix_length "$option" "$osd_device")
         if [[ $optprefixlen > $pfxlen ]]; then
-          link=$symdir/$option
+          link=$option
           pfxlen=$optprefixlen
         fi
       fi


### PR DESCRIPTION
Fixes #750 

While investigating this issue, it appears from the git blame of the file, the error was introduced when a dev cleaned up the shellcheck lining errors. I don't want to suggest any blame, and I'm glad to see that people are interested in maintaining clean, maintainable code. This error could have been caught with unit testing, and ideally, I'd like to add unit tests starting with this code. I can see a few ways to proceed, however, and I'd like to discuss the community's interest and thoughts. Here are my thoughts so far:

- With a codebase of scripts this large, it may be more appropriate to convert code to Python and add unit tests for all Python code. Python has strong unit testing and libraries and seems more suitable for a project that is this size and growing larger. This could be done all-at-once, or it could be done incrementally on a by-function or by-file basis as updates/additions to the codebase are needed.
- On the flip side of this argument, there is already a substantial amount of scripting written in bash, and there has been care taken to ensure the scripts are high quality. It could make more sense to instead add bash unit tests to the codebase. This also could be done all-at-once, or it could be done on a function-by-function basis as updates/additions to the codebase are needed.