### PR TITLE
mon: Add rbd keyring to mon keyring

### DIFF
--- a/ceph-releases/luminous/ubuntu/16.04/daemon/start_mon.sh
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/start_mon.sh
@@ -132,7 +132,7 @@ function start_mon {
     fi
 
     # Testing if it's not the first monitor, if one key doesn't exist we assume none of them exist
-    for keyring in $OSD_BOOTSTRAP_KEYRING $MDS_BOOTSTRAP_KEYRING $RGW_BOOTSTRAP_KEYRING $ADMIN_KEYRING; do
+    for keyring in $OSD_BOOTSTRAP_KEYRING $MDS_BOOTSTRAP_KEYRING $RGW_BOOTSTRAP_KEYRING $RBD_BOOTSTRAP_KEYRING $ADMIN_KEYRING; do
       ceph-authtool "$MON_KEYRING" --import-keyring "$keyring"
     done
 


### PR DESCRIPTION
This fix the rbd keyring that is not registered in ceph for rbdmirror
nodes.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>