### PR TITLE
contrib: add flag for docker hub status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # docker-ceph
 
+![Ceph Daemon Stars](https://img.shields.io/docker/stars/ceph/daemon.svg)
+![Ceph Daemon Pulls](https://img.shields.io/docker/pulls/ceph/daemon.svg)
+![Ceph Daemon Automated](https://img.shields.io/docker/automated/ceph/daemon.svg)
+![Ceph Daemon Build Status](https://img.shields.io/docker/status/ceph/daemon.svg)
+
 Ceph-related Docker files.
 
 ## Core Components:


### PR DESCRIPTION
Currently shields.io does not support tags but it's ongoing.
See progress here: https://github.com/badges/shields/issues/935

Signed-off-by: Sébastien Han <seb@redhat.com>