### PR TITLE
[skip ci] ci: better coverage with new osd scenarios

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
-envlist = {ceph_ansible,ceph_ansible2.2}-{jewel,luminous}-{xenial,centos7}-{cluster,dedicated_journal,dmcrypt_journal_collocation}
+envlist = {ceph_ansible,ceph_ansible2.2}-{jewel}-{xenial,centos7}-{cluster,filestore_osds_container}
+	{ceph_ansible,ceph_ansible2.3}-{luminous}-{xenial,centos7}-{cluster,filestore_osds_container,bluestore_osds_container,docker_cluster_collocation}
 skipsdist = True
 
 [testenv]
@@ -16,21 +17,23 @@ setenv=
   # only available for ansible >= 2.2
   ANSIBLE_STDOUT_CALLBACK = debug
   cluster: CEPH_ANSIBLE_SCENARIO_PATH = {toxinidir}/ceph-ansible/tests/functional/centos/7/docker
-  dedicated_journal: CEPH_ANSIBLE_SCENARIO_PATH = {toxinidir}/ceph-ansible/tests/functional/centos/7/docker-ded-jrn
-  dmcrypt_journal_collocation: CEPH_ANSIBLE_SCENARIO_PATH = {toxinidir}/ceph-ansible/tests/functional/centos/7/docker-crypt-jrn-col
-  # we're reusing the same test scenario from ceph-ansible so
-  # for now we can reuse this same address
+  docker_cluster_collocation: CEPH_ANSIBLE_SCENARIO_PATH = {toxinidir}/ceph-ansible/tests/functional/centos/7/docker-collocation
+  filestore_osds_container: CEPH_ANSIBLE_SCENARIO_PATH = {toxinidir}/ceph-ansible/tests/functional/centos/7/fs-osds-container
+  bluestore_osds_container: CEPH_ANSIBLE_SCENARIO_PATH = {toxinidir}/ceph-ansible/tests/functional/centos/7/bs-osds-container
   cluster: REGISTRY_ADDRESS = 192.168.17.1:5000
-  dedicated_journal: REGISTRY_ADDRESS = 192.168.29.1:5000
-  dmcrypt_journal_collocation: REGISTRY_ADDRESS = 192.168.27.1:5000
+  docker_cluster_collocation: REGISTRY_ADDRESS = 192.168.15.1:5000
+  filestore_osds_container: REGISTRY_ADDRESS = 192.168.55.1:5000
+  bluestore_osds_container: REGISTRY_ADDRESS = 192.168.35.1:5000
   centos7: IMAGE_DISTRO = centos/7
   xenial: IMAGE_DISTRO = ubuntu/16.04
   jewel: CEPH_STABLE_RELEASE = jewel
   luminous: CEPH_STABLE_RELEASE = luminous
-  ceph_ansible2.2: CEPH_ANSIBLE_BRANCH = stable-2.2
   ceph_ansible: CEPH_ANSIBLE_BRANCH = master
+  ceph_ansible2.2: CEPH_ANSIBLE_BRANCH = stable-2.2
+  ceph_ansible2.3: CEPH_ANSIBLE_BRANCH = stable-3.0
   VAGRANT_PROVIDER={env:VAGRANT_PROVIDER:libvirt}
 deps=
-  ansible==2.3.1
+  ansible2.2: ansible==2.2.3
+  ansible2.3: ansible==2.3.1
 commands=
   bash {toxinidir}/tests/tox.sh


### PR DESCRIPTION
We now test stable-3.0 with ansible 2.3.1 and also we added the new osd
scenarios from with https://github.com/ceph/ceph-ansible/pull/2000

Signed-off-by: Sébastien Han <seb@redhat.com>