### PR TITLE
daemon: do not run umount lockbox

### DIFF
--- a/ceph-releases/luminous/ubuntu/16.04/daemon/osd_scenarios/osd_disk_prepare.sh
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/osd_scenarios/osd_disk_prepare.sh
@@ -70,8 +70,10 @@ function osd_disk_prepare {
     fi
   fi
 
-  # unmount lockbox partition when using dmcrypt
-  umount_lockbox
+  if [[ ${OSD_DMCRYPT} -eq 1 ]]; then
+    # unmount lockbox partition when using dmcrypt
+    umount_lockbox
+  fi
 
   # watch the udev event queue, and exit if all current events are handled
   udevadm settle --timeout=600


### PR DESCRIPTION
Even if it runs with || true and won't fail this is really confusing for
users.

Signed-off-by: Sébastien Han <seb@redhat.com>