### PR TITLE
luminous: Create the bootstrap-rbd keyring when using etcd

### DIFF
--- a/ceph-releases/luminous/ubuntu/16.04/daemon/config.kv.etcd.sh
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/config.kv.etcd.sh
@@ -66,7 +66,7 @@ function get_mon_config {
     ceph-authtool "$ADMIN_KEYRING" --create-keyring "${CLI[@]}" -n client.admin --set-uid=0 --cap mon 'allow *' --cap osd 'allow *' --cap mds 'allow' --cap mgr 'allow *'
     ceph-authtool "$MON_KEYRING" --create-keyring --gen-key -n mon. --cap mon 'allow *'
 
-    for item in ${OSD_BOOTSTRAP_KEYRING}:Osd ${MDS_BOOTSTRAP_KEYRING}:Mds ${RGW_BOOTSTRAP_KEYRING}:Rgw; do
+    for item in ${OSD_BOOTSTRAP_KEYRING}:Osd ${MDS_BOOTSTRAP_KEYRING}:Mds ${RGW_BOOTSTRAP_KEYRING}:Rgw ${RBD_MIRROR_BOOTSTRAP_KEYRING}:Rbd; do
       local array
       IFS=" " read -r -a array <<< "${item//:/ }"
       local keyring=${array[0]}
@@ -96,7 +96,7 @@ function get_mon_config {
 }
 
 function import_bootstrap_keyrings {
-  for item in ${OSD_BOOTSTRAP_KEYRING}:Osd ${MDS_BOOTSTRAP_KEYRING}:Mds ${RGW_BOOTSTRAP_KEYRING}:Rgw; do
+  for item in ${OSD_BOOTSTRAP_KEYRING}:Osd ${MDS_BOOTSTRAP_KEYRING}:Mds ${RGW_BOOTSTRAP_KEYRING}:Rgw ${RBD_MIRROR_BOOTSTRAP_KEYRING}:Rbd; do
     local array
     IFS=" " read -r -a array <<< "${item//:/ }"
     local keyring


### PR DESCRIPTION
The static config creates a keyring for RBD_MIRROR_BOOTSTRAP_KEYRING,
which is used by rbd-mirror and also by the start script for the
mon. The etcd config was not creating this keyring, preventing mon and
rbd-mirror from starting.

Add RBD_MIRROR_BOOTSTRAP_KEYRING to the list of keyrings to generate
when using etcd.