### PR TITLE
Fix generate-dev-env returning failure on success

### DIFF
--- a/generate-dev-env.sh
+++ b/generate-dev-env.sh
@@ -74,4 +74,4 @@ case "$1" in
       esac
     ;;
 esac
-popd &> /dev/null
+popd &> /dev/null || true # Don't return failure if we never pushd'ed


### PR DESCRIPTION
The generate-dev-env.sh script should not return failure on the final
`popd` if a preceding `pushd` was never executed.

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>