### PR TITLE
osd_disk_activate: fix osd_bluestore with dmcrypt activation error

### DIFF
--- a/ceph-releases/luminous/ubuntu/16.04/daemon/osd_scenarios/osd_disk_activate.sh
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/osd_scenarios/osd_disk_activate.sh
@@ -61,13 +61,13 @@ function osd_activate {
 
     # Open LUKS device(s) if necessary
     if [[ ! -e /dev/mapper/"${DATA_UUID}" ]]; then
-      open_encrypted_part "${BLOCK_UUID}" "${DATA_PART}" "${BLOCK_UUID}"
+      open_encrypted_part "${BLOCK_UUID}" "${DATA_PART}" "${DATA_UUID}"
     fi
     if [[ ! -e /dev/mapper/"${BLOCK_DB_UUID}" ]]; then
-      open_encrypted_part "${BLOCK_DB_UUID}" "${BLOCK_DB_PART}" "${BLOCK_UUID}"
+      open_encrypted_part "${BLOCK_DB_UUID}" "${BLOCK_DB_PART}" "${DATA_UUID}"
     fi
     if [[ ! -e /dev/mapper/"${BLOCK_WAL_UUID}" ]]; then
-      open_encrypted_part "${BLOCK_WAL_UUID}" "${BLOCK_WAL_PART}" "${BLOCK_UUID}"
+      open_encrypted_part "${BLOCK_WAL_UUID}" "${BLOCK_WAL_PART}" "${DATA_UUID}"
     fi
   fi
 


### PR DESCRIPTION
Fix error while opening encrypted part for bluestore scenario:

`authentication error (22) Invalid argument`

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>