### PR TITLE
daemon: only call close_encrypted_part on dmcrypt

### DIFF
--- a/ceph-releases/luminous/ubuntu/16.04/daemon/common_functions.sh
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/common_functions.sh
@@ -407,13 +407,11 @@ function close_encrypted_part {
 }
 
 function umount_lockbox {
-  if [[ ${OSD_DMCRYPT} -eq 1 ]]; then
-    log "Unmounting LOCKBOX directory"
-    # NOTE(leseb): adding || true so when this bug will be fixed the entrypoint will not fail
-    # Ceph bug tracker: http://tracker.ceph.com/issues/18944
-    DATA_UUID=$(get_part_uuid "${OSD_DEVICE}"1)
-    umount /var/lib/ceph/osd-lockbox/"${DATA_UUID}" || true
-  fi
+  log "Unmounting LOCKBOX directory"
+  # NOTE(leseb): adding || true so when this bug will be fixed the entrypoint will not fail
+  # Ceph bug tracker: http://tracker.ceph.com/issues/18944
+  DATA_UUID=$(get_part_uuid "${OSD_DEVICE}"1)
+  umount /var/lib/ceph/osd-lockbox/"${DATA_UUID}" || true
 }
 
 function ami_privileged {

--- a/ceph-releases/luminous/ubuntu/16.04/daemon/osd_scenarios/osd_disk_prepare.sh
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/osd_scenarios/osd_disk_prepare.sh
@@ -73,11 +73,6 @@ function osd_disk_prepare {
   # unmount lockbox partition when using dmcrypt
   umount_lockbox
 
-  # close dmcrypt device
-  DATA_UUID=$(get_part_uuid "$(dev_part "${OSD_DEVICE}" 1)")
-  DATA_PART=$(dev_part "${OSD_DEVICE}" 1)
-  close_encrypted_part "${DATA_UUID}" "${DATA_PART}" "${DATA_UUID}" 1> /dev/null
-
   # watch the udev event queue, and exit if all current events are handled
   udevadm settle --timeout=600
 


### PR DESCRIPTION
We don't need to call close_encrypted_part when not using dmcrypt; fixes
error:

Device 635e0cbc-5b37-49f0-8159-8a8fdf65d648 is not active.

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1495979
Signed-off-by: Sébastien Han <seb@redhat.com>