### PR TITLE
daemon: ceph-disk list replacement tool

### DIFF
--- a/ceph-releases/luminous/centos/7/daemon/disk_list.sh
+++ b/ceph-releases/luminous/centos/7/daemon/disk_list.sh
@@ -1,0 +1,1 @@
+../../../ubuntu/16.04/daemon/disk_list.sh

--- a/ceph-releases/luminous/rhel/7.3/daemon/disk_list.sh
+++ b/ceph-releases/luminous/rhel/7.3/daemon/disk_list.sh
@@ -1,0 +1,1 @@
+../../../ubuntu/16.04/daemon/disk_list.sh

--- a/ceph-releases/luminous/ubuntu/16.04/daemon/common_functions.sh
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/common_functions.sh
@@ -74,8 +74,8 @@ function create_mandatory_directories {
   mkdir -p /var/lib/ceph/mgr/"${CLUSTER}-$MGR_NAME"
 
   # Adjust the owner of all those directories
-  chown --verbose -R ceph. /var/run/ceph/
-  find -L /var/lib/ceph/ -mindepth 1 -maxdepth 3 -exec chown --verbose ceph. {} \;
+  chown "${CHOWN_OPT[@]}" -R ceph. /var/run/ceph/
+  find -L /var/lib/ceph/ -mindepth 1 -maxdepth 3 -exec chown "${CHOWN_OPT[@]}" ceph. {} \;
 }
 
 # Print resolved symbolic links of a device
@@ -263,7 +263,7 @@ function get_part_typecode {
 function apply_ceph_ownership_to_disks {
   if [[ ${OSD_DMCRYPT} -eq 1 ]]; then
     wait_for_file "$(dev_part "${OSD_DEVICE}" 5)"
-    chown --verbose ceph. "$(dev_part "${OSD_DEVICE}" 5)"
+    chown "${CHOWN_OPT[@]}" ceph. "$(dev_part "${OSD_DEVICE}" 5)"
   fi
   if [[ ${OSD_BLUESTORE} -eq 1 ]]; then
     dev_real_path=$(resolve_symlink "$OSD_BLUESTORE_BLOCK_WAL" "$OSD_BLUESTORE_BLOCK_DB")
@@ -275,20 +275,20 @@ function apply_ceph_ownership_to_disks {
             "$part_code" == "30cd0809-c2b2-499c-8879-2d6b78529876" ||
             "$part_code" == "89c57f98-2fe5-4dc0-89c1-f3ad0ceff2be" ||
             "$part_code" == "cafecafe-9b03-4f30-b4c6-b4b80ceff106" ]]; then
-        chown --verbose ceph. "$partition"
+        chown "${CHOWN_OPT[@]}" ceph. "$partition"
       fi
     done
   elif [[ ${OSD_FILESTORE} -eq 1 ]]; then
     if [[ -n "${OSD_JOURNAL}" ]]; then
       wait_for_file "${OSD_JOURNAL}"
-      chown --verbose ceph. "${OSD_JOURNAL}"
+      chown "${CHOWN_OPT[@]}" ceph. "${OSD_JOURNAL}"
     else
       wait_for_file "$(dev_part "${OSD_DEVICE}" 2)"
-      chown --verbose ceph. "$(dev_part "${OSD_DEVICE}" 2)"
+      chown "${CHOWN_OPT[@]}" ceph. "$(dev_part "${OSD_DEVICE}" 2)"
     fi
   fi
   wait_for_file "$(dev_part "${OSD_DEVICE}" 1)"
-  chown --verbose ceph. "$(dev_part "${OSD_DEVICE}" 1)"
+  chown "${CHOWN_OPT[@]}" ceph. "$(dev_part "${OSD_DEVICE}" 1)"
 }
 
 # Get partition uuid of a given partition
@@ -363,7 +363,7 @@ function mount_lockbox {
   cluster_name=$(basename "$(grep -R fsid /etc/ceph/ | grep -oE '^[^.]*')")
   ceph_fsid=$(ceph-conf --lookup fsid -c /etc/ceph/"$cluster_name".conf)
   echo "$ceph_fsid" > /var/lib/ceph/osd-lockbox/"${1}"/ceph_fsid
-  chown --verbose ceph. /var/lib/ceph/osd-lockbox/"${1}"/ceph_fsid
+  chown "${CHOWN_OPT[@]}" ceph. /var/lib/ceph/osd-lockbox/"${1}"/ceph_fsid
 }
 
 function umount_lockbox {

--- a/ceph-releases/luminous/ubuntu/16.04/daemon/config.kv.etcd.sh
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/config.kv.etcd.sh
@@ -82,7 +82,7 @@ function get_mon_config {
     log "Importing Keyrings and Monmap to KV."
     etcdctl "${ETCDCTL_OPTS[@]}" "${KV_TLS[@]}" set "${CLUSTER_PATH}"/monKeyring < "$MON_KEYRING"
     etcdctl "${ETCDCTL_OPTS[@]}" "${KV_TLS[@]}" set "${CLUSTER_PATH}"/adminKeyring < "$ADMIN_KEYRING"
-    chown --verbose ceph. "$MON_KEYRING" "$ADMIN_KEYRING"
+    chown "${CHOWN_OPT[@]}" ceph. "$MON_KEYRING" "$ADMIN_KEYRING"
 
     uuencode "$MONMAP" - | etcdctl "${ETCDCTL_OPTS[@]}" "${KV_TLS[@]}" set "${CLUSTER_PATH}"/monmap
 
@@ -104,7 +104,7 @@ function import_bootstrap_keyrings {
     local bootstrap_keyring
     bootstrap_keyring="bootstrap${array[1]}Keyring"
     etcdctl "${ETCDCTL_OPTS[@]}" "${KV_TLS[@]}" get "${CLUSTER_PATH}"/"${bootstrap_keyring}" > "$keyring"
-    chown --verbose ceph. "$keyring"
+    chown "${CHOWN_OPT[@]}" ceph. "$keyring"
   done
 }
 

--- a/ceph-releases/luminous/ubuntu/16.04/daemon/config.static.sh
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/config.static.sh
@@ -94,7 +94,7 @@ ENDHERE
     ceph-authtool "$RBD_MIRROR_BOOTSTRAP_KEYRING" --create-keyring --gen-key -n client.bootstrap-rbd --cap mon 'allow profile bootstrap-rbd'
   fi
     # Apply proper permissions to the keys
-    chown --verbose ceph. "$MON_KEYRING" "$OSD_BOOTSTRAP_KEYRING" "$MDS_BOOTSTRAP_KEYRING" "$RGW_BOOTSTRAP_KEYRING" "$RBD_MIRROR_BOOTSTRAP_KEYRING"
+    chown "${CHOWN_OPT[@]}" ceph. "$MON_KEYRING" "$OSD_BOOTSTRAP_KEYRING" "$MDS_BOOTSTRAP_KEYRING" "$RGW_BOOTSTRAP_KEYRING" "$RBD_MIRROR_BOOTSTRAP_KEYRING"
 
   if [ ! -e "$MONMAP" ]; then
     if [ -e /etc/ceph/monmap ]; then
@@ -104,7 +104,7 @@ ENDHERE
       # Generate initial monitor map
       monmaptool --create --add "${MON_NAME}" "${MON_IP}:6789" --fsid "${fsid}" "$MONMAP"
     fi
-    chown --verbose ceph. "$MONMAP"
+    chown "${CHOWN_OPT[@]}" ceph. "$MONMAP"
   fi
 }
 

--- a/ceph-releases/luminous/ubuntu/16.04/daemon/debug.sh
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/debug.sh
@@ -15,6 +15,7 @@ for option in $(comma_to_space "${DEBUG}"); do
       log "-e CEPH_ARGS='--debug-ms 1 --debug-osd 10'"
       log "This container environement variables are: $(env)"
       export PS4='+${BASH_SOURCE}:${LINENO}: ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
+      # shellcheck disable=SC2034
       CHOWN_OPT=(--verbose)
       set -x
       ;;

--- a/ceph-releases/luminous/ubuntu/16.04/daemon/debug.sh
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/debug.sh
@@ -15,6 +15,7 @@ for option in $(comma_to_space "${DEBUG}"); do
       log "-e CEPH_ARGS='--debug-ms 1 --debug-osd 10'"
       log "This container environement variables are: $(env)"
       export PS4='+${BASH_SOURCE}:${LINENO}: ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
+      CHOWN_OPT=(--verbose)
       set -x
       ;;
     fstree*)

--- a/ceph-releases/luminous/ubuntu/16.04/daemon/disk_introspection.sh
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/disk_introspection.sh
@@ -6,19 +6,6 @@ MY_NAMESPACE=$(kubectl get pods --all-namespaces -o jsonpath="{.items[?(@.metada
 DISK_FILE=$(kubectl --namespace="${MY_NAMESPACE}" get pods "${HOSTNAME}" -o jsonpath="{.spec.nodeName}")-disks
 DISK_FILE_PATH=/tmp/$DISK_FILE
 
-function ami_privileged {
-  if ! blkid > /dev/null || ! stat /dev/disk/ > /dev/null; then
-    log "ERROR: I don't have enough privileges, I can't discover devices on that machine."
-    log "ERROR: run me as a privileged container with the following options"
-    log "ERROR: --privileged=true -v /dev/:/dev/"
-    exit 1
-  fi
-  # NOTE (leseb): when not running with --privileged=true -v /dev/:/dev/
-  # lsblk is not able to get device mappers path and is complaining.
-  # That's why stderr is suppressed in /dev/null
-  DISCOVERED_DEVICES=$(lsblk --output NAME --noheadings --raw --scsi)
-}
-
 function get_all_disks_without_partitions {
   for disk in $DISCOVERED_DEVICES; do
     if [[ "$(grep -Ec "${disk}[0-9]" /proc/partitions)" == 0 ]]; then
@@ -39,5 +26,6 @@ function store_disk_list_configmaps {
 }
 
 ami_privileged
+DISCOVERED_DEVICES=$(lsblk --output NAME --noheadings --raw --scsi)
 get_all_disks_without_partitions
 store_disk_list_configmaps

--- a/ceph-releases/luminous/ubuntu/16.04/daemon/disk_list.sh
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/disk_list.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+set -e
+
+
+#############
+# VARIABLES #
+#############
+
+tmp_dir="$(mktemp --directory --tmpdir=/var/lib/ceph/tmp/)"
+DOCKER_ENV=""
+
+
+#############
+# FUNCTIONS #
+#############
+
+function mandatory_checks () {
+  ami_privileged
+
+  : "${OSD_DEVICE:=none}"
+  if [[ ${OSD_DEVICE} == "none" ]]; then
+    log "ERROR: you must submit OSD_DEVICE, e.g: -e OSD_DEVICE=/dev/sda"
+    exit 1
+  fi
+}
+
+function is_dmcrypt () {
+  blkid -t TYPE=crypto_LUKS "${OSD_DEVICE}1" -o value -s PARTUUID &> /dev/null
+}
+
+function mount_ceph_data () {
+  if is_dmcrypt; then
+    mount /dev/mapper/"${data_uuid}" "$tmp_dir"
+  else
+    mount "${OSD_DEVICE}1" "$tmp_dir"
+  fi
+}
+
+function umount_ceph_data () {
+  umount "$tmp_dir"
+}
+
+function start_disk_list () {
+  mount_ceph_data
+  cd "$tmp_dir" || return
+  osd_type=$(<type)
+  if [[ "$osd_type" == "filestore" ]]; then
+    if [[ -L journal_dmcrypt ]]; then
+      journal_part=$(resolve_symlink journal_dmcrypt)
+      DOCKER_ENV="$DOCKER_ENV -e OSD_JOURNAL=$journal_part"
+    elif [[ -L journal ]]; then
+      journal_part=$(resolve_symlink journal)
+      DOCKER_ENV="$DOCKER_ENV -e OSD_JOURNAL=$journal_part"
+    fi
+  # NOTE(leseb):
+  # For bluestore we return the full device, not the partition
+  # because apply_ceph_ownership_to_disks will determine the partitions
+  # We could probably make this easier...
+  elif [[ "$osd_type" == "bluestore" ]]; then
+    if [[ -L block.db_dmcrypt ]]; then
+      block_db_part=$(resolve_symlink block.db_dmcrypt)
+      DOCKER_ENV="$DOCKER_ENV -e OSD_BLUESTORE_BLOCK_DB=${block_db_part%?}"
+    elif [[ -L block.db ]]; then
+      block_db_part=$(resolve_symlink block.db)
+      DOCKER_ENV="$DOCKER_ENV -e OSD_BLUESTORE_BLOCK_DB=${block_db_part%?}"
+    fi
+    if [[ -L block.wal_dmcrypt ]]; then
+      block_wal_part=$(resolve_symlink block.wal_dmcrypt)
+      DOCKER_ENV="$DOCKER_ENV -e OSD_BLUESTORE_BLOCK_WAL=${block_wal_part%?}"
+    elif [[ -L block.wal ]]; then
+      block_wal_part=$(resolve_symlink block.wal)
+      DOCKER_ENV="$DOCKER_ENV -e OSD_BLUESTORE_BLOCK_WAL=${block_wal_part%?}"
+    fi
+  else
+    log "ERROR: unrecognized OSD type: $osd_type"
+  fi
+
+  echo "$DOCKER_ENV"
+
+  cd || return
+  umount_ceph_data
+}
+
+
+########
+# MAIN #
+########
+
+mandatory_checks
+if is_dmcrypt; then
+  # creates /dev/mapper/<uuid> for dmcrypt
+  # usually after a reboot they don't go created
+  udevadm trigger
+
+  lockbox_uuid=$(get_part_uuid "$(dev_part "${OSD_DEVICE}" 5)")
+  data_uuid=$(get_part_uuid "$(dev_part "${OSD_DEVICE}" 1)")
+  data_part=$(dev_part "${OSD_DEVICE}" 1)
+  mount_lockbox "$data_uuid" "$lockbox_uuid" 1> /dev/null
+  if [[ ! -e /dev/mapper/"${data_uuid}" ]]; then
+    open_encrypted_part "${data_uuid}" "${data_part}" "${data_uuid}" 1> /dev/null
+  fi
+  start_disk_list
+  close_encrypted_part "${data_uuid}" "${data_part}" "${data_uuid}" 1> /dev/null
+  umount_lockbox "$lockbox_uuid" 1> /dev/null
+else
+  start_disk_list
+fi

--- a/ceph-releases/luminous/ubuntu/16.04/daemon/entrypoint.sh.in
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/entrypoint.sh.in
@@ -148,6 +148,10 @@ case "$CEPH_DAEMON" in
     # TAG: demo
     source demo.sh
     ;;
+  disk_list)
+    # TAG: disk_list
+    source disk_list.sh
+    ;;
   *)
     invalid_ceph_daemon
   ;;

--- a/ceph-releases/luminous/ubuntu/16.04/daemon/osd_scenarios/osd_activate_journal.sh
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/osd_scenarios/osd_activate_journal.sh
@@ -13,7 +13,7 @@ function osd_activate_journal {
   # wait till partition exists
   wait_for_file "${OSD_JOURNAL}"
 
-  chown --verbose ceph. "${OSD_JOURNAL}"
+  chown "${CHOWN_OPT[@]}" ceph. "${OSD_JOURNAL}"
   ceph-disk -v --setuser ceph --setgroup disk activate-journal "${OSD_JOURNAL}"
 
   start_osd

--- a/ceph-releases/luminous/ubuntu/16.04/daemon/osd_scenarios/osd_directory.sh
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/osd_scenarios/osd_directory.sh
@@ -23,7 +23,7 @@ function osd_directory {
 
     # create the folder and own it
     mkdir -p "$OSD_PATH"
-    chown --verbose ceph. "$OSD_PATH"
+    chown "${CHOWN_OPT[@]}" ceph. "$OSD_PATH"
     log "created folder $OSD_PATH"
   fi
 
@@ -37,18 +37,18 @@ function osd_directory {
 
     if [ -n "${JOURNAL_DIR}" ]; then
        OSD_J="${JOURNAL_DIR}/journal.${OSD_ID}"
-       chown --verbose -R ceph. "${JOURNAL_DIR}"
+       chown "${CHOWN_OPT[@]}" -R ceph. "${JOURNAL_DIR}"
     else
        if [ -n "${JOURNAL}" ]; then
           OSD_J=${JOURNAL}
-          chown -R ceph. "$(dirname "${JOURNAL_DIR}")"
+          chown "${CHOWN_OPT[@]}" -R ceph. "$(dirname "${JOURNAL_DIR}")"
        else
           OSD_J=${OSD_PATH}/journal
        fi
     fi
     # check to see if our osd has been initialized
     if [ ! -e "${OSD_PATH}"/keyring ]; then
-      chown --verbose ceph. "$OSD_PATH"
+      chown "${CHOWN_OPT[@]}" ceph. "$OSD_PATH"
       # create osd key and file structure
       ceph-osd "${CLI_OPTS[@]}" -i "$OSD_ID" --mkfs --mkkey --mkjournal --osd-journal "${OSD_J}" --setuser ceph --setgroup ceph
       if [ ! -e "$OSD_BOOTSTRAP_KEYRING"  ]; then
@@ -60,7 +60,7 @@ function osd_directory {
       # add the osd key
       ceph "${CLI_OPTS[@]}" --name client.bootstrap-osd --keyring "$OSD_BOOTSTRAP_KEYRING" auth add osd."${OSD_ID}" -i "${OSD_KEYRING}" osd 'allow *' mon 'allow profile osd'  || log "$1"
       log "done adding key"
-      chown --verbose ceph. "${OSD_KEYRING}"
+      chown "${CHOWN_OPT[@]}" ceph. "${OSD_KEYRING}"
       chmod 0600 "${OSD_KEYRING}"
       # add the osd to the crush map
     fi

--- a/ceph-releases/luminous/ubuntu/16.04/daemon/osd_scenarios/osd_disk_prepare.sh
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/osd_scenarios/osd_disk_prepare.sh
@@ -73,6 +73,11 @@ function osd_disk_prepare {
   # unmount lockbox partition when using dmcrypt
   umount_lockbox
 
+  # close dmcrypt device
+  DATA_UUID=$(get_part_uuid "$(dev_part "${OSD_DEVICE}" 1)")
+  DATA_PART=$(dev_part "${OSD_DEVICE}" 1)
+  close_encrypted_part "${DATA_UUID}" "${DATA_PART}" "${DATA_UUID}" 1> /dev/null
+
   # watch the udev event queue, and exit if all current events are handled
   udevadm settle --timeout=600
 

--- a/ceph-releases/luminous/ubuntu/16.04/daemon/start_mds.sh
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/start_mds.sh
@@ -23,7 +23,7 @@ function start_mds {
 
       # Generate the MDS key
       ceph "${CLI_OPTS[@]}" "${keyring_opt[@]}" auth get-or-create mds."$MDS_NAME" osd 'allow rwx' mds 'allow' mon 'allow profile mds' -o "$MDS_KEYRING"
-      chown --verbose ceph. "$MDS_KEYRING"
+      chown "${CHOWN_OPT[@]}" ceph. "$MDS_KEYRING"
       chmod 600 "$MDS_KEYRING"
 
     fi

--- a/ceph-releases/luminous/ubuntu/16.04/daemon/start_mgr.sh
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/start_mgr.sh
@@ -13,7 +13,7 @@ function start_mgr {
   if [ ! -e "$MGR_KEYRING" ]; then
     # Create ceph-mgr key
     ceph "${CLI_OPTS[@]}" auth get-or-create mgr."$MGR_NAME" mon 'allow profile mgr' osd 'allow *' mds 'allow *' -o "$MGR_KEYRING"
-    chown --verbose ceph. "$MGR_KEYRING"
+    chown "${CHOWN_OPT[@]}" ceph. "$MGR_KEYRING"
     chmod 600 "$MGR_KEYRING"
   fi
 

--- a/ceph-releases/luminous/ubuntu/16.04/daemon/start_nfs.sh
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/start_nfs.sh
@@ -26,7 +26,7 @@ function start_nfs {
 
     # Generate the RGW key
     ceph "${CLI_OPTS[@]}" --name client.bootstrap-rgw --keyring "$RGW_BOOTSTRAP_KEYRING" auth get-or-create client.rgw."${RGW_NAME}" osd 'allow rwx' mon 'allow rw' -o "$RGW_KEYRING"
-    chown --verbose ceph. "$RGW_KEYRING"
+    chown "${CHOWN_OPT[@]}" ceph. "$RGW_KEYRING"
     chmod 0600 "$RGW_KEYRING"
   fi
 

--- a/ceph-releases/luminous/ubuntu/16.04/daemon/start_rbd_mirror.sh
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/start_rbd_mirror.sh
@@ -22,7 +22,7 @@ function start_rbd_mirror {
 
     # Generate the rbd mirror key
     ceph "${CLI_OPTS[@]}" --name client.bootstrap-rbd --keyring "$RBD_MIRROR_BOOTSTRAP_KEYRING" auth get-or-create client.rbd-mirror."${RBD_MIRROR_NAME}" mon 'profile rbd' osd 'profile rbd' -o "$RBD_MIRROR_KEYRING"
-    chown --verbose ceph. "$RBD_MIRROR_KEYRING"
+    chown "${CHOWN_OPT[@]}" ceph. "$RBD_MIRROR_KEYRING"
     chmod 0600 "$RBD_MIRROR_KEYRING"
   fi
 

--- a/ceph-releases/luminous/ubuntu/16.04/daemon/start_rgw.sh
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/start_rgw.sh
@@ -22,7 +22,7 @@ function start_rgw {
 
     # Generate the RGW key
     ceph "${CLI_OPTS[@]}" --name client.bootstrap-rgw --keyring "$RGW_BOOTSTRAP_KEYRING" auth get-or-create client.rgw."${RGW_NAME}" osd 'allow rwx' mon 'allow rw' -o "$RGW_KEYRING"
-    chown --verbose ceph. "$RGW_KEYRING"
+    chown "${CHOWN_OPT[@]}" ceph. "$RGW_KEYRING"
     chmod 0600 "$RGW_KEYRING"
   fi
 

--- a/ceph-releases/luminous/ubuntu/16.04/daemon/variables_entrypoint.sh
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/variables_entrypoint.sh
@@ -5,7 +5,7 @@
 # LIST OF ALL SCENARIOS AVAILABLE #
 ###################################
 
-ALL_SCENARIOS="populate_kvstore mon osd osd_directory osd_directory_single osd_ceph_disk osd_ceph_disk_prepare osd_ceph_disk_activate osd_ceph_activate_journal mds rgw rgw_user restapi nfs zap_device mon_health mgr disk_introspection demo"
+ALL_SCENARIOS="populate_kvstore mon osd osd_directory osd_directory_single osd_ceph_disk osd_ceph_disk_prepare osd_ceph_disk_activate osd_ceph_activate_journal mds rgw rgw_user restapi nfs zap_device mon_health mgr disk_introspection demo disk_list"
 
 
 #########################


### PR DESCRIPTION
ceph-disk list output is really hazardous, so we now have a simpler
scenario to detect journal, block.wal, block.db. It's meant to be used
by ceph-ansible (or other tools) that needs to run the osd activation
stage. For this, it needs to know some variables about the OSD itself.

Signed-off-by: Sébastien Han <seb@redhat.com>