### PR TITLE
daemon: use dev_part for DATA_UUID

### DIFF
--- a/ceph-releases/luminous/ubuntu/16.04/daemon/common_functions.sh
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/common_functions.sh
@@ -461,7 +461,7 @@ function umount_lockbox {
   log "Unmounting LOCKBOX directory"
   # NOTE(leseb): adding || true so when this bug will be fixed the entrypoint will not fail
   # Ceph bug tracker: http://tracker.ceph.com/issues/18944
-  DATA_UUID=$(get_part_uuid "${OSD_DEVICE}"1)
+  DATA_UUID=$(get_part_uuid "$(dev_part "${OSD_DEVICE}" 1)")
   umount /var/lib/ceph/osd-lockbox/"${DATA_UUID}" || true
 }
 


### PR DESCRIPTION
This fixes the case where a disk is specified with by-path, blkid can
not resolve part uuid from disks like
/dev/disk/by-path/pci-0000:00:01.1-ata-1.0
The command was actual wrong has it'll append '1' at the end of
/dev/disk/by-path/pci-0000:00:01.1-ata-1.0

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=1494127
Signed-off-by: Sébastien Han <seb@redhat.com>