### PR TITLE
daemon; fix dmcrypt opening partition

### DIFF
--- a/ceph-releases/luminous/ubuntu/16.04/daemon/common_functions.sh
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/common_functions.sh
@@ -343,12 +343,13 @@ function open_encrypted_part {
   # $1 is the encrypted device
   # $2 is the partition uuid
   # $3 is the data partition uuid (always this one for the lockbox)
+  # add || true to handle the case where the device is already opened
   log "Opening encrypted device $1"
   ceph "${CLI_OPTS[@]}" --name client.osd-lockbox."${3}" \
   --keyring /var/lib/ceph/osd-lockbox/"${3}"/keyring \
   config-key \
   get \
-  dm-crypt/osd/"${3}"/luks | base64 -d | cryptsetup --key-file - luksOpen "${2}" "${1}"
+  dm-crypt/osd/"${3}"/luks | base64 -d | cryptsetup --key-file - luksOpen "${2}" "${1}" || true
 }
 
 # shellcheck disable=SC2153


### PR DESCRIPTION
Sometimes (typically after a prepare) the LUKS device is already open.
If that's the case ceph-disk will try to open it and complain.
Quick fix for now, will work on a better way to handle that.

Signed-off-by: Sébastien Han <seb@redhat.com>