### PR TITLE
daemon: do not rely on ceph-disk list for bluestore dmcrypt

### DIFF
--- a/ceph-releases/luminous/ubuntu/16.04/daemon/common_functions.sh
+++ b/ceph-releases/luminous/ubuntu/16.04/daemon/common_functions.sh
@@ -346,9 +346,17 @@ function get_dmcrypt_bluestore_uuid {
   BLOCK_UUID=$(get_part_uuid "$(dev_part "${OSD_DEVICE}" 2)")
   BLOCK_PART=$(dev_part "${OSD_DEVICE}" 2)
   LOCKBOX_UUID=$(get_part_uuid "$(dev_part "${OSD_DEVICE}" 5)")
-  BLOCK_DB_PART=$(ceph-disk list "${OSD_BLUESTORE_BLOCK_DB}" | awk '/ceph block.db/ {print $1}') # This is a privileged container so 'ceph-disk list' works
+
+  export DISK_LIST_SEARCH=block.db_dmcrypt
+  start_disk_list
+  BLOCK_DB_PART=$(start_disk_list)
+  unset DISK_LIST_SEARCH
   BLOCK_DB_UUID=$(get_part_uuid "${BLOCK_DB_PART}")
-  BLOCK_WAL_PART=$(ceph-disk list "${OSD_BLUESTORE_BLOCK_WAL}" | awk '/ceph block.wal/ {print $1}') # This is a privileged container so 'ceph-disk list' works
+
+  export DISK_LIST_SEARCH=block.wal_dmcrypt
+  start_disk_list
+  BLOCK_WAL_PART=$(start_disk_list)
+  unset DISK_LIST_SEARCH
   BLOCK_WAL_UUID=$(get_part_uuid "${BLOCK_WAL_PART}")
 }
 


### PR DESCRIPTION
This was a leftover, ceph-disk list returns

```
root@257b2b1826f2:/# ceph-disk list /dev/sdc | awk '/ceph block.db/
{print $1}'
/dev/sdc1
/dev/sdc3
```

So we have 2 values where we expect one. Now we use start_disk_list
which will report the right device.

Signed-off-by: Sébastien Han <seb@redhat.com>