### PR TITLE
daemon: do not log inside the container

### DIFF
--- a/ceph-releases/luminous/ubuntu/16.04/daemon/config.static.sh
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/config.static.sh
@@ -34,6 +34,7 @@ osd pool default pgp num = 8
 osd pool default size = 1
 public network = ${CEPH_PUBLIC_NETWORK}
 cluster network = ${CEPH_PUBLIC_NETWORK}
+log file = /dev/null
 ENDHERE
 
       # For ext4
@@ -55,6 +56,7 @@ auth client required = cephx
 public network = ${CEPH_PUBLIC_NETWORK}
 cluster network = ${CEPH_CLUSTER_NETWORK}
 osd journal size = ${OSD_JOURNAL_SIZE}
+log file = /dev/null
 ENDHERE
     fi
     if [ "$IP_LEVEL" -eq 6 ]; then


### PR DESCRIPTION
Logging inside the container is not useful since it writes to the
overlayfs partition, resulting in potential performance degradation on
the container.

If you need to check the logs, just look at journald.

Signed-off-by: Sébastien Han <seb@redhat.com>