### PR TITLE
daemon: show env var of the container

### DIFF
--- a/ceph-releases/luminous/ubuntu/16.04/daemon/debug.sh
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/debug.sh
@@ -13,6 +13,7 @@ for option in $(comma_to_space "${DEBUG}"); do
       log "VERBOSE: activating bash debugging mode."
       log "To run Ceph daemons in debugging mode, pass the CEPH_ARGS variable like this:"
       log "-e CEPH_ARGS='--debug-ms 1 --debug-osd 10'"
+      log "This container environement variables are: $(env)"
       export PS4='+${BASH_SOURCE}:${LINENO}: ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
       set -x
       ;;


### PR DESCRIPTION
When running the container with DEBUG=verbose, it's also useful to know
the env var of the container.

Signed-off-by: Sébastien Han <seb@redhat.com>