### PR TITLE
Add RBD bootstrap key support to kubernetes

### DIFF
--- a/examples/kubernetes/README.md
+++ b/examples/kubernetes/README.md
@@ -104,6 +104,7 @@ kubectl create secret generic ceph-conf-combined --from-file=ceph.conf --from-fi
 kubectl create secret generic ceph-bootstrap-rgw-keyring --from-file=ceph.keyring=ceph.rgw.keyring --namespace=ceph
 kubectl create secret generic ceph-bootstrap-mds-keyring --from-file=ceph.keyring=ceph.mds.keyring --namespace=ceph
 kubectl create secret generic ceph-bootstrap-osd-keyring --from-file=ceph.keyring=ceph.osd.keyring --namespace=ceph
+kubectl create secret generic ceph-bootstrap-rbd-keyring --from-file=ceph.keyring=ceph.rbd.keyring --namespace=ceph
 kubectl create secret generic ceph-client-key --from-file=ceph-client-key --namespace=ceph
 
 cd ..

--- a/examples/kubernetes/ceph-mds-v1-dp.yaml
+++ b/examples/kubernetes/ceph-mds-v1-dp.yaml
@@ -33,6 +33,9 @@ spec:
         - name: ceph-bootstrap-rgw-keyring
           secret:
             secretName: ceph-bootstrap-rgw-keyring
+        - name: ceph-bootstrap-rbd-keyring
+          secret:
+            secretName: ceph-bootstrap-rbd-keyring
       containers:
         - name: ceph-mds
           image: ceph/daemon:latest
@@ -56,6 +59,8 @@ spec:
               mountPath: /var/lib/ceph/bootstrap-mds
             - name: ceph-bootstrap-rgw-keyring
               mountPath: /var/lib/ceph/bootstrap-rgw
+            - name: ceph-bootstrap-rbd-keyring
+              mountPath: /var/lib/ceph/bootstrap-rbd
           livenessProbe:
               tcpSocket:
                 port: 6800

--- a/examples/kubernetes/ceph-mon-check-v1-dp.yaml
+++ b/examples/kubernetes/ceph-mon-check-v1-dp.yaml
@@ -31,6 +31,9 @@ spec:
         - name: ceph-bootstrap-rgw-keyring
           secret:
             secretName: ceph-bootstrap-rgw-keyring
+        - name: ceph-bootstrap-rbd-keyring
+          secret:
+            secretName: ceph-bootstrap-rbd-keyring
       containers:
         - name: ceph-mon
           image: ceph/daemon:latest
@@ -55,6 +58,8 @@ spec:
               mountPath: /var/lib/ceph/bootstrap-mds
             - name: ceph-bootstrap-rgw-keyring
               mountPath: /var/lib/ceph/bootstrap-rgw
+            - name: ceph-bootstrap-rbd-keyring
+              mountPath: /var/lib/ceph/bootstrap-rbd
           resources:
             requests:
               memory: "5Mi"

--- a/examples/kubernetes/ceph-mon-v1-dp.yaml
+++ b/examples/kubernetes/ceph-mon-v1-dp.yaml
@@ -47,6 +47,9 @@ spec:
         - name: ceph-bootstrap-rgw-keyring
           secret:
             secretName: ceph-bootstrap-rgw-keyring
+        - name: ceph-bootstrap-rbd-keyring
+          secret:
+            secretName: ceph-bootstrap-rbd-keyring
       containers:
         - name: ceph-mon
           image: ceph/daemon:latest
@@ -77,6 +80,8 @@ spec:
               mountPath: /var/lib/ceph/bootstrap-mds
             - name: ceph-bootstrap-rgw-keyring
               mountPath: /var/lib/ceph/bootstrap-rgw
+            - name: ceph-bootstrap-rbd-keyring
+              mountPath: /var/lib/ceph/bootstrap-rbd
           livenessProbe:
               tcpSocket:
                 port: 6789

--- a/examples/kubernetes/ceph-mon-v1-ds.yaml
+++ b/examples/kubernetes/ceph-mon-v1-ds.yaml
@@ -32,6 +32,9 @@ spec:
         - name: ceph-bootstrap-rgw-keyring
           secret:
             secretName: ceph-bootstrap-rgw-keyring
+        - name: ceph-bootstrap-rbd-keyring
+          secret:
+            secretName: ceph-bootstrap-rbd-keyring
       containers:
         - name: ceph-mon
           image: ceph/daemon:latest
@@ -62,6 +65,8 @@ spec:
               mountPath: /var/lib/ceph/bootstrap-mds
             - name: ceph-bootstrap-rgw-keyring
               mountPath: /var/lib/ceph/bootstrap-rgw
+            - name: ceph-bootstrap-rbd-keyring
+              mountPath: /var/lib/ceph/bootstrap-rbd
           livenessProbe:
               tcpSocket:
                 port: 6789

--- a/examples/kubernetes/ceph-osd-activate-v1-ds.yaml
+++ b/examples/kubernetes/ceph-osd-activate-v1-ds.yaml
@@ -36,6 +36,9 @@ spec:
         - name: ceph-bootstrap-rgw-keyring
           secret:
             secretName: ceph-bootstrap-rgw-keyring
+        - name: ceph-bootstrap-rbd-keyring
+          secret:
+            secretName: ceph-bootstrap-rbd-keyring
         - name: osd-directory
           hostPath:
             path: /var/lib/ceph/osd
@@ -56,6 +59,8 @@ spec:
               mountPath: /var/lib/ceph/bootstrap-mds
             - name: ceph-bootstrap-rgw-keyring
               mountPath: /var/lib/ceph/bootstrap-rgw
+            - name: ceph-bootstrap-rbd-keyring
+              mountPath: /var/lib/ceph/bootstrap-rbd
             - name: osd-directory
               mountPath: /var/lib/ceph/osd
           securityContext:

--- a/examples/kubernetes/ceph-osd-prepare-v1-ds.yaml
+++ b/examples/kubernetes/ceph-osd-prepare-v1-ds.yaml
@@ -36,6 +36,9 @@ spec:
         - name: ceph-bootstrap-rgw-keyring
           secret:
             secretName: ceph-bootstrap-rgw-keyring
+        - name: ceph-bootstrap-rbd-keyring
+          secret:
+            secretName: ceph-bootstrap-rbd-keyring
         - name: osd-directory
           hostPath:
             path: /var/lib/ceph/osd
@@ -56,6 +59,8 @@ spec:
               mountPath: /var/lib/ceph/bootstrap-mds
             - name: ceph-bootstrap-rgw-keyring
               mountPath: /var/lib/ceph/bootstrap-rgw
+            - name: ceph-bootstrap-rbd-keyring
+              mountPath: /var/lib/ceph/bootstrap-rbd
             - name: osd-directory
               mountPath: /var/lib/ceph/osd
           securityContext:

--- a/examples/kubernetes/ceph-osd-v1-ds.yaml
+++ b/examples/kubernetes/ceph-osd-v1-ds.yaml
@@ -36,6 +36,9 @@ spec:
         - name: ceph-bootstrap-rgw-keyring
           secret:
             secretName: ceph-bootstrap-rgw-keyring
+        - name: ceph-bootstrap-rbd-keyring
+          secret:
+            secretName: ceph-bootstrap-rbd-keyring
         - name: osd-directory
           emptyDir: {}
 #          hostPath:
@@ -57,6 +60,8 @@ spec:
               mountPath: /var/lib/ceph/bootstrap-mds
             - name: ceph-bootstrap-rgw-keyring
               mountPath: /var/lib/ceph/bootstrap-rgw
+            - name: ceph-bootstrap-rbd-keyring
+              mountPath: /var/lib/ceph/bootstrap-rbd
             - name: osd-directory
               mountPath: /var/lib/ceph/osd
           securityContext:

--- a/examples/kubernetes/ceph-rgw-v1-dp.yaml
+++ b/examples/kubernetes/ceph-rgw-v1-dp.yaml
@@ -33,6 +33,9 @@ spec:
         - name: ceph-bootstrap-rgw-keyring
           secret:
             secretName: ceph-bootstrap-rgw-keyring
+        - name: ceph-bootstrap-rbd-keyring
+          secret:
+            secretName: ceph-bootstrap-rbd-keyring
       containers:
         - name: ceph-rgw
           image: ceph/daemon:latest
@@ -54,6 +57,8 @@ spec:
               mountPath: /var/lib/ceph/bootstrap-mds
             - name: ceph-bootstrap-rgw-keyring
               mountPath: /var/lib/ceph/bootstrap-rgw
+            - name: ceph-bootstrap-rbd-keyring
+              mountPath: /var/lib/ceph/bootstrap-rbd
           livenessProbe:
               httpGet:
                 path: /

--- a/examples/kubernetes/create_secrets.sh
+++ b/examples/kubernetes/create_secrets.sh
@@ -9,6 +9,7 @@ kubectl create secret generic ceph-conf-combined --from-file=ceph.conf --from-fi
 kubectl create secret generic ceph-bootstrap-rgw-keyring --from-file=ceph.keyring=ceph.rgw.keyring --namespace=ceph
 kubectl create secret generic ceph-bootstrap-mds-keyring --from-file=ceph.keyring=ceph.mds.keyring --namespace=ceph
 kubectl create secret generic ceph-bootstrap-osd-keyring --from-file=ceph.keyring=ceph.osd.keyring --namespace=ceph
+kubectl create secret generic ceph-bootstrap-rbd-keyring --from-file=ceph.keyring=ceph.rbd.keyring --namespace=ceph
 kubectl create secret generic ceph-client-key --from-file=ceph-client-key --namespace=ceph
 kubectl create secret generic ceph-secret-admin --from-file=ceph-client-key --type=kubernetes.io/rbd --namespace=ceph
 

--- a/examples/kubernetes/generator/README.md
+++ b/examples/kubernetes/generator/README.md
@@ -61,5 +61,6 @@ kubectl create secret generic ceph-conf-combined --from-file=ceph.conf --from-fi
 kubectl create secret generic ceph-bootstrap-rgw-keyring --from-file=ceph.keyring=ceph.rgw.keyring --namespace=ceph
 kubectl create secret generic ceph-bootstrap-mds-keyring --from-file=ceph.keyring=ceph.mds.keyring --namespace=ceph
 kubectl create secret generic ceph-bootstrap-osd-keyring --from-file=ceph.keyring=ceph.osd.keyring --namespace=ceph
+kubectl create secret generic ceph-bootstrap-rbd-keyring --from-file=ceph.keyring=ceph.rbd.keyring --namespace=ceph
 kubectl create secret generic ceph-client-key --from-file=ceph-client-key --namespace=ceph
 ```

--- a/examples/kubernetes/generator/generate_secrets.sh
+++ b/examples/kubernetes/generator/generate_secrets.sh
@@ -76,6 +76,7 @@ gen-all-bootstrap-keyrings() {
   gen-bootstrap-keyring osd > ceph.osd.keyring
   gen-bootstrap-keyring mds > ceph.mds.keyring
   gen-bootstrap-keyring rgw > ceph.rgw.keyring
+  gen-bootstrap-keyring rbd > ceph.rbd.keyring
 }
 
 gen-all() {
@@ -101,4 +102,3 @@ main() {
 }
 
 main "$@"
-


### PR DESCRIPTION
Make changes to key generator, README docs, and kubernetes config yaml
files to support bootstrapping RBDs.

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>