### PR TITLE
osd_disk_activate: fix wrong catching of journal part

### DIFF
--- a/ceph-releases/luminous/ubuntu/16.04/daemon/osd_scenarios/osd_disk_activate.sh
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/osd_scenarios/osd_disk_activate.sh
@@ -17,7 +17,7 @@ function osd_activate {
     else
       CLI+=("${OSD_DEVICE}")
     fi
-    JOURNAL_PART=$(ceph-disk list "${CLI[@]}" | awk '/ceph journal/ {print $1}') # This is a privileged container so 'ceph-disk list' works
+    JOURNAL_PART=$(ceph-disk list "${CLI[@]}" | grep journal | sed -r 's/^.*\s([^ ]+)$/\1/') # This is a privileged container so 'ceph-disk list' works
     JOURNAL_UUID=$(get_part_uuid "${JOURNAL_PART}" || true)
   fi
 


### PR DESCRIPTION
`ceph-disk list <device>` returns:

```
/dev/sdb :
 /dev/sdb1 ceph data, prepared, cluster test, osd.1, journal /dev/sdc2
 ```

 therefore, `awk '/ceph journal/ {print $1}'` won't catch the actual
 associated journal partition.

This commit fixes it by using sed instead.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>